### PR TITLE
refactor(S15): decouple requirements and milestone from project init

### DIFF
--- a/references/conventions.md
+++ b/references/conventions.md
@@ -70,7 +70,7 @@ Special formats:
 ```
 .tff/
   PROJECT.md              ← project vision (markdown-authoritative)
-  REQUIREMENTS.md         ← requirements content
+  REQUIREMENTS.md         ← requirements for active milestone (written during /tff:new-milestone)
   STATE.md                ← DERIVED, never edit manually
   settings.yaml           ← model profiles, quality gates
   slices/

--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -11,7 +11,9 @@ all slices closed ∧ milestone audit passed
 3. REVIEW: invoke Skill `plannotator-review` for interactive milestone review
 4. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
 5. AFTER MERGE (user merges via GitHub):
-   - close milestone bead, update STATE.md
+   - close all open slice beads: `bd list --label tff:slice --json` → for each open/non-closed slice under this milestone: `bd close <id> --reason "Milestone completed"`
+   - close milestone bead: `bd close <milestone-bead-id> --reason "Milestone merged to main"`
+   - update STATE.md: `tff-tools sync:state`
    - suggest `/tff:new-milestone`
 
 **RULE: tff NEVER merges. Only create PR. User merges via GitHub.**

--- a/workflows/new-milestone.md
+++ b/workflows/new-milestone.md
@@ -5,9 +5,11 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 ## Steps
 1. ASK user: milestone name (e.g. "MVP", "Auth System"), goal
 2. CREATE: `tff-tools milestone:create "<name>"`
-   - creates `tff:milestone` bead + `milestone/M01` branch (from main)
-3. DEFINE SLICES: ask user to break milestone into slices (name, desc, deps)
-4. CREATE slice beads w/ dependencies
-5. SUMMARY: show milestone structure + slice ordering
+   - creates `tff:milestone` bead + `milestone/M0X` branch (from main)
+3. REQUIREMENTS: ask user for requirements scoped to this milestone → write `.tff/REQUIREMENTS.md`
+   - If REQUIREMENTS.md exists, ask whether to replace or append
+4. DEFINE SLICES: ask user to break milestone into slices (name, desc, deps)
+5. CREATE slice beads w/ dependencies
+6. SUMMARY: show milestone structure + slice ordering
    - suggest `/tff:discuss`
-6. NEXT: @references/next-steps.md
+7. NEXT: @references/next-steps.md

--- a/workflows/new-project.md
+++ b/workflows/new-project.md
@@ -48,11 +48,8 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
    - Pre-filled from step 3 if onboarding occurred
 5. INIT: `tff-tools project:init "<name>" "<vision>"`
 6. SETTINGS: generate `.tff/settings.yaml` from @references/settings-template.md
-7. CREATE `.tff/REQUIREMENTS.md`: ask user for requirements → structured doc
-   - Pre-filled from step 3 if onboarding occurred
-8. FIRST MILESTONE: ask goal → execute new-milestone workflow
-9. SUMMARY: show created files (PROJECT.md, settings.yaml, REQUIREMENTS.md, milestone + branch)
-   - suggest `/tff:discuss`
+7. SUMMARY: show created files (PROJECT.md, settings.yaml)
+   - suggest `/tff:new-milestone` to create the first milestone
 
 ## Dolt Remote (optional)
 Prompt:
@@ -75,4 +72,4 @@ Configure snapshot merge driver:
 git config merge.tff-snapshot.driver "node ./tools/dist/tff-tools.cjs snapshot:merge %O %A %B"
 ```
 
-10. NEXT: @references/next-steps.md
+8. NEXT: @references/next-steps.md


### PR DESCRIPTION
## Summary
- Remove requirements (step 7) and first milestone (step 8) from `/tff:new` workflow
- Add requirements step to `/tff:new-milestone` — requirements are now scoped per-milestone
- Update conventions to reflect REQUIREMENTS.md is written during milestone creation
- Project init now only produces PROJECT.md + settings.yaml, then suggests `/tff:new-milestone`

## Test plan
- [x] new-project.md no longer references REQUIREMENTS.md or milestone creation
- [x] new-milestone.md includes requirements step with append/replace option
- [x] conventions.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)