### PR TITLE
fix(S01): derive milestone number from highest existing ID

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -22854,7 +22854,17 @@ var milestoneCreateCmd = async (args) => {
   }
   const projectBeadId = projectResult.data[0].id;
   const milestonesResult = await beadStore.list({ label: "tff:milestone" });
-  const number4 = isOk(milestonesResult) ? milestonesResult.data.length + 1 : 1;
+  let maxMilestoneNumber = 0;
+  if (isOk(milestonesResult)) {
+    for (const m of milestonesResult.data) {
+      const match = m.design?.match(/M(\d+)/);
+      if (match) {
+        const num = parseInt(match[1], 10);
+        if (num > maxMilestoneNumber) maxMilestoneNumber = num;
+      }
+    }
+  }
+  const number4 = maxMilestoneNumber + 1;
   const result = await createMilestoneUseCase(
     { projectBeadId, name, number: number4 },
     { beadStore, artifactStore, gitOps }

--- a/tools/src/cli/commands/milestone-create.cmd.ts
+++ b/tools/src/cli/commands/milestone-create.cmd.ts
@@ -22,9 +22,19 @@ export const milestoneCreateCmd = async (args: string[]): Promise<string> => {
   }
   const projectBeadId = projectResult.data[0].id;
 
-  // Auto-number: count existing milestones + 1
+  // Auto-number: find highest existing milestone number and increment
   const milestonesResult = await beadStore.list({ label: 'tff:milestone' });
-  const number = isOk(milestonesResult) ? milestonesResult.data.length + 1 : 1;
+  let maxMilestoneNumber = 0;
+  if (isOk(milestonesResult)) {
+    for (const m of milestonesResult.data) {
+      const match = m.design?.match(/M(\d+)/);
+      if (match) {
+        const num = parseInt(match[1], 10);
+        if (num > maxMilestoneNumber) maxMilestoneNumber = num;
+      }
+    }
+  }
+  const number = maxMilestoneNumber + 1;
 
   const result = await createMilestoneUseCase(
     { projectBeadId, name, number },


### PR DESCRIPTION
## Summary
- Fix `milestone:create` to derive milestone number from highest existing `M(\d+)` in design fields instead of counting milestones
- `bd list` excludes closed beads by default, so count-based numbering produced duplicate M01 after M01 was closed

## Test plan
- [x] Build passes
- [x] 580 tests pass
- [x] Same pattern as S12 slice numbering fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)