### PR TITLE
fix(S01): correct misused error codes and version drift

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -22419,7 +22419,7 @@ var MarkdownArtifactAdapter = class {
     try {
       return Ok(await (0, import_promises2.readFile)(this.resolve(path), "utf-8"));
     } catch {
-      return Err(createDomainError("PROJECT_EXISTS", `File not found: ${path}`, { path }));
+      return Err(createDomainError("NOT_FOUND", `File not found: ${path}`, { path }));
     }
   }
   async write(path, content) {
@@ -22429,7 +22429,7 @@ var MarkdownArtifactAdapter = class {
       await (0, import_promises2.writeFile)(fullPath, content, "utf-8");
       return Ok(void 0);
     } catch (err) {
-      return Err(createDomainError("SYNC_CONFLICT", `Failed to write: ${path}`, { path, error: String(err) }));
+      return Err(createDomainError("VALIDATION_ERROR", `Failed to write: ${path}`, { path, error: String(err) }));
     }
   }
   async exists(path) {
@@ -22453,7 +22453,7 @@ var MarkdownArtifactAdapter = class {
       await (0, import_promises2.mkdir)(this.resolve(path), { recursive: true });
       return Ok(void 0);
     } catch (err) {
-      return Err(createDomainError("SYNC_CONFLICT", `Failed to mkdir: ${path}`, { path, error: String(err) }));
+      return Err(createDomainError("VALIDATION_ERROR", `Failed to mkdir: ${path}`, { path, error: String(err) }));
     }
   }
 };
@@ -23373,9 +23373,9 @@ init_domain_error();
 var loadCheckpoint = async (sliceId, deps) => {
   const path = `.tff/slices/${sliceId}/CHECKPOINT.md`;
   const contentResult = await deps.artifactStore.read(path);
-  if (!isOk(contentResult)) return Err(createDomainError("PROJECT_EXISTS", `No checkpoint found for slice "${sliceId}"`, { sliceId }));
+  if (!isOk(contentResult)) return Err(createDomainError("NOT_FOUND", `No checkpoint found for slice "${sliceId}"`, { sliceId }));
   const match = contentResult.data.match(/<!-- checkpoint-json: (.+) -->/);
-  if (!match) return Err(createDomainError("SYNC_CONFLICT", `Checkpoint file for "${sliceId}" is corrupted`, { sliceId }));
+  if (!match) return Err(createDomainError("VALIDATION_ERROR", `Checkpoint file for "${sliceId}" is corrupted`, { sliceId }));
   const data = JSON.parse(match[1]);
   return Ok(data);
 };
