### PR TITLE
V3 Plan D: Interactive design + granular planning workflows

### DIFF
--- a/agents/tff-brainstormer.md
+++ b/agents/tff-brainstormer.md
@@ -1,6 +1,6 @@
 ---
 name: tff-brainstormer
-description: Challenges assumptions, surfaces unknowns, and locks scope during slice discussion
+description: Stress-tests design specs — challenges assumptions, surfaces unknowns, validates scope
 model: opus
 tools: Read, Grep, Glob, Bash, WebSearch
 ---
@@ -15,11 +15,9 @@ Socratic method, pre-mortem analysis, scope locking.
 
 ## Role
 
-Two modes:
-1. **Spec challenger** (primary): spawned after spec is drafted to stress-test design. Input: spec content. Output: critical issues ∨ approval.
-2. **Discussion driver** (legacy): spawned for direct brainstorming outside tff workflow.
-
-Always FRESH. ¬ S-tier slices. F-full only for spec challenge.
+**Spec challenger**: spawned after spec is drafted to stress-test design.
+Input: spec content. Output: critical issues ∨ approval.
+Always FRESH. F-full only.
 
 ## Philosophy
 
@@ -29,27 +27,26 @@ Always FRESH. ¬ S-tier slices. F-full only for spec challenge.
 
 ## Process
 
-1. Read slice + context (`@.tff/PROJECT.md`, `@.tff/REQUIREMENTS.md`)
-2. `∀ assumption: challenge` — one question at a time w/ risk rationale
-3. `∀ "obvious" decision: why this ∧ ¬ alternatives?`
-4. Surface hidden deps ∧ unknowns
-5. Lock scope (IN/OUT explicit)
-6. Output complexity signals → `tff-tools.cjs slice:classify`
+1. Read spec content provided by orchestrator
+2. `∀ assumption in spec: challenge` — why this holds? what if wrong?
+3. `∀ design decision: why this ∧ ¬ alternatives?`
+4. Surface hidden deps, failure modes, scaling concerns
+5. Verify scope is locked (IN/OUT explicit in spec)
 
 ## Deliverables
 
 ```
-## Brainstorm — [Slice]
-### Assumptions Validated
+## Spec Challenge — [Slice]
+### Verdict: APPROVE | REVISE
+
+### Critical Issues (blocks planning)
+| # | Section | Issue | Risk |
+
+### Concerns (note in spec, proceed)
+| # | Section | Concern | Suggestion |
+
+### Assumptions Verified
 - [assumption] — [why holds]
-### Unknowns
-- [unknown] — [impact] — [investigation]
-### Scope
-IN: [included] | OUT: [excluded]
-### Risks
-- [risk] — [low/med/high] — [mitigation]
-### Complexity
-Tasks: [N] | Modules: [N] | External: [y/n] | Unknowns: [N]
 ```
 
 ## Rules

--- a/agents/tff-brainstormer.md
+++ b/agents/tff-brainstormer.md
@@ -15,7 +15,11 @@ Socratic method, pre-mortem analysis, scope locking.
 
 ## Role
 
-Spawned during **discussing**. Always FRESH. ¬ S-tier slices.
+Two modes:
+1. **Spec challenger** (primary): spawned after spec is drafted to stress-test design. Input: spec content. Output: critical issues ∨ approval.
+2. **Discussion driver** (legacy): spawned for direct brainstorming outside tff workflow.
+
+Always FRESH. ¬ S-tier slices. F-full only for spec challenge.
 
 ## Philosophy
 

--- a/references/conventions.md
+++ b/references/conventions.md
@@ -75,6 +75,7 @@ Special formats:
   settings.yaml           ← model profiles, quality gates
   slices/
     M01-S01/
+      SPEC.md             ← design spec (produced during discuss)
       PLAN.md             ← slice plan and task descriptions
       RESEARCH.md         ← research notes
       CHECKPOINT.md       ← resumability data

--- a/references/orchestrator-pattern.md
+++ b/references/orchestrator-pattern.md
@@ -32,9 +32,10 @@ tff workflows are orchestrators. They coordinate — they don't do heavy work.
 
 ## Exception: Conversation-Driven Workflows
 
