### PR TITLE
fix(S03): fix InMemoryBeadStore.ready() deps and type dolt-sync

### DIFF
--- a/tools/src/infrastructure/adapters/dolt/dolt-sync.ts
+++ b/tools/src/infrastructure/adapters/dolt/dolt-sync.ts
@@ -3,18 +3,27 @@ import { promisify } from 'node:util';
 
 const exec = promisify(execFile);
 
+interface DoltConfig {
+  remote: string;
+  'auto-sync'?: boolean;
+}
+
+interface DoltAwareSettings {
+  dolt?: DoltConfig;
+}
+
 interface DoltSettings {
   remote: string;
   autoSync: boolean;
 }
 
-export function parseDoltSettings(settings: Record<string, any> | undefined): DoltSettings | null {
+export function parseDoltSettings(settings: DoltAwareSettings | undefined): DoltSettings | null {
   const dolt = settings?.dolt;
   if (!dolt?.remote) return null;
   return { remote: dolt.remote, autoSync: dolt['auto-sync'] === true };
 }
 
-export function shouldAutoSync(settings: Record<string, any> | undefined): boolean {
+export function shouldAutoSync(settings: DoltAwareSettings | undefined): boolean {
   return parseDoltSettings(settings)?.autoSync === true;
 }
 

--- a/tools/src/infrastructure/testing/in-memory-bead-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-bead-store.ts
@@ -55,7 +55,11 @@ export class InMemoryBeadStore implements BeadStore {
 
   async ready(): Promise<Result<BeadData[], DomainError>> {
     // Return open beads with no unresolved blockers
-    const results = [...this.beads.values()].filter((b) => b.status === 'open');
+    const results = [...this.beads.values()].filter((b) => {
+      if (b.status !== 'open') return false;
+      if (!b.blocks || b.blocks.length === 0) return true;
+      return b.blocks.every((blockerId) => this.beads.get(blockerId)?.status === 'closed');
+    });
     return Ok(results);
   }
 


### PR DESCRIPTION
## Summary
- Fix `InMemoryBeadStore.ready()` to respect `blocks` dependency graph — bead is ready only if all blockers are `closed`
- Replace `Record<string, any>` in `dolt-sync.ts` with typed `DoltConfig` and `DoltAwareSettings` interfaces

## Test plan
- [x] All 580 tests pass
- [x] Code review — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)