### PR TITLE
fix(S09/S13): enforce .tff/worktrees path and add worktree instructions

### DIFF
--- a/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
@@ -38,6 +38,9 @@ const execBd = async (
 ): Promise<string> => {
   const options: { timeout: number; input?: string } = { timeout: 30_000 };
   if (stdin) options.input = stdin;
+  // TODO(S09): When running inside a worktree (process.cwd() contains '.tff/worktrees/'),
+  // bd commands should use '--sandbox' flag to prevent auto-sync and Dolt server conflicts
+  // with the main repo's Dolt server. Requires verifying that bd supports a '--sandbox' flag.
   const { stdout } = await exec('bd', args, options);
   return stdout.trim();
 };

--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -29,8 +29,10 @@ exploration, spawn Explore subagents and reason about their findings.
 
 ## Phase 2: Fix (slice + worktree, like quick)
 
-6. CREATE slice as S-tier: bead + worktree
-7. SPAWN domain agent with: root cause description, fix strategy, implicated files
+6. CREATE slice as S-tier:
+   - Create slice bead via `tff-tools`
+   - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
+7. SPAWN domain agent (working in `.tff/worktrees/<slice-id>/`) with: root cause description, fix strategy, implicated files
 8. VERIFY: spawn tff-product-lead for sanity check
 9. SHIP: fresh reviewer enforcement, code-only review (no spec review — no SPEC.md), create slice PR
    - user merges via GitHub

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -8,9 +8,11 @@ Skip discuss + research → straight to plan, execute, ship.
 active milestone exists
 
 ## Steps
-1. CREATE slice as S-tier: bead + worktree
+1. CREATE slice as S-tier:
+   - Create slice bead via `tff-tools`
+   - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
 2. PLAN (lightweight): ask user for 1-2 sentence desc → single task in PLAN.md, skip plannotator
-3. EXECUTE: single wave, single task, spawn domain agent, no TDD (S-tier)
+3. EXECUTE: single wave, single task, spawn domain agent (working in `.tff/worktrees/<slice-id>/`), no TDD (S-tier)
 4. VERIFY: spawn tff-product-lead for quick sanity check
 5. SHIP: fresh reviewer enforcement, spec + code review (lightweight), create slice PR
    - user merges via GitHub


### PR DESCRIPTION
## Summary
- Update `workflows/quick.md` and `workflows/debug.md` with explicit `tff-tools worktree:create` calls and `.tff/worktrees/` paths
- Add TODO comment in `bd-cli.adapter.ts` for `--sandbox` flag when running in worktrees
- `.tff/worktrees/` already in `.gitignore`, `worktree:create` already uses correct path

## Test plan
- [x] All tests pass
- [x] Code review — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)