### PR TITLE
fix(S06): read actual bead status in slice:transition

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -14444,7 +14444,7 @@ var init_bd_cli_adapter = __esm({
         title: raw.title,
         status: raw.status,
         design: raw.design,
-        parentId: raw.parent ?? raw.parent_id ?? raw.parentId,
+        parentId: raw.parent,
         blocks: raw.blocks,
         validates: raw.validates,
         metadata: raw.metadata

--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -22900,24 +22900,31 @@ var transitionSliceUseCase = async (input, deps) => {
 init_bead_adapter_factory();
 init_result();
 var sliceTransitionCmd = async (args) => {
-  const [beadId, targetStatus, currentStatus, sliceId] = args;
+  const [beadId, targetStatus] = args;
   if (!beadId || !targetStatus) {
-    return JSON.stringify({ ok: false, error: { code: "INVALID_ARGS", message: "Usage: slice:transition <bead-id> <target-status> [current-status] [slice-id]" } });
+    return JSON.stringify({ ok: false, error: { code: "INVALID_ARGS", message: "Usage: slice:transition <bead-id> <target-status>" } });
   }
   try {
     SliceStatusSchema.parse(targetStatus);
   } catch {
     return JSON.stringify({ ok: false, error: { code: "INVALID_ARGS", message: `Invalid status: ${targetStatus}` } });
   }
+  const { store: beadStore } = await createBeadAdapter();
+  const beadResult = await beadStore.get(beadId);
+  if (!isOk(beadResult)) {
+    return JSON.stringify({ ok: false, error: { code: "NOT_FOUND", message: `Bead "${beadId}" not found` } });
+  }
+  const bead = beadResult.data;
+  const sliceIdMatch = bead.design?.match(/Slice (M\d+-S\d+)/);
+  const sliceId = sliceIdMatch?.[1] ?? beadId;
   const slice = {
-    id: crypto.randomUUID(),
-    milestoneId: crypto.randomUUID(),
-    name: "slice",
-    sliceId: sliceId ?? "unknown",
-    status: currentStatus ?? "discussing",
+    id: bead.id,
+    milestoneId: bead.parentId ?? "",
+    name: bead.title,
+    sliceId,
+    status: bead.status,
     createdAt: /* @__PURE__ */ new Date()
   };
-  const { store: beadStore } = await createBeadAdapter();
   const result = await transitionSliceUseCase(
     { slice, beadId, targetStatus },
     { beadStore }

--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -14444,7 +14444,7 @@ var init_bd_cli_adapter = __esm({
         title: raw.title,
         status: raw.status,
         design: raw.design,
-        parentId: raw.parent_id ?? raw.parentId,
+        parentId: raw.parent ?? raw.parent_id ?? raw.parentId,
         blocks: raw.blocks,
         validates: raw.validates,
         metadata: raw.metadata
@@ -22915,14 +22915,21 @@ var sliceTransitionCmd = async (args) => {
     return JSON.stringify({ ok: false, error: { code: "NOT_FOUND", message: `Bead "${beadId}" not found` } });
   }
   const bead = beadResult.data;
+  const parsedStatus = SliceStatusSchema.safeParse(bead.status);
+  if (!parsedStatus.success) {
+    return JSON.stringify({ ok: false, error: { code: "VALIDATION_ERROR", message: `Bead has invalid slice status: "${bead.status}"` } });
+  }
+  if (!bead.parentId) {
+    return JSON.stringify({ ok: false, error: { code: "VALIDATION_ERROR", message: `Bead "${beadId}" has no parent milestone` } });
+  }
   const sliceIdMatch = bead.design?.match(/Slice (M\d+-S\d+)/);
-  const sliceId = sliceIdMatch?.[1] ?? beadId;
+  const sliceId = sliceIdMatch?.[1] ?? "unknown";
   const slice = {
     id: bead.id,
-    milestoneId: bead.parentId ?? "",
+    milestoneId: bead.parentId,
     name: bead.title,
     sliceId,
-    status: bead.status,
+    status: parsedStatus.data,
     createdAt: /* @__PURE__ */ new Date()
   };
   const result = await transitionSliceUseCase(

--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -4,9 +4,9 @@ import { type SliceStatus, SliceStatusSchema } from '../../domain/value-objects/
 import { isOk } from '../../domain/result.js';
 
 export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
-  const [beadId, targetStatus, currentStatus, sliceId] = args;
+  const [beadId, targetStatus] = args;
   if (!beadId || !targetStatus) {
-    return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Usage: slice:transition <bead-id> <target-status> [current-status] [slice-id]' } });
+    return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Usage: slice:transition <bead-id> <target-status>' } });
   }
 
   try {
@@ -15,17 +15,29 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
     return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: `Invalid status: ${targetStatus}` } });
   }
 
-  // Build a minimal slice object from the args
+  const { store: beadStore } = await createBeadAdapter();
+
+  // Read actual bead to get current status
+  const beadResult = await beadStore.get(beadId);
+  if (!isOk(beadResult)) {
+    return JSON.stringify({ ok: false, error: { code: 'NOT_FOUND', message: `Bead "${beadId}" not found` } });
+  }
+
+  const bead = beadResult.data;
+
+  // Extract slice ID from bead design field (format: "Slice M01-S01: ...")
+  const sliceIdMatch = bead.design?.match(/Slice (M\d+-S\d+)/);
+  const sliceId = sliceIdMatch?.[1] ?? beadId;
+
   const slice = {
-    id: crypto.randomUUID(),
-    milestoneId: crypto.randomUUID(),
-    name: 'slice',
-    sliceId: sliceId ?? 'unknown',
-    status: (currentStatus ?? 'discussing') as SliceStatus,
+    id: bead.id,
+    milestoneId: bead.parentId ?? '',
+    name: bead.title,
+    sliceId,
+    status: bead.status as SliceStatus,
     createdAt: new Date(),
   };
 
-  const { store: beadStore } = await createBeadAdapter();
   const result = await transitionSliceUseCase(
     { slice, beadId, targetStatus: targetStatus as SliceStatus },
     { beadStore },

--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -25,16 +25,26 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
 
   const bead = beadResult.data;
 
+  // Validate bead status is a valid slice status
+  const parsedStatus = SliceStatusSchema.safeParse(bead.status);
+  if (!parsedStatus.success) {
+    return JSON.stringify({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Bead has invalid slice status: "${bead.status}"` } });
+  }
+
+  if (!bead.parentId) {
+    return JSON.stringify({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Bead "${beadId}" has no parent milestone` } });
+  }
+
   // Extract slice ID from bead design field (format: "Slice M01-S01: ...")
   const sliceIdMatch = bead.design?.match(/Slice (M\d+-S\d+)/);
-  const sliceId = sliceIdMatch?.[1] ?? beadId;
+  const sliceId = sliceIdMatch?.[1] ?? 'unknown';
 
   const slice = {
     id: bead.id,
-    milestoneId: bead.parentId ?? '',
+    milestoneId: bead.parentId,
     name: bead.title,
     sliceId,
-    status: bead.status as SliceStatus,
+    status: parsedStatus.data,
     createdAt: new Date(),
   };
 

--- a/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
@@ -87,7 +87,7 @@ const normalizeBeadData = (raw: Record<string, unknown>): Result<BeadData, Domai
     title: raw.title as string,
     status: raw.status,
     design: raw.design as string | undefined,
-    parentId: (raw.parent_id ?? raw.parentId) as string | undefined,
+    parentId: (raw.parent ?? raw.parent_id ?? raw.parentId) as string | undefined,
     blocks: raw.blocks as string[] | undefined,
     validates: raw.validates as string[] | undefined,
     metadata: raw.metadata as Record<string, string> | undefined,

--- a/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
@@ -68,8 +68,8 @@ const runBdRetry = async (
 };
 
 /**
- * Normalize beads JSON output (snake_case) to our BeadData interface.
- * bd returns snake_case fields: issue_type, created_at, parent_id, etc.
+ * Normalize beads JSON output to our BeadData interface.
+ * bd returns: id, title, design, status, parent, labels, etc.
  */
 const normalizeBeadData = (raw: Record<string, unknown>): Result<BeadData, DomainError> => {
   if (!raw.id || typeof raw.id !== 'string') {
@@ -87,7 +87,7 @@ const normalizeBeadData = (raw: Record<string, unknown>): Result<BeadData, Domai
     title: raw.title as string,
     status: raw.status,
     design: raw.design as string | undefined,
-    parentId: (raw.parent ?? raw.parent_id ?? raw.parentId) as string | undefined,
+    parentId: raw.parent as string | undefined,
     blocks: raw.blocks as string[] | undefined,
     validates: raw.validates as string[] | undefined,
     metadata: raw.metadata as Record<string, string> | undefined,


### PR DESCRIPTION
## Summary
- Replace fake slice object (random UUIDs, hardcoded `discussing` status) with real bead lookup via `beadStore.get()`
- Command now only needs 2 args (`beadId`, `targetStatus`) instead of 4
- Validate `bead.status` against `SliceStatusSchema` instead of unsafe cast
- Return error when bead has no parent milestone
- Fix `normalizeBeadData` to read `parent` field (bd JSON uses `parent`, not `parent_id`)

## Root cause
`slice:transition` built a fake slice with `status: currentStatus ?? 'discussing'`, so sequential transitions failed unless the caller manually passed `currentStatus`. The bead's actual status was never read.

## Review pipeline
- [x] Spec review — PASS
- [x] Code review — PASS (2 fixes applied: status validation, parent field mapping)
- [x] Security audit — PASS (net improvement: removes caller-controlled status bypass)

## Test plan
- [x] All 580 existing tests pass
- [x] Manual: transition without currentStatus arg succeeds
- [x] Manual: invalid transition rejected with correct slice ID and status

🤖 Generated with [Claude Code](https://claude.com/claude-code)