### PR TITLE
fix(S11): make auto-transition instructions explicit in all workflows

### DIFF
--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -2,6 +2,8 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
+**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+
 ## Prerequisites
 status = discussing
 
@@ -55,7 +57,10 @@ AskUserQuestion: "Spec at `.tff/slices/<id>/SPEC.md`. Approve?"
 `tff-tools slice:transition <id> researching`
 
 ## Auto-Transition
-Read `.tff/settings.yaml` → `autonomy.mode`.
-`plan-to-pr` ∧ ¬HUMAN_GATE → auto-invoke next workflow via `tff-tools workflow:next <status>`.
-`guided` → suggest next step, wait for user.
-Progress: `[tff] <slice-id>: discussing → researching`
+After completing all steps above:
+1. READ `.tff/settings.yaml` → check `autonomy.mode`
+2. IF `plan-to-pr`:
+   - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
+   - Human gates (plan approval, spec approval, completion): pause and ask
+3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
+4. Log: `[tff] <slice-id>: discussing → researching`

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -2,6 +2,8 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
+**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+
 ## Prerequisites
 status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
 
@@ -26,7 +28,10 @@ status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
 5. NEXT: @references/next-steps.md
 
 ## Auto-Transition
-Read `.tff/settings.yaml` → `autonomy.mode`.
-`plan-to-pr` ∧ ¬HUMAN_GATE → auto-invoke next workflow via `tff-tools workflow:next <status>`.
-`guided` → suggest next step, wait for user.
-Progress: `[tff] <slice-id>: executing → verifying`
+After completing all steps above:
+1. READ `.tff/settings.yaml` → check `autonomy.mode`
+2. IF `plan-to-pr`:
+   - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
+   - Human gates (plan approval, spec approval, completion): pause and ask
+3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
+4. Log: `[tff] <slice-id>: executing → verifying`

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -71,7 +71,7 @@ DISPATCH anonymous reviewer via Agent tool (prompt: @skills/interactive-design.m
 Issues → fix, re-dispatch (max 3)
 
 ### 8. Plannotator Review
-`plannotator annotate .tff/slices/<id>/PLAN.md`
+invoke Skill `plannotator-annotate` with arg `.tff/slices/<id>/PLAN.md`
 feedback → revise ∨ approved → continue
 
 ### 9. Worktree + Transition

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -2,6 +2,8 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
+**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+
 ## Prerequisites
 status = planning
 SPEC.md exists at `.tff/slices/<id>/SPEC.md`
@@ -79,5 +81,10 @@ feedback → revise ∨ approved → continue
 `tff-tools slice:transition <id> executing`
 
 ## Auto-Transition
-`plan-to-pr` → auto-invoke execute | `guided` → suggest `/tff:execute`
-`[tff] <slice-id>: planning → executing`
+After completing all steps above:
+1. READ `.tff/settings.yaml` → check `autonomy.mode`
+2. IF `plan-to-pr`:
+   - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
+   - Human gates (plan approval, spec approval, completion): pause and ask
+3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
+4. Log: `[tff] <slice-id>: planning → executing`

--- a/workflows/research-slice.md
+++ b/workflows/research-slice.md
@@ -2,6 +2,8 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
+**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+
 ## Prerequisites
 status = researching
 
@@ -15,7 +17,10 @@ status = researching
 4. NEXT: @references/next-steps.md
 
 ## Auto-Transition
-Read `.tff/settings.yaml` → `autonomy.mode`.
-`plan-to-pr` ∧ ¬HUMAN_GATE → auto-invoke next workflow via `tff-tools workflow:next <status>`.
-`guided` → suggest next step, wait for user.
-Progress: `[tff] <slice-id>: researching → planning`
+After completing all steps above:
+1. READ `.tff/settings.yaml` → check `autonomy.mode`
+2. IF `plan-to-pr`:
+   - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
+   - Human gates (plan approval, spec approval, completion): pause and ask
+3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
+4. Log: `[tff] <slice-id>: researching → planning`

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -14,7 +14,7 @@ status = reviewing
    REQUEST_CHANGES → SPAWN tff-fixer → loop until APPROVE
 4. Stage 3 (security) — SPAWN tff-security-auditor: {diff, @references/security-baseline.md}
    critical ∨ high → blocks PR → SPAWN tff-fixer → re-audit
-5. USER REVIEW: `plannotator review`
+5. USER REVIEW: invoke Skill `plannotator-review` for interactive code review of the diff
 6. PR: `gh pr create` — `slice/<slice-id>` → `milestone/<milestone>`
    **Show PR URL to user**
 7. POST-MERGE (user merges via GitHub):

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -2,6 +2,8 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
+**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+
 ## Prerequisites
 status = reviewing
 
@@ -25,10 +27,13 @@ status = reviewing
 8. NEXT: @references/next-steps.md
 
 ## Auto-Transition
-Read `.tff/settings.yaml` → `autonomy.mode`.
-`plan-to-pr` ∧ ¬HUMAN_GATE → auto-invoke next workflow via `tff-tools workflow:next <status>`.
-`guided` → suggest next step, wait for user.
-Progress: `[tff] <slice-id>: reviewing → completing`
+After completing all steps above:
+1. READ `.tff/settings.yaml` → check `autonomy.mode`
+2. IF `plan-to-pr`:
+   - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
+   - Human gates (plan approval, spec approval, completion): pause and ask
+3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
+4. Log: `[tff] <slice-id>: reviewing → completing`
 
 ## Auto-Fix (plan-to-pr)
 REQUEST_CHANGES ∧ cycles < 2 → SPAWN tff-fixer, re-review


### PR DESCRIPTION
## Summary
- Add **Autonomy** note at top of all 5 workflow files for visibility
- Replace terse auto-transition sections with explicit 4-step directive blocks
- Explicitly state: non-gate steps → IMMEDIATELY invoke next, do NOT ask user
- Also includes S08 plannotator skill name fixes (absorbed into this branch)

## Workflows updated
- `discuss-slice.md`, `research-slice.md`, `plan-slice.md`, `execute-slice.md`, `ship-slice.md`

## Test plan
- [x] Code review — PASS
- [x] Workflow docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)