### PR TITLE
feat(S03): add error handling convention and checks to workflows

### DIFF
--- a/references/orchestrator-pattern.md
+++ b/references/orchestrator-pattern.md
@@ -23,6 +23,12 @@ tff workflows are orchestrators. They coordinate — they don't do heavy work.
 
 5. **State transitions go through tff-tools.** The orchestrator calls `tff-tools.cjs` for all state changes. Agents don't transition state directly.
 
+6. **Check tff-tools results for errors.** Every `tff-tools` call returns `{ "ok": true, ... }` or `{ "ok": false, "error": { "code": "...", "message": "..." } }`. The orchestrator MUST check `ok` — if `false`:
+   - Log the error: `⚠ tff-tools <command> failed: <message>`
+   - For state transitions: warn user and offer retry or abort
+   - For non-critical operations (snapshot, checkpoint): warn but continue
+   - NEVER silently continue after a failed state transition
+
 ## Anti-Patterns
 
 - Reading entire codebases in the workflow (spawn an agent instead)

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -55,6 +55,7 @@ AskUserQuestion: "Spec at `.tff/slices/<id>/SPEC.md`. Approve?"
 
 ### 8. Transition
 `tff-tools slice:transition <id> researching`
+CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
 
 ## Auto-Transition
 After completing all steps above:

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -25,6 +25,7 @@ status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
   sync:state
 ```
 4. TRANSITION: `tff-tools slice:transition <id> verifying`
+   CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
 5. NEXT: @references/next-steps.md
 
 ## Auto-Transition

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -78,7 +78,9 @@ feedback → revise ∨ approved → continue
 
 ### 9. Worktree + Transition
 `tff-tools worktree:create <id>`
+CHECK: `ok` = true → continue | `ok` = false → warn (worktree failure is non-blocking)
 `tff-tools slice:transition <id> executing`
+CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
 
 ## Auto-Transition
 After completing all steps above:

--- a/workflows/research-slice.md
+++ b/workflows/research-slice.md
@@ -14,6 +14,7 @@ status = researching
    - Check dependencies + integration points
    - Output → `.tff/slices/<slice-id>/RESEARCH.md`
 3. TRANSITION: `tff-tools slice:transition <id> planning`
+   CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
 4. NEXT: @references/next-steps.md
 
 ## Auto-Transition

--- a/workflows/verify-slice.md
+++ b/workflows/verify-slice.md
@@ -10,7 +10,8 @@ status = verifying
    - Verify each criterion against implementation
 2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff/slices/<slice-id>/VERIFICATION.md`
 3. VERDICT:
-   - PASS → `tff-tools slice:transition <id> reviewing` → suggest `/tff:ship`
+   - PASS → `tff-tools slice:transition <id> reviewing`
+     CHECK: `ok` = true → suggest `/tff:ship` | `ok` = false → warn user, offer retry or abort
    - FAIL → ask user: fix (→ back to executing, replan) ∨ accept w/ exceptions (→ reviewing)
 4. NEXT: @references/next-steps.md
 


### PR DESCRIPTION
## Summary
- Add rule 6 to orchestrator pattern: all tff-tools calls must check `ok` field
- Add explicit CHECK after state transitions in 5 critical workflows: discuss, research, plan, execute, verify
- Failed transitions → warn user → offer retry or abort (no silent continuation)
- Non-critical failures (worktree, snapshot) → warn but continue

## Test plan
- [x] Orchestrator pattern has rule 6 with error handling convention
- [x] All 5 transition workflows have CHECK after `slice:transition` calls
- [x] plan-slice distinguishes blocking (transition) vs non-blocking (worktree) failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)