-The discuss workflow is an exception to rule 2 ("agents do the heavy lifting"). Interactive Q&A requires maintaining conversation context with the user, which cannot be delegated to a subagent. The orchestrator drives the conversation directly via AskUserQuestion, then spawns agents for independent review tasks (challenge, validate, review).
-
-This exception applies ONLY to workflows that require multi-turn user interaction. All other workflows follow the standard orchestrator pattern.
+discuss workflow: orchestrator drives Q&A directly via AskUserQuestion (rule 2 exception).
+Reason: multi-turn user context ¬delegable to subagent.
+Agents spawned for independent tasks only (challenge, validate, review).
+∀ other workflows: standard pattern applies.
 
 ## Template
 

--- a/references/orchestrator-pattern.md
+++ b/references/orchestrator-pattern.md
@@ -30,6 +30,12 @@ tff workflows are orchestrators. They coordinate — they don't do heavy work.
 - Making architecture decisions in the workflow (that's the architect's job)
 - Long workflow files with complex logic (break into agent spawns)
 
+## Exception: Conversation-Driven Workflows
+
+The discuss workflow is an exception to rule 2 ("agents do the heavy lifting"). Interactive Q&A requires maintaining conversation context with the user, which cannot be delegated to a subagent. The orchestrator drives the conversation directly via AskUserQuestion, then spawns agents for independent review tasks (challenge, validate, review).
+
+This exception applies ONLY to workflows that require multi-turn user interaction. All other workflows follow the standard orchestrator pattern.
+
 ## Template
 
 Every workflow step should be one of:

--- a/skills/interactive-design.md
+++ b/skills/interactive-design.md
@@ -1,0 +1,102 @@
+---
+name: interactive-design
+description: Use when running /tff:discuss to drive spec creation through structured conversation
+token-budget: critical
+---
+
+## When to Use
+
+∀ discuss workflow: load this skill. Drives orchestrator Q&A → SPEC.md.
+
+## Conversation Rules
+
+1. One question per message via AskUserQuestion
+2. Multiple choice preferred (A/B/C/D) — open-ended when needed
+3. Assess scope first: multi-subsystem → decompose before detailing
+4. ∀ assumption: surface explicitly, ¬proceed on implicit agreement
+5. Propose 2-3 approaches w/ trade-offs before committing
+
+## Flow
+
+1. SCOPE: goal, constraints, success criteria (2-4 questions)
+2. APPROACH: propose 2-3, recommend one, user picks
+3. DESIGN: section-by-section, user approves each via AskUserQuestion
+   - F-lite: problem, approach, acceptance criteria, non-goals (~1 page)
+   - F-full: + constraints, architecture, error handling, testing strategy (~3 pages)
+4. WRITE: `.tff/slices/<id>/SPEC.md`
+5. CHALLENGE: spawn tff-brainstormer (F-full only, max 2 iterations)
+6. VALIDATE: spawn tff-product-lead → ∀ criterion: testable ∧ binary
+7. REVIEW: dispatch anonymous spec-document-reviewer (max 3 iterations)
+8. USER GATE: show spec, ask approval via AskUserQuestion
+
+## Spec Template — F-lite
+
+```
+## Problem — what and why
+## Approach — chosen from 2-3 proposed
+## Acceptance Criteria — testable, binary (AC1, AC2, ...)
+## Non-Goals — explicitly out of scope
+```
+
+## Spec Template — F-full
+
+```
+## Problem — what and why
+## Constraints — time, tech, dependencies, team
+## Approach — chosen from 2-3 proposed
+## Architecture — boundaries, dependencies, patterns
+## Acceptance Criteria — testable, binary (AC1, AC2, ...)
+## Error Handling — failure modes and recovery
+## Testing Strategy — what to test, how
+## Non-Goals — explicitly out of scope
+```
+
+## Spec Document Reviewer Prompt
+
+Dispatch via Agent tool (subagent_type: general-purpose) with prompt:
+
+"You are reviewing a design spec for completeness and quality.
+Read the spec at [path]. Tier: [F-lite | F-full].
+
+| Check | F-lite | F-full |
+|---|---|---|
+| Problem statement clear | ✓ | ✓ |
+| Approach chosen from alternatives | ✓ | ✓ |
+| Acceptance criteria testable + binary | ✓ | ✓ |
+| Non-goals explicitly stated | ✓ | ✓ |
+| Constraints documented | - | ✓ |
+| Architecture decisions justified | - | ✓ |
+| Error handling defined | - | ✓ |
+| Testing strategy defined | - | ✓ |
+| No TODOs/placeholders/TBDs | ✓ | ✓ |
+| No internal contradictions | ✓ | ✓ |
+| Single subsystem scope | ✓ | ✓ |
+| YAGNI — nothing unnecessary | ✓ | ✓ |
+
+Calibration: only flag issues that cause real problems during planning.
+∀ finding: explain WHY, not just WHAT. Approve unless serious gaps exist.
+
+Report:
+✅ Approved — spec ready for planning
+OR
+❌ Issues Found:
+| # | Check | Issue | Suggestion |"
+
+## Plan Document Reviewer Prompt
+
+Dispatch via Agent tool (subagent_type: general-purpose) with prompt:
+
+"Review the plan at [plan path]. Spec at [spec path].
+
+| Check | Question |
+|---|---|
+| Completeness | ∀ acceptance criterion in spec has ≥1 task? |
+| Task Decomposition | ∀ task has exact file paths, code, test commands? |
+| Buildability | Could an engineer follow without getting stuck? |
+| TDD | ∀ task has RED→GREEN→COMMIT cycle? |
+| Traceability | ∀ task maps to ≥1 acceptance criterion? |
+| YAGNI | No tasks beyond spec scope? |
+| File Structure | Files mapped before tasks? ∀ file: one responsibility? |
+
+Calibration: only flag issues that cause real problems during execution.
+Report: ✅ Approved OR ❌ Issues with specifics."

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -37,26 +37,22 @@ UPDATE bead design field: `beadStore.updateDesign(id, spec_content)`
 
 ### 4. Challenge Spec (F-full only)
 SPAWN tff-brainstormer: {spec_content}
