### PR TITLE
fix(S16): add merge gate to close beads after PR merge

### DIFF
--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -3,19 +3,25 @@
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
 ## Prerequisites
-all slices closed ∧ milestone audit passed
+milestone audit passed
 
 ## Steps
-1. PR: `gh pr create` milestone/<milestone> → main — **ALWAYS show PR URL**
-2. SPAWN tff-security-auditor: milestone-level review
-3. REVIEW: invoke Skill `plannotator-review` for interactive milestone review
-4. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
-5. AFTER MERGE (user merges via GitHub):
-   - close all open slice beads: `bd list --label tff:slice --json` → for each open/non-closed slice under this milestone: `bd close <id> --reason "Milestone completed"`
-   - close milestone bead: `bd close <milestone-bead-id> --reason "Milestone merged to main"`
+1. CLOSE SLICES: `bd list --label tff:slice --json` → for each non-closed slice under this milestone:
+   - verify its PR is merged: `gh pr list --state merged --head slice/<slice-id>`
+   - if merged → `bd close <id> --reason "Slice PR merged"`
+   - if not merged → warn user, block milestone completion
+2. PR: `gh pr create` milestone/<milestone> → main — **ALWAYS show PR URL**
+3. SPAWN tff-security-auditor: milestone-level review
+4. REVIEW: invoke Skill `plannotator-review` for interactive milestone review
+5. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
+
+**tff NEVER merges — only creates PR.**
+
+6. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
+   - merged → continue to step 7
+   - needs changes → fix → push → go back to step 6
+7. CLOSE MILESTONE:
+   - `bd close <milestone-bead-id> --reason "Milestone merged to main"`
    - update STATE.md: `tff-tools sync:state`
    - suggest `/tff:new-milestone`
-
-**RULE: tff NEVER merges. Only create PR. User merges via GitHub.**
-
-6. NEXT: @references/next-steps.md
+8. NEXT: @references/next-steps.md

--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -35,5 +35,8 @@ exploration, spawn Explore subagents and reason about their findings.
 7. SPAWN domain agent (working in `.tff/worktrees/<slice-id>/`) with: root cause description, fix strategy, implicated files
 8. VERIFY: spawn tff-product-lead for sanity check
 9. SHIP: fresh reviewer enforcement, code-only review (no spec review — no SPEC.md), create slice PR
-   - user merges via GitHub
-10. NEXT: @references/next-steps.md
+   **Show PR URL to user**
+10. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
+    - merged → `bd close <slice-bead-id> --reason "Slice PR merged"`
+    - needs changes → fix → push → go back to step 10
+11. NEXT: @references/next-steps.md

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -15,5 +15,8 @@ active milestone exists
 3. EXECUTE: single wave, single task, spawn domain agent (working in `.tff/worktrees/<slice-id>/`), no TDD (S-tier)
 4. VERIFY: spawn tff-product-lead for quick sanity check
 5. SHIP: fresh reviewer enforcement, spec + code review (lightweight), create slice PR
-   - user merges via GitHub
-6. NEXT: @references/next-steps.md
+   **Show PR URL to user**
+6. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
+   - merged → `bd close <slice-bead-id> --reason "Slice PR merged"`
+   - needs changes → fix → push → go back to step 6
+7. NEXT: @references/next-steps.md

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -19,22 +19,26 @@ status = reviewing
 5. USER REVIEW: invoke Skill `plannotator-review` for interactive code review of the diff
 6. PR: `gh pr create` — `slice/<slice-id>` → `milestone/<milestone>`
    **Show PR URL to user**
-7. POST-MERGE (user merges via GitHub):
-   delete worktree → close bead → completing → closed
 
 **tff NEVER merges — only creates PR.**
 
-8. NEXT: @references/next-steps.md
+7. MERGE GATE: AskUserQuestion with options:
+   - **"PR merged"** → continue to step 8
+   - **"PR needs changes"** → SPAWN tff-fixer with requested changes → push fixes → go back to step 7
+8. CLOSE:
+   - `tff-tools worktree:delete <slice-id>` (if worktree exists)
+   - `bd close <slice-bead-id> --reason "Slice PR merged"`
+   - Log: `[tff] <slice-id>: reviewing → closed`
+9. NEXT: @references/next-steps.md
 
 ## Auto-Transition
 After completing all steps above:
 1. READ `.tff/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
-   - Human gates (plan approval, spec approval, completion): pause and ask
+   - Human gates (plan approval, spec approval, merge gate): pause and ask
 3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
-4. Log: `[tff] <slice-id>: reviewing → completing`
 
 ## Auto-Fix (plan-to-pr)
-REQUEST_CHANGES ∧ cycles < 2 → SPAWN tff-fixer, re-review
+REQUEST_CHANGES ∧ cycles < 2 → SPAWN tff-fixer, re-review, go back to merge gate
 REQUEST_CHANGES ∧ cycles ≥ 2 → escalation task, pause chain


### PR DESCRIPTION
## Summary
- Add AskUserQuestion merge gate to all shipping workflows (ship-slice, quick, debug, complete-milestone)
- "PR merged" → automatically close slice/milestone beads via `bd close`
- "PR needs changes" → fix loop → re-push → ask again
- complete-milestone now closes all slice beads (verifying PR merge status) before creating milestone PR
- Removes impossible prerequisite "all slices closed" from complete-milestone (replaced by step 1 auto-closure)

## Root cause
Merges happen on GitHub, but bead closures happen in Claude. No workflow had automation to bridge the two — beads were left open indefinitely after PR merges.

## Test plan
- [x] ship-slice.md has merge gate (step 7) + close (step 8)
- [x] quick.md has merge gate (step 6)
- [x] debug.md has merge gate (step 10)
- [x] complete-milestone.md closes slices (step 1) + has merge gate (step 6) + closes milestone (step 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)