### PR TITLE
fix(S07): use Skill tool for all plannotator invocations

### DIFF
--- a/skills/plannotator-usage.md
+++ b/skills/plannotator-usage.md
@@ -14,16 +14,16 @@ token-budget: background
 
 | Point | Workflow | Command | Input |
 |---|---|---|---|
-| Plan review | /tff:plan | `plannotator annotate .tff/slices/M01-S01/PLAN.md` | PLAN.md |
-| Verification | /tff:verify | `plannotator annotate .tff/slices/M01-S01/VERIFICATION.md` | VERIFICATION.md |
-| Code review | /tff:ship | `plannotator review` | git diff |
+| Plan review | /tff:plan | invoke Skill `plannotator-annotate` with arg `.tff/slices/<id>/PLAN.md` | PLAN.md |
+| Verification | /tff:verify | invoke Skill `plannotator-annotate` with arg `.tff/slices/<id>/VERIFICATION.md` | VERIFICATION.md |
+| Code review | /tff:ship | invoke Skill `plannotator-review` | git diff |
 
 ∀ points: opens interactive UI → user annotates → feedback returns to stdout → agent processes
 
 ## Command Frontmatter
 
 ```yaml
-allowed-tools: Bash(plannotator:*)
+allowed-tools: Skill(plannotator-annotate, plannotator-review)
 ```
 
 ## Loop

--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -8,7 +8,7 @@ all slices closed ∧ milestone audit passed
 ## Steps
 1. PR: `gh pr create` milestone/<milestone> → main — **ALWAYS show PR URL**
 2. SPAWN tff-security-auditor: milestone-level review
-3. REVIEW: `plannotator review`
+3. REVIEW: invoke Skill `plannotator-review` for interactive milestone review
 4. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
 5. AFTER MERGE (user merges via GitHub):
    - close milestone bead, update STATE.md

--- a/workflows/compose-skills.md
+++ b/workflows/compose-skills.md
@@ -23,7 +23,7 @@ Pass: `tff-tools compose:detect --min-sessions 3 --min-patterns 2 --max-distance
 3. SPAWN tff-skill-drafter ("Compose Bundle" mode) for selected cluster:
    - provide cluster skills + co-activation rate → decides bundle vs agent
    - draft → `.tff/drafts/<name>.md`
-4. REVIEW: `plannotator annotate .tff/drafts/<name>.md`
+4. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/drafts/<name>.md`
 5. HANDLE:
    - approved bundle → `skills/<name>.md`
    - approved agent → `agents/<name>.md`

--- a/workflows/create-skill.md
+++ b/workflows/create-skill.md
@@ -11,9 +11,9 @@ Draft new skill from pattern candidate or user description.
    - draft → `.tff/drafts/<skill-name>.md`
 3. VALIDATE: `tff-tools skills:validate '<json>'`
    - fail → drafter fixes ∧ re-validates
-4. REVIEW: `plannotator annotate .tff/drafts/<skill-name>.md`
+4. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/drafts/<skill-name>.md`
 5. HANDLE:
    - approved → move `.tff/drafts/<name>.md` → `skills/<name>.md`
-   - feedback → revise ∧ re-submit to plannotator
+   - feedback → revise ∧ re-invoke `plannotator-annotate`
    - rejected → delete draft
 6. NEXT: @references/next-steps.md

--- a/workflows/learn-skills.md
+++ b/workflows/learn-skills.md
@@ -20,7 +20,7 @@ Pass maxDrift: `tff-tools skills:drift --max-drift 0.2`
    - draft → `.tff/drafts/<skill-name>.md`
 4. CONSTRAINTS: max 20% per refinement, max 60% cumulative drift, 7-day cooldown
    - violated → warn user, suggest new skill instead
-5. REVIEW: `plannotator annotate .tff/drafts/<skill-name>.md`
+5. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/drafts/<skill-name>.md`
 6. HANDLE:
    - approved → archive to `.tff/observations/skill-history/<name>.v<N>.md`, update `skills/<name>.md`
    - rejected → record as intentional divergence (suppress future suggestions)

--- a/workflows/verify-slice.md
+++ b/workflows/verify-slice.md
@@ -8,7 +8,7 @@ status = verifying
 ## Steps
 1. SPAWN tff-product-lead: {acceptance_criteria from PLAN.md}
    - Verify each criterion against implementation
-2. FINDINGS → `plannotator annotate .tff/slices/<slice-id>/VERIFICATION.md`
+2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff/slices/<slice-id>/VERIFICATION.md`
 3. VERDICT:
    - PASS → `tff-tools slice:transition <id> reviewing` → suggest `/tff:ship`
    - FAIL → ask user: fix (→ back to executing, replan) ∨ accept w/ exceptions (→ reviewing)


### PR DESCRIPTION
## Summary
- Replace raw `plannotator annotate/review` bash commands with proper Skill tool invocations (`plannotator-annotate`, `plannotator-review`) in 5 workflows and the plannotator-usage skill reference
- Affected: verify-slice, compose-skills, create-skill, complete-milestone, learn-skills

## Test plan
- [x] All plannotator references use Skill tool format
- [x] No remaining raw bash `plannotator` commands in workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)