-- Stress-tests assumptions, surfaces unknowns
-- Critical issues → revise spec (loop to Phase 3, max 2 iterations then escalate)
-- Minor concerns → note in spec, proceed
+REVISE → critical issues → loop Phase 3 (max 2) ∨ escalate
+APPROVE → note concerns in spec, proceed
 
-### 5. Validate Acceptance Criteria
+### 5. Validate AC
 SPAWN tff-product-lead: {spec_content, acceptance_criteria}
-- ∀ criterion: testable ∧ binary
-- Gaps → revise via AskUserQuestion
+∀ criterion: testable ∧ binary — gaps → revise via AskUserQuestion
 
 ### 6. Spec Review
-DISPATCH anonymous reviewer via Agent tool (prompt from @skills/interactive-design.md)
-- Checks: completeness, consistency, clarity, scope, YAGNI
-- Issues → fix, re-dispatch (max 3 iterations)
+DISPATCH anonymous reviewer via Agent tool (prompt: @skills/interactive-design.md)
+Issues → fix, re-dispatch (max 3)
 
 ### 7. User Gate
-AskUserQuestion: "Spec at `.tff/slices/<id>/SPEC.md`. Review and approve?"
-Wait for approval
+AskUserQuestion: "Spec at `.tff/slices/<id>/SPEC.md`. Approve?"
 
 ### 8. Transition
-TRANSITION: `tff-tools slice:transition <id> researching`
+`tff-tools slice:transition <id> researching`
 
 ## Auto-Transition
 Read `.tff/settings.yaml` → `autonomy.mode`.

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -6,15 +6,57 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 status = discussing
 
 ## Steps
