### PR TITLE
feat(S02): add tffWarn helper and surface swallowed errors

### DIFF
--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -1,5 +1,6 @@
 import { transitionSliceUseCase } from '../../application/lifecycle/transition-slice.js';
 import { createBeadAdapter } from '../../infrastructure/adapters/beads/bead-adapter-factory.js';
+import { tffWarn } from '../../infrastructure/adapters/logging/warn.js';
 import { type SliceStatus, SliceStatusSchema } from '../../domain/value-objects/slice-status.js';
 import { isOk } from '../../domain/result.js';
 
@@ -58,7 +59,7 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
     try {
       const { snapshotSaveCmd } = await import('./snapshot-save.cmd.js');
       await snapshotSaveCmd([]);
-    } catch { /* snapshot failure is non-blocking */ }
+    } catch (e) { tffWarn('snapshot failed', { error: String(e) }); }
 
     // Auto-sync to Dolt remote if configured
     try {
@@ -70,7 +71,7 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
       if (settings.dolt?.['auto-sync'] && settings.dolt.remote) {
         await doltPush(settings.dolt.remote);
       }
-    } catch { /* dolt sync failure is non-blocking */ }
+    } catch (e) { tffWarn('dolt sync failed', { error: String(e) }); }
 
     return JSON.stringify({ ok: true, data: { status: result.data.slice.status } });
   }

--- a/tools/src/infrastructure/adapters/beads/bead-adapter-factory.ts
+++ b/tools/src/infrastructure/adapters/beads/bead-adapter-factory.ts
@@ -1,6 +1,7 @@
 import { BdCliAdapter } from './bd-cli.adapter.js';
 import { MarkdownBeadAdapter } from './markdown-bead.adapter.js';
 import type { BeadStore } from '../../../domain/ports/bead-store.port.js';
+import { tffWarn } from '../logging/warn.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
@@ -29,7 +30,9 @@ export async function createBeadAdapter(opts: FactoryOpts = {}): Promise<Adapter
   const checkBd = opts.checkBd ?? defaultCheckBd;
   const basePath = opts.basePath ?? process.cwd();
   if (await checkBd()) {
+    tffWarn('using beads adapter: bd-cli');
     return { store: new BdCliAdapter(), type: 'beads' };
   }
+  tffWarn('using beads adapter: markdown-fallback');
   return { store: new MarkdownBeadAdapter(basePath), type: 'markdown' };
 }

--- a/tools/src/infrastructure/adapters/logging/warn.ts
+++ b/tools/src/infrastructure/adapters/logging/warn.ts
@@ -1,0 +1,7 @@
+export function tffWarn(message: string, context?: Record<string, unknown>): void {
+  if (context !== undefined) {
+    console.warn('[tff]', message, context);
+  } else {
+    console.warn('[tff]', message);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `tffWarn` helper in `infrastructure/adapters/logging/warn.ts`
- Surface bead adapter selection (bd-cli vs markdown-fallback)
- Replace swallowed errors in `slice:transition` with `tffWarn` calls
- Domain layer `project-settings.ts` intentionally unchanged (hexagonal boundary)

## Test plan
- [x] All 580 tests pass
- [x] Code review — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)