### PR TITLE
feat(S10): auto-generate STATE.md and save checkpoints after transitions

### DIFF
--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -73,6 +73,26 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
       }
     } catch (e) { tffWarn('dolt sync failed', { error: String(e) }); }
 
+    // Auto-regenerate STATE.md
+    try {
+      const { syncStateCmd } = await import('./sync-state.cmd.js');
+      await syncStateCmd([bead.parentId ?? '']);
+    } catch (e) { tffWarn('state sync failed', { error: String(e) }); }
+
+    // Auto-save CHECKPOINT.md
+    try {
+      const { checkpointSaveCmd } = await import('./checkpoint-save.cmd.js');
+      const checkpointData = JSON.stringify({
+        sliceId,
+        baseCommit: '',
+        currentWave: 0,
+        completedWaves: [],
+        completedTasks: [],
+        executorLog: [],
+      });
+      await checkpointSaveCmd([checkpointData]);
+    } catch (e) { tffWarn('checkpoint save failed', { error: String(e) }); }
+
     return JSON.stringify({ ok: true, data: { status: result.data.slice.status } });
   }
   return JSON.stringify({ ok: false, error: result.error });


### PR DESCRIPTION
## Summary
- Auto-call `sync:state` after successful slice transitions to regenerate STATE.md
- Auto-save minimal CHECKPOINT.md after transitions (placeholder data — full checkpoint data only available during execution phase)
- Both use `tffWarn` for non-blocking error logging

## Test plan
- [x] All 580 tests pass
- [x] Code review — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)