-1. CHECK: read slice bead + notes
-2. CLASSIFY: `tff-tools slice:classify '<signals>'`
-3. tier = S → auto-transition researching, skip brainstorm
-4. SPAWN tff-brainstormer: {slice_desc, project_context, requirements}
-   - Challenge assumptions, surface unknowns, lock scope
-5. SPAWN tff-product-lead: {requirements, acceptance_criteria}
-   - Validate requirements, define acceptance criteria
-6. TRANSITION: `tff-tools slice:transition <id> researching`
-7. NEXT: @references/next-steps.md
+
+### 1. Load Context
+CHECK: read slice bead + notes
+CLASSIFY: `tff-tools slice:classify '<signals>'`
+tier = S → auto-transition researching, skip discuss
+
+### 2. Interactive Design (F-lite ∧ F-full)
+LOAD @skills/interactive-design.md
+
+**Phase 1 — Scope** (2-4 questions via AskUserQuestion)
+- What problem does this solve? Who benefits?
+- What constraints? (time, tech, dependencies)
+- What does success look like?
+- (F-full) What are the known unknowns?
+
+**Phase 2 — Approach** (1 message)
+- Propose 2-3 approaches w/ trade-offs
+- Recommend one, explain why
+- User picks via AskUserQuestion
+
+**Phase 3 — Design** (section by section)
+- Present each section per tier template from @skills/interactive-design.md
+- ∀ section: ask "does this look right?" via AskUserQuestion
+- Revise until approved, then next section
+
+### 3. Write Spec
+WRITE `.tff/slices/<id>/SPEC.md` w/ validated design
+UPDATE bead design field: `beadStore.updateDesign(id, spec_content)`
+
+### 4. Challenge Spec (F-full only)
+SPAWN tff-brainstormer: {spec_content}
+- Stress-tests assumptions, surfaces unknowns
+- Critical issues → revise spec (loop to Phase 3, max 2 iterations then escalate)
+- Minor concerns → note in spec, proceed
+
+### 5. Validate Acceptance Criteria
+SPAWN tff-product-lead: {spec_content, acceptance_criteria}
+- ∀ criterion: testable ∧ binary
+- Gaps → revise via AskUserQuestion
+
+### 6. Spec Review
+DISPATCH anonymous reviewer via Agent tool (prompt from @skills/interactive-design.md)
+- Checks: completeness, consistency, clarity, scope, YAGNI
+- Issues → fix, re-dispatch (max 3 iterations)
+
+### 7. User Gate
+AskUserQuestion: "Spec at `.tff/slices/<id>/SPEC.md`. Review and approve?"
+Wait for approval
+
+### 8. Transition
+TRANSITION: `tff-tools slice:transition <id> researching`
 
 ## Auto-Transition
 Read `.tff/settings.yaml` → `autonomy.mode`.

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -4,15 +4,85 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
 ## Prerequisites
 status = planning
+SPEC.md exists at `.tff/slices/<id>/SPEC.md`
 
 ## Steps
-1. DECOMPOSE: slice → tasks w/ acceptance criteria + dependencies (1 task = 1 commit)
-2. WRITE `.tff/slices/<slice-id>/PLAN.md`: goal, tasks[desc, criteria, deps], tier
-3. CREATE task beads w/ dependencies
-4. DETECT WAVES: `tff-tools waves:detect '<tasks-json>'` → show user
-5. SPAWN tff-architect (F-lite ∧ F-full): validate plan structure
-6. REVIEW: `plannotator annotate .tff/slices/<slice-id>/PLAN.md`
-   - feedback → revise → re-submit | approved → continue
-7. WORKTREE: `tff-tools worktree:create <slice-id>`
-8. TRANSITION: `tff-tools slice:transition <id> executing`
-9. NEXT: @references/next-steps.md
+
+### 1. Load Spec
+READ `.tff/slices/<id>/SPEC.md`
+READ `.tff/slices/<id>/RESEARCH.md` (if exists)
+
+### 2. File Structure
+Map files to create/modify BEFORE tasks.
+∀ file: one responsibility, follow existing codebase patterns.
+Present file map to user.
+
+### 3. Task Decomposition
+DECOMPOSE spec → tasks:
+- 1 task = 1 logical unit (may be multiple commits)
+- ∀ task: description, files (create/modify/test), acceptance criteria refs (AC1, AC2...), deps
+- TDD steps ∀ task:
+  1. Write failing test (exact code)
+  2. Run test (exact command + expected FAIL)
+  3. Write implementation (exact code)
+  4. Run test (exact command + expected PASS)
+  5. Commit (exact git command)
+- Exact file paths, not "add to the service"
+- Code snippets, not "implement validation"
+
+### 4. Write PLAN.md
+WRITE `.tff/slices/<id>/PLAN.md`:
+
+```
+# [Slice] Implementation Plan
+
+> For agentic workers: execute task-by-task with TDD.
+
+**Goal:** [from SPEC.md]
+**Architecture:** [from SPEC.md]
+**Tech Stack:** [relevant to slice]
+
+## File Structure
+[files to create/modify with responsibilities]
+
+---
+
+### Task N: [Component]
+**Files:** Create/Modify/Test with exact paths
+**Traces to:** AC1, AC3
+
+- [ ] Step 1: Write failing test [exact code]
+- [ ] Step 2: Run [exact command], verify FAIL
+- [ ] Step 3: Implement [exact code]
+- [ ] Step 4: Run [exact command], verify PASS
+- [ ] Step 5: Commit [exact git command]
+```
+
+### 5. Create Task Beads + Detect Waves
+CREATE beads: `tff-tools` ∀ task w/ deps
+DETECT: `tff-tools waves:detect '<tasks-json>'` → show user
+
+### 6. Architecture Review (F-lite ∧ F-full)
+SPAWN tff-architect: {plan_content, spec_content}
+- Validates boundaries, dependency direction, patterns
+- Issues → revise plan
+
+### 7. Plan Review — Subagent Loop
+DISPATCH anonymous reviewer via Agent tool (prompt from @skills/interactive-design.md § Plan Document Reviewer)
+Issues → fix, re-dispatch (max 3 iterations)
+
+### 8. Plannotator Review
+`plannotator annotate .tff/slices/<id>/PLAN.md`
+feedback → revise → loop ∨ approved → continue
+
+### 9. Worktree
+`tff-tools worktree:create <id>`
+
+### 10. Transition
+TRANSITION: `tff-tools slice:transition <id> executing`
+
+## Auto-Transition
+Read `.tff/settings.yaml` → `autonomy.mode`.
+`plan-to-pr` → auto-invoke execute workflow.
+`guided` → suggest `/tff:execute`.
+Progress: `[tff] <slice-id>: planning → executing`

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -64,25 +64,20 @@ DETECT: `tff-tools waves:detect '<tasks-json>'` → show user
 
 ### 6. Architecture Review (F-lite ∧ F-full)
 SPAWN tff-architect: {plan_content, spec_content}
