### PR TITLE
security(S04): add path traversal guard and Dolt remote validation

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -14392,7 +14392,7 @@ async function withRetry(fn, opts = {}) {
       lastError = err;
       if (attempt < maxAttempts) {
         const delay = Math.min(baseMs * Math.pow(2, attempt - 1), maxMs);
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise((resolve2) => setTimeout(resolve2, delay));
       }
     }
   }
@@ -14735,7 +14735,12 @@ var init_markdown_artifact_adapter = __esm({
         this.basePath = basePath;
       }
       resolve(path) {
-        return (0, import_node_path2.join)(this.basePath, path);
+        const resolved = (0, import_node_path2.resolve)((0, import_node_path2.join)(this.basePath, path));
+        const base = (0, import_node_path2.resolve)(this.basePath);
+        if (!resolved.startsWith(base + "/") && resolved !== base) {
+          throw new Error(`Path traversal rejected: ${path}`);
+        }
+        return resolved;
       }
       async read(path) {
         try {
@@ -22394,24 +22399,32 @@ function parseDoltSettings(settings) {
 function shouldAutoSync(settings) {
   return parseDoltSettings(settings)?.autoSync === true;
 }
+function validateRemote(remote) {
+  if (!VALID_REMOTE.test(remote)) {
+    throw new Error(`Invalid Dolt remote name: "${remote}". Must be alphanumeric, hyphens, or underscores only.`);
+  }
+}
 async function doltPush(remote) {
   try {
+    validateRemote(remote);
     await exec4("dolt", ["push", remote], { timeout: 3e4, cwd: process.cwd() });
   } catch {
   }
 }
 async function doltPull(remote) {
   try {
+    validateRemote(remote);
     await exec4("dolt", ["pull", remote], { timeout: 3e4, cwd: process.cwd() });
   } catch {
   }
 }
-var import_node_child_process4, import_node_util4, exec4;
+var import_node_child_process4, import_node_util4, exec4, VALID_REMOTE;
 var init_dolt_sync = __esm({
   "tools/src/infrastructure/adapters/dolt/dolt-sync.ts"() {
     import_node_child_process4 = require("child_process");
     import_node_util4 = require("util");
     exec4 = (0, import_node_util4.promisify)(import_node_child_process4.execFile);
+    VALID_REMOTE = /^[a-zA-Z0-9_-]+$/;
   }
 });
 
@@ -22604,7 +22617,7 @@ var initProject = async (input, deps) => {
   if (!isOk(regResult)) return regResult;
   let existing = await deps.beadStore.list({ label: "tff:project" });
   for (let attempt = 1; attempt < 5 && !isOk(existing); attempt++) {
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve2) => setTimeout(resolve2, 500));
     existing = await deps.beadStore.list({ label: "tff:project" });
   }
   if (isOk(existing) && existing.data.length > 0) return Err(projectExistsError(input.name));

--- a/tools/src/infrastructure/adapters/dolt/dolt-sync.ts
+++ b/tools/src/infrastructure/adapters/dolt/dolt-sync.ts
@@ -27,14 +27,24 @@ export function shouldAutoSync(settings: DoltAwareSettings | undefined): boolean
   return parseDoltSettings(settings)?.autoSync === true;
 }
 
+const VALID_REMOTE = /^[a-zA-Z0-9_-]+$/;
+
+function validateRemote(remote: string): void {
+  if (!VALID_REMOTE.test(remote)) {
+    throw new Error(`Invalid Dolt remote name: "${remote}". Must be alphanumeric, hyphens, or underscores only.`);
+  }
+}
+
 export async function doltPush(remote: string): Promise<void> {
   try {
+    validateRemote(remote);
     await exec('dolt', ['push', remote], { timeout: 30000, cwd: process.cwd() });
   } catch { /* non-blocking */ }
 }
 
 export async function doltPull(remote: string): Promise<void> {
   try {
+    validateRemote(remote);
     await exec('dolt', ['pull', remote], { timeout: 30000, cwd: process.cwd() });
   } catch { /* non-blocking */ }
 }

--- a/tools/src/infrastructure/adapters/filesystem/markdown-artifact.adapter.ts
+++ b/tools/src/infrastructure/adapters/filesystem/markdown-artifact.adapter.ts
@@ -1,12 +1,19 @@
 import { readFile, writeFile, mkdir, readdir, access } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { type ArtifactStore } from '../../../domain/ports/artifact-store.port.js';
 import { type Result, Ok, Err } from '../../../domain/result.js';
 import { type DomainError, createDomainError } from '../../../domain/errors/domain-error.js';
 
 export class MarkdownArtifactAdapter implements ArtifactStore {
   constructor(private readonly basePath: string) {}
-  private resolve(path: string): string { return join(this.basePath, path); }
+  private resolve(path: string): string {
+    const resolved = resolve(join(this.basePath, path));
+    const base = resolve(this.basePath);
+    if (!resolved.startsWith(base + '/') && resolved !== base) {
+      throw new Error(`Path traversal rejected: ${path}`);
+    }
+    return resolved;
+  }
 
   async read(path: string): Promise<Result<string, DomainError>> {
     try { return Ok(await readFile(this.resolve(path), 'utf-8')); }


### PR DESCRIPTION
## Summary
- **Path traversal guard**: `MarkdownArtifactAdapter.resolve()` now checks that resolved path starts with `basePath` — rejects `../../` escape attempts
- **Dolt remote validation**: `doltPush`/`doltPull` validate remote name against `^[a-zA-Z0-9_-]+$` — prevents flag injection via crafted remote values like `--upload-pack=...`

## Test plan
- [x] Build passes, 580 tests pass
- [x] Path traversal: `join(base, "../../etc/passwd")` would throw before any FS access
- [x] Dolt remote: `"--upload-pack=evil"` would be rejected before exec

🤖 Generated with [Claude Code](https://claude.com/claude-code)