@@ -23957,7 +23957,7 @@ var main = async () => {
   if (!command || command === "--help" || command === "-h") {
     console.log(JSON.stringify({
       ok: true,
-      data: { name: "tff-tools", version: "0.4.0", commands: Object.keys(commands) }
+      data: { name: "tff-tools", version: "0.5.0", commands: Object.keys(commands) }
     }));
     return;
   }

--- a/tools/src/application/checkpoint/load-checkpoint.ts
+++ b/tools/src/application/checkpoint/load-checkpoint.ts
@@ -10,10 +10,10 @@ export const loadCheckpoint = async (
 ): Promise<Result<CheckpointData, DomainError>> => {
   const path = `.tff/slices/${sliceId}/CHECKPOINT.md`;
   const contentResult = await deps.artifactStore.read(path);
-  if (!isOk(contentResult)) return Err(createDomainError('PROJECT_EXISTS', `No checkpoint found for slice "${sliceId}"`, { sliceId }));
+  if (!isOk(contentResult)) return Err(createDomainError('NOT_FOUND', `No checkpoint found for slice "${sliceId}"`, { sliceId }));
 
   const match = contentResult.data.match(/<!-- checkpoint-json: (.+) -->/);
-  if (!match) return Err(createDomainError('SYNC_CONFLICT', `Checkpoint file for "${sliceId}" is corrupted`, { sliceId }));
+  if (!match) return Err(createDomainError('VALIDATION_ERROR', `Checkpoint file for "${sliceId}" is corrupted`, { sliceId }));
 
   const data = JSON.parse(match[1]) as CheckpointData;
   return Ok(data);

--- a/tools/src/cli/index.ts
+++ b/tools/src/cli/index.ts
@@ -66,7 +66,7 @@ const main = async () => {
   if (!command || command === '--help' || command === '-h') {
     console.log(JSON.stringify({
       ok: true,
-      data: { name: 'tff-tools', version: '0.4.0', commands: Object.keys(commands) },
+      data: { name: 'tff-tools', version: '0.5.0', commands: Object.keys(commands) },
     }));
     return;
   }

--- a/tools/src/infrastructure/adapters/filesystem/markdown-artifact.adapter.ts
+++ b/tools/src/infrastructure/adapters/filesystem/markdown-artifact.adapter.ts
@@ -10,12 +10,12 @@ export class MarkdownArtifactAdapter implements ArtifactStore {
 
   async read(path: string): Promise<Result<string, DomainError>> {
     try { return Ok(await readFile(this.resolve(path), 'utf-8')); }
-    catch { return Err(createDomainError('PROJECT_EXISTS', `File not found: ${path}`, { path })); }
+    catch { return Err(createDomainError('NOT_FOUND', `File not found: ${path}`, { path })); }
   }
 
   async write(path: string, content: string): Promise<Result<void, DomainError>> {
     try { const fullPath = this.resolve(path); await mkdir(dirname(fullPath), { recursive: true }); await writeFile(fullPath, content, 'utf-8'); return Ok(undefined); }
-    catch (err) { return Err(createDomainError('SYNC_CONFLICT', `Failed to write: ${path}`, { path, error: String(err) })); }
+    catch (err) { return Err(createDomainError('VALIDATION_ERROR', `Failed to write: ${path}`, { path, error: String(err) })); }
   }
 
   async exists(path: string): Promise<boolean> {
@@ -29,6 +29,6 @@ export class MarkdownArtifactAdapter implements ArtifactStore {
 
   async mkdir(path: string): Promise<Result<void, DomainError>> {
     try { await mkdir(this.resolve(path), { recursive: true }); return Ok(undefined); }
-    catch (err) { return Err(createDomainError('SYNC_CONFLICT', `Failed to mkdir: ${path}`, { path, error: String(err) })); }
+    catch (err) { return Err(createDomainError('VALIDATION_ERROR', `Failed to mkdir: ${path}`, { path, error: String(err) })); }
   }
 }

--- a/tools/src/infrastructure/testing/in-memory-artifact-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-artifact-store.ts
@@ -7,7 +7,7 @@ export class InMemoryArtifactStore implements ArtifactStore {
 
   async read(path: string): Promise<Result<string, DomainError>> {
     const content = this.files.get(path);
-    if (content === undefined) return Err(createDomainError('PROJECT_EXISTS', `File not found: ${path}`, { path }));
+    if (content === undefined) return Err(createDomainError('NOT_FOUND', `File not found: ${path}`, { path }));
     return Ok(content);
   }
 

--- a/tools/src/infrastructure/testing/in-memory-git-ops.ts
+++ b/tools/src/infrastructure/testing/in-memory-git-ops.ts
@@ -17,7 +17,7 @@ export class InMemoryGitOps implements GitOps {
   }
 
   async deleteWorktree(path: string): Promise<Result<void, DomainError>> {
-    if (!this.worktrees.has(path)) return Err(createDomainError('PROJECT_EXISTS', `Worktree not found: ${path}`, { path }));
+    if (!this.worktrees.has(path)) return Err(createDomainError('NOT_FOUND', `Worktree not found: ${path}`, { path }));
     this.worktrees.delete(path); return Ok(undefined);
   }
 


### PR DESCRIPTION
## Summary
- Replace `PROJECT_EXISTS` with `NOT_FOUND` for file/resource not-found errors across 4 files
- Replace `SYNC_CONFLICT` with `VALIDATION_ERROR` for write/mkdir/corruption failures across 2 files
- Fix CLI help version from `0.4.0` to `0.5.0` to match `package.json`

## Files changed (6)
- `tools/src/infrastructure/adapters/filesystem/markdown-artifact.adapter.ts`
- `tools/src/infrastructure/testing/in-memory-artifact-store.ts`
- `tools/src/infrastructure/testing/in-memory-git-ops.ts`
- `tools/src/application/checkpoint/load-checkpoint.ts`
- `tools/src/cli/index.ts`
- `tools/dist/tff-tools.cjs`

## Review pipeline
- [x] Spec review — PASS (all 4 acceptance criteria met)
- [x] Code review — PASS (expanded scope to fix 3 additional instances)
- [x] Security audit — PASS (no findings)
- [x] Plannotator review — PASS (no changes requested)

## Test plan
- [x] All 580 existing tests pass
- [x] Bundle rebuilt and CLI `--help` reports `0.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)