### PR TITLE
feat(S02): add bead-vs-PR reconciliation to health workflow

### DIFF
--- a/workflows/health.md
+++ b/workflows/health.md
@@ -6,16 +6,25 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 1. CHECK beads: `bd --version`
 2. CHECK plannotator installed
 3. CHECK state consistency: beads vs markdown mismatches, orphans, worktree integrity
-4. REPORT:
+4. CHECK bead-vs-PR status:
+   - `bd list --label tff:slice --json` → for each non-closed slice:
+     - extract slice ID from design field (e.g. `M02-S01`)
+     - `gh pr list --state merged --head slice/<slice-id> --json number` → if merged PR exists but bead is open:
+       - report as stale: `⚠ <slice-id>: bead is <status> but PR #<N> is merged`
+   - `bd list --label tff:milestone --json` → for each non-closed milestone:
+     - if all child slices are closed → report: `⚠ <milestone>: all slices closed but milestone bead is still open`
+5. REPORT:
    ```
    | Check | Status |
    |---|---|
    | beads CLI | OK/MISSING |
    | plannotator | OK/MISSING |
    | State consistency | OK/X mismatches |
+   | Bead-PR sync | OK/X stale beads |
    | Worktrees | OK/X orphans |
    ```
-5. issues found → offer `/tff:sync` to reconcile
+6. stale beads found → AskUserQuestion: "Close stale beads?" → yes → `bd close <id> --reason "PR already merged"`
+7. other issues found → offer `/tff:sync` to reconcile
 
 ## Adapter Mode
 Check `bd --version`:


### PR DESCRIPTION
## Summary
- Add bead-vs-PR status check to `/tff:health` workflow (step 4)
- Detects stale beads: open/non-closed beads whose slice PR is already merged on GitHub
- Detects stale milestones: all child slices closed but milestone bead still open
- Offers to auto-close stale beads via AskUserQuestion

## Test plan
- [x] health.md includes bead-PR sync check with `gh pr list` commands
- [x] Report table includes new "Bead-PR sync" row
- [x] Auto-close flow via AskUserQuestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)