### PR TITLE
fix(S07): register tff custom statuses with beads

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -14471,6 +14471,11 @@ var init_bd_cli_adapter = __esm({
         await runBd(["init", "--quiet"]);
         return Ok(void 0);
       }
+      async registerStatuses(statuses) {
+        const r = await runBd(["config", "set", "status.custom", statuses.join(",")]);
+        if (!r.ok) return r;
+        return Ok(void 0);
+      }
       async create(input) {
         const args = ["create", input.title, "-l", input.label, "--no-inherit-labels", "--json"];
         if (input.parentId) args.push("--parent", input.parentId);
@@ -14570,6 +14575,9 @@ var init_markdown_bead_adapter = __esm({
       beadsDir;
       async init() {
         await (0, import_promises.mkdir)(this.beadsDir, { recursive: true });
+        return Ok(void 0);
+      }
+      async registerStatuses(_statuses) {
         return Ok(void 0);
       }
       async create(input) {
@@ -22383,6 +22391,15 @@ var initProject = async (input, deps) => {
   if (await deps.artifactStore.exists(".tff/PROJECT.md")) return Err(projectExistsError(input.name));
   await deps.beadStore.init();
   await new Promise((resolve) => setTimeout(resolve, 2e3));
+  await deps.beadStore.registerStatuses([
+    "discussing",
+    "researching",
+    "planning",
+    "executing",
+    "verifying",
+    "reviewing",
+    "completing"
+  ]);
   const existing = await deps.beadStore.list({ label: "tff:project" });
   if (isOk(existing) && existing.data.length > 0) return Err(projectExistsError(input.name));
   const project = createProject(input);
@@ -22873,7 +22890,8 @@ init_result();
 var transitionSliceUseCase = async (input, deps) => {
   const result = transitionSlice(input.slice, input.targetStatus);
   if (!isOk(result)) return result;
-  await deps.beadStore.updateStatus(input.beadId, input.targetStatus);
+  const updateResult = await deps.beadStore.updateStatus(input.beadId, input.targetStatus);
+  if (!isOk(updateResult)) return updateResult;
   return result;
 };
 

--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -22391,7 +22391,7 @@ var initProject = async (input, deps) => {
   if (await deps.artifactStore.exists(".tff/PROJECT.md")) return Err(projectExistsError(input.name));
   await deps.beadStore.init();
   await new Promise((resolve) => setTimeout(resolve, 2e3));
-  await deps.beadStore.registerStatuses([
+  const regResult = await deps.beadStore.registerStatuses([
     "discussing",
     "researching",
     "planning",
@@ -22400,6 +22400,7 @@ var initProject = async (input, deps) => {
     "reviewing",
     "completing"
   ]);
+  if (!isOk(regResult)) return regResult;
   const existing = await deps.beadStore.list({ label: "tff:project" });
   if (isOk(existing) && existing.data.length > 0) return Err(projectExistsError(input.name));
   const project = createProject(input);

--- a/tools/src/application/lifecycle/transition-slice.ts
+++ b/tools/src/application/lifecycle/transition-slice.ts
@@ -14,6 +14,7 @@ export const transitionSliceUseCase = async (
 ): Promise<Result<TransitionOutput, DomainError>> => {
   const result = transitionSlice(input.slice, input.targetStatus);
   if (!isOk(result)) return result;
-  await deps.beadStore.updateStatus(input.beadId, input.targetStatus);
+  const updateResult = await deps.beadStore.updateStatus(input.beadId, input.targetStatus);
+  if (!isOk(updateResult)) return updateResult;
   return result;
 };

--- a/tools/src/application/project/init-project.ts
+++ b/tools/src/application/project/init-project.ts
@@ -24,10 +24,11 @@ export const initProject = async (
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   // Register tff slice lifecycle statuses as custom bd statuses
-  await deps.beadStore.registerStatuses([
+  const regResult = await deps.beadStore.registerStatuses([
     'discussing', 'researching', 'planning', 'executing',
     'verifying', 'reviewing', 'completing',
   ]);
+  if (!isOk(regResult)) return regResult;
 
   const existing = await deps.beadStore.list({ label: 'tff:project' });
   if (isOk(existing) && existing.data.length > 0) return Err(projectExistsError(input.name));

--- a/tools/src/application/project/init-project.ts
+++ b/tools/src/application/project/init-project.ts
@@ -23,6 +23,12 @@ export const initProject = async (
   // Small delay to let Dolt server stabilize after init
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
+  // Register tff slice lifecycle statuses as custom bd statuses
+  await deps.beadStore.registerStatuses([
+    'discussing', 'researching', 'planning', 'executing',
+    'verifying', 'reviewing', 'completing',
+  ]);
+
   const existing = await deps.beadStore.list({ label: 'tff:project' });
   if (isOk(existing) && existing.data.length > 0) return Err(projectExistsError(input.name));
 

--- a/tools/src/domain/ports/bead-store.port.ts
+++ b/tools/src/domain/ports/bead-store.port.ts
@@ -17,6 +17,9 @@ export interface BeadData {
 export interface BeadStore {
   init(): Promise<Result<void, DomainError>>;
 
+  /** Register custom statuses with the backing store */
+  registerStatuses(statuses: string[]): Promise<Result<void, DomainError>>;
+
   create(input: {
     label: BeadLabel;
     title: string;

--- a/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
@@ -120,6 +120,12 @@ export class BdCliAdapter implements BeadStore {
     return Ok(undefined);
   }
 
+  async registerStatuses(statuses: string[]): Promise<Result<void, DomainError>> {
+    const r = await runBd(['config', 'set', 'status.custom', statuses.join(',')]);
+    if (!r.ok) return r;
+    return Ok(undefined);
+  }
+
   async create(input: {
     label: BeadLabel;
     title: string;

--- a/tools/src/infrastructure/adapters/beads/markdown-bead.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/markdown-bead.adapter.ts
@@ -19,6 +19,11 @@ export class MarkdownBeadAdapter implements BeadStore {
     return Ok(undefined);
   }
 
+  async registerStatuses(_statuses: string[]): Promise<Result<void, DomainError>> {
+    // Markdown adapter accepts any status string — no registration needed
+    return Ok(undefined);
+  }
+
   async create(input: {
     label: BeadLabel;
     title: string;

--- a/tools/src/infrastructure/testing/in-memory-bead-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-bead-store.ts
@@ -11,6 +11,10 @@ export class InMemoryBeadStore implements BeadStore {
     return Ok(undefined);
   }
 
+  async registerStatuses(_statuses: string[]): Promise<Result<void, DomainError>> {
+    return Ok(undefined);
+  }
+
   async create(input: {
     label: BeadLabel;
     title: string;


### PR DESCRIPTION
## Summary
- Add `registerStatuses()` to `BeadStore` port and all 3 implementations (BdCliAdapter, MarkdownBeadAdapter, InMemoryBeadStore)
- Call `registerStatuses()` during `project:init` after `beadStore.init()` — registers tff lifecycle statuses (`discussing`, `researching`, `planning`, etc.) as valid bd custom statuses
- Check `updateStatus` Result in `transitionSliceUseCase` — propagate error instead of silently ignoring failed bead updates
- Check `registerStatuses` Result in `initProject` — fail fast if registration fails

## Root cause
`bd update <id> -s researching` was rejected with "invalid status" because tff lifecycle statuses were never registered via `bd config set status.custom`. All `slice:transition` calls appeared to succeed (domain validation passed) but bead state never updated.

## Review pipeline
- [x] Spec review — PASS
- [x] Code review — PASS (one fix applied: check registerStatuses Result)
- [x] Security audit — PASS

## Test plan
- [x] All 580 existing tests pass
- [x] Manual verification: `bd update <id> -s researching` succeeds after status registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)