### PR TITLE
fix(S13): use CLAUDE_PLUGIN_ROOT for PostToolUse hook path

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "hooks/tff-observe.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/tff-observe.sh",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Fix `hooks/hooks.json` to use `${CLAUDE_PLUGIN_ROOT}/hooks/tff-observe.sh` instead of relative `hooks/tff-observe.sh`
- Relative path resolved against cwd, not plugin root, causing "PostToolUse hook error" on every tool call

## Test plan
- [x] Hook command uses `${CLAUDE_PLUGIN_ROOT}` prefix matching superpowers plugin pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)