-- Validates boundaries, dependency direction, patterns
-- Issues → revise plan
+Issues → revise plan
 
-### 7. Plan Review — Subagent Loop
-DISPATCH anonymous reviewer via Agent tool (prompt from @skills/interactive-design.md § Plan Document Reviewer)
-Issues → fix, re-dispatch (max 3 iterations)
+### 7. Plan Review
+DISPATCH anonymous reviewer via Agent tool (prompt: @skills/interactive-design.md § Plan Document Reviewer)
+Issues → fix, re-dispatch (max 3)
 
 ### 8. Plannotator Review
 `plannotator annotate .tff/slices/<id>/PLAN.md`
-feedback → revise → loop ∨ approved → continue
+feedback → revise ∨ approved → continue
 
-### 9. Worktree
+### 9. Worktree + Transition
 `tff-tools worktree:create <id>`
-
-### 10. Transition
-TRANSITION: `tff-tools slice:transition <id> executing`
+`tff-tools slice:transition <id> executing`
 
 ## Auto-Transition
-Read `.tff/settings.yaml` → `autonomy.mode`.
-`plan-to-pr` → auto-invoke execute workflow.
-`guided` → suggest `/tff:execute`.
-Progress: `[tff] <slice-id>: planning → executing`
+`plan-to-pr` → auto-invoke execute | `guided` → suggest `/tff:execute`
+`[tff] <slice-id>: planning → executing`


### PR DESCRIPTION
## Summary

- **New `interactive-design` skill** -- conversation methodology, spec templates (F-lite/F-full), spec-document-reviewer and plan-document-reviewer prompt templates
- **Rewritten `discuss-slice`** -- orchestrator drives Q&A via AskUserQuestion (not agent monologue), produces `.tff/slices/<id>/SPEC.md`, spawns brainstormer as spec challenger (F-full only), product-lead for AC validation, anonymous reviewer for quality
- **Rewritten `plan-slice`** -- reads SPEC.md, maps file structure before tasks, produces bite-sized TDD tasks with exact code/file paths/commands, task-to-AC traceability, anonymous plan-reviewer loop + plannotator
- **Orchestrator pattern updated** -- conversation-driven workflow exception documented
- **Conventions updated** -- SPEC.md added to project directory listing
- **Brainstormer updated** -- spec-challenger role added alongside existing discussion driver role

### What this enables

The discuss → plan pipeline now matches superpowers-level quality: structured conversation → validated spec → granular plan → reliable subagent execution. This is what made V3 Plans A/B/C execute successfully -- now it's built into tff's own workflow.

## Test plan

- [ ] Verify `interactive-design.md` has correct frontmatter (name, description, token-budget: critical)
- [ ] Verify 6/6 skills have `token-budget` in frontmatter
- [ ] Verify `discuss-slice.md` references AskUserQuestion and produces SPEC.md
- [ ] Verify `plan-slice.md` requires SPEC.md as prerequisite and includes TDD steps
- [ ] Verify `orchestrator-pattern.md` has "Conversation-Driven Workflows" exception
- [ ] Verify `conventions.md` lists SPEC.md in project directory
- [ ] Verify `tff-brainstormer.md` has "Spec challenger" role

🤖 Generated with [Claude Code](https://claude.com/claude-code)