### PR TITLE
refactor(S05): milestone-scoped directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Complexity is auto-classified as **F-lite** (5 tasks, 2 modules, no external int
 /tff:research M01-S01
 ```
 
-The agent investigates the technical approach: reads the existing codebase, checks what auth libraries are available, documents findings in `.tff/slices/M01-S01/RESEARCH.md`.
+The agent investigates the technical approach: reads the existing codebase, checks what auth libraries are available, documents findings in `.tff/milestones/M01/slices/M01-S01/RESEARCH.md`.
 
 **Next step suggested:** `/tff:plan M01-S01`
 

--- a/references/conventions.md
+++ b/references/conventions.md
@@ -70,15 +70,17 @@ Special formats:
 ```
 .tff/
   PROJECT.md              ← project vision (markdown-authoritative)
-  REQUIREMENTS.md         ← requirements for active milestone (written during /tff:new-milestone)
   STATE.md                ← DERIVED, never edit manually
   settings.yaml           ← model profiles, quality gates
-  slices/
-    M01-S01/
-      SPEC.md             ← design spec (produced during discuss)
-      PLAN.md             ← slice plan and task descriptions
-      RESEARCH.md         ← research notes
-      CHECKPOINT.md       ← resumability data
+  milestones/
+    M01/
+      REQUIREMENTS.md     ← requirements scoped to this milestone
+      slices/
+        M01-S01/
+          SPEC.md         ← design spec (produced during discuss)
+          PLAN.md         ← slice plan and task descriptions
+          RESEARCH.md     ← research notes
+          CHECKPOINT.md   ← resumability data
   worktrees/
     M01-S01/              ← git worktree (gitignored)
 ```

--- a/skills/interactive-design.md
+++ b/skills/interactive-design.md
@@ -23,7 +23,7 @@ token-budget: critical
 3. DESIGN: section-by-section, user approves each via AskUserQuestion
    - F-lite: problem, approach, acceptance criteria, non-goals (~1 page)
    - F-full: + constraints, architecture, error handling, testing strategy (~3 pages)
-4. WRITE: `.tff/slices/<id>/SPEC.md`
+4. WRITE: `.tff/milestones/<milestone>/slices/<id>/SPEC.md`
 5. CHALLENGE: spawn tff-brainstormer (F-full only, max 2 iterations)
 6. VALIDATE: spawn tff-product-lead → ∀ criterion: testable ∧ binary
 7. REVIEW: dispatch anonymous spec-document-reviewer (max 3 iterations)

--- a/skills/plannotator-usage.md
+++ b/skills/plannotator-usage.md
@@ -14,8 +14,8 @@ token-budget: background
 
 | Point | Workflow | Command | Input |
 |---|---|---|---|
-| Plan review | /tff:plan | invoke Skill `plannotator-annotate` with arg `.tff/slices/<id>/PLAN.md` | PLAN.md |
-| Verification | /tff:verify | invoke Skill `plannotator-annotate` with arg `.tff/slices/<id>/VERIFICATION.md` | VERIFICATION.md |
+| Plan review | /tff:plan | invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md` | PLAN.md |
+| Verification | /tff:verify | invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/VERIFICATION.md` | VERIFICATION.md |
 | Code review | /tff:ship | invoke Skill `plannotator-review` | git diff |
 
 ∀ points: opens interactive UI → user annotates → feedback returns to stdout → agent processes

--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -22504,8 +22504,9 @@ var init_save_checkpoint = __esm({
         `<!-- checkpoint-json: ${JSON.stringify(data)} -->`,
         ""
       ];
-      const path = `.tff/slices/${data.sliceId}/CHECKPOINT.md`;
-      await deps.artifactStore.mkdir(`.tff/slices/${data.sliceId}`);
+      const milestoneId = data.sliceId.match(/^(M\d+)/)?.[1] ?? "M01";
+      const path = `.tff/milestones/${milestoneId}/slices/${data.sliceId}/CHECKPOINT.md`;
+      await deps.artifactStore.mkdir(`.tff/milestones/${milestoneId}/slices/${data.sliceId}`);
       await deps.artifactStore.write(path, lines.join("\n"));
       return Ok(void 0);
     };
@@ -22612,7 +22613,7 @@ var initProject = async (input, deps) => {
   const beadResult = await deps.beadStore.create({ label: "tff:project", title: project.name, design: project.vision });
   if (!isOk(beadResult)) return beadResult;
   await deps.artifactStore.mkdir(".tff");
-  await deps.artifactStore.mkdir(".tff/slices");
+  await deps.artifactStore.mkdir(".tff/milestones");
   const projectMd = `# ${project.name}
 
 ## Vision
@@ -22717,15 +22718,15 @@ var createMilestoneUseCase = async (input, deps) => {
   });
   if (!isOk(beadResult)) return beadResult;
   await deps.gitOps.createBranch(branchName, "main");
-  if (!await deps.artifactStore.exists(".tff/REQUIREMENTS.md")) {
-    await deps.artifactStore.write(
-      ".tff/REQUIREMENTS.md",
-      `# Requirements \u2014 ${input.name}
+  const milestoneDir = `.tff/milestones/${formatMilestoneNumber(input.number)}`;
+  await deps.artifactStore.mkdir(`${milestoneDir}/slices`);
+  await deps.artifactStore.write(
+    `${milestoneDir}/REQUIREMENTS.md`,
+    `# Requirements \u2014 ${input.name}
 
 _Define your requirements here._
 `
-    );
-  }
+  );
   return Ok({
     milestone,
     beadId: beadResult.data.id,
@@ -22997,7 +22998,8 @@ var createSliceUseCase = async (input, deps) => {
     parentId: input.milestoneBeadId
   });
   if (!isOk(beadResult)) return beadResult;
-  const sliceDir = `.tff/slices/${slice.sliceId}`;
+  const milestoneDir = `.tff/milestones/M${String(input.milestoneNumber).padStart(2, "0")}`;
+  const sliceDir = `${milestoneDir}/slices/${slice.sliceId}`;
   await deps.artifactStore.mkdir(sliceDir);
   await deps.artifactStore.write(
     `${sliceDir}/PLAN.md`,
@@ -23289,9 +23291,11 @@ var reconcileState = async (input, deps) => {
   });
   if (!isOk(slicesResult)) return slicesResult;
   const sliceBeads = slicesResult.data;
-  const sliceFilesResult = await deps.artifactStore.list(".tff/slices");
+  const milestoneNum = input.milestoneName.match(/(M\d+)/)?.[1] ?? "M01";
+  const slicesDir = `.tff/milestones/${milestoneNum}/slices`;
+  const sliceFilesResult = await deps.artifactStore.list(slicesDir);
   const sliceFiles = isOk(sliceFilesResult) ? sliceFilesResult.data : [];
-  const prefix = ".tff/slices/";
+  const prefix = `${slicesDir}/`;
   const mdSliceIds = new Set(
     sliceFiles.filter((f) => f.startsWith(prefix)).map((f) => {
       const rest = f.slice(prefix.length);
@@ -23300,7 +23304,7 @@ var reconcileState = async (input, deps) => {
     }).filter((id) => id.length > 0)
   );
   for (const bead of sliceBeads) {
-    const sliceDir = `.tff/slices/${bead.title}`;
+    const sliceDir = `${slicesDir}/${bead.title}`;
     const planPath = `${sliceDir}/PLAN.md`;
     if (!await deps.artifactStore.exists(planPath)) {
       await deps.artifactStore.mkdir(sliceDir);
@@ -23339,7 +23343,7 @@ ${bead.design ?? "_No plan yet._"}
     mdSliceIds.delete(bead.title);
   }
   for (const sliceId of mdSliceIds) {
-    const planPath = `.tff/slices/${sliceId}/PLAN.md`;
+    const planPath = `${slicesDir}/${sliceId}/PLAN.md`;
     if (await deps.artifactStore.exists(planPath)) {
       const mdResult = await deps.artifactStore.read(planPath);
       const design = isOk(mdResult) ? mdResult.data : "";
@@ -23516,7 +23520,8 @@ init_checkpoint_save_cmd();
 init_result();
 init_domain_error();
 var loadCheckpoint = async (sliceId, deps) => {
-  const path = `.tff/slices/${sliceId}/CHECKPOINT.md`;
+  const milestoneId = sliceId.match(/^(M\d+)/)?.[1] ?? "M01";
+  const path = `.tff/milestones/${milestoneId}/slices/${sliceId}/CHECKPOINT.md`;
   const contentResult = await deps.artifactStore.read(path);
   if (!isOk(contentResult)) return Err(createDomainError("NOT_FOUND", `No checkpoint found for slice "${sliceId}"`, { sliceId }));
   const match = contentResult.data.match(/<!-- checkpoint-json: (.+) -->/);

--- a/tools/src/application/checkpoint/checkpoint.spec.ts
+++ b/tools/src/application/checkpoint/checkpoint.spec.ts
@@ -21,7 +21,7 @@ describe('checkpoint', () => {
   it('should save checkpoint as CHECKPOINT.md', async () => {
     const result = await saveCheckpoint(checkpointData, { artifactStore });
     expect(isOk(result)).toBe(true);
-    expect(await artifactStore.exists('.tff/slices/M01-S01/CHECKPOINT.md')).toBe(true);
+    expect(await artifactStore.exists('.tff/milestones/M01/slices/M01-S01/CHECKPOINT.md')).toBe(true);
   });
 
   it('should load a saved checkpoint', async () => {

--- a/tools/src/application/checkpoint/load-checkpoint.ts
+++ b/tools/src/application/checkpoint/load-checkpoint.ts
@@ -8,7 +8,8 @@ interface LoadCheckpointDeps { artifactStore: ArtifactStore; }
 export const loadCheckpoint = async (
   sliceId: string, deps: LoadCheckpointDeps,
 ): Promise<Result<CheckpointData, DomainError>> => {
-  const path = `.tff/slices/${sliceId}/CHECKPOINT.md`;
+  const milestoneId = sliceId.match(/^(M\d+)/)?.[1] ?? 'M01';
+  const path = `.tff/milestones/${milestoneId}/slices/${sliceId}/CHECKPOINT.md`;
   const contentResult = await deps.artifactStore.read(path);
   if (!isOk(contentResult)) return Err(createDomainError('NOT_FOUND', `No checkpoint found for slice "${sliceId}"`, { sliceId }));
 

--- a/tools/src/application/checkpoint/save-checkpoint.ts
+++ b/tools/src/application/checkpoint/save-checkpoint.ts
@@ -22,8 +22,9 @@ export const saveCheckpoint = async (
     `- Executor log: ${data.executorLog.map((e) => `${e.agent}→${e.taskRef}`).join(', ')}`,
     '', `<!-- checkpoint-json: ${JSON.stringify(data)} -->`, '',
   ];
-  const path = `.tff/slices/${data.sliceId}/CHECKPOINT.md`;
-  await deps.artifactStore.mkdir(`.tff/slices/${data.sliceId}`);
+  const milestoneId = data.sliceId.match(/^(M\d+)/)?.[1] ?? 'M01';
+  const path = `.tff/milestones/${milestoneId}/slices/${data.sliceId}/CHECKPOINT.md`;
+  await deps.artifactStore.mkdir(`.tff/milestones/${milestoneId}/slices/${data.sliceId}`);
   await deps.artifactStore.write(path, lines.join('\n'));
   return Ok(undefined);
 };

--- a/tools/src/application/milestone/create-milestone.spec.ts
+++ b/tools/src/application/milestone/create-milestone.spec.ts
@@ -37,6 +37,6 @@ describe('createMilestoneUseCase', () => {
       { beadStore, artifactStore, gitOps },
     );
 
-    expect(await artifactStore.exists('.tff/REQUIREMENTS.md')).toBe(true);
+    expect(await artifactStore.exists('.tff/milestones/M01/REQUIREMENTS.md')).toBe(true);
   });
 });

--- a/tools/src/application/milestone/create-milestone.ts
+++ b/tools/src/application/milestone/create-milestone.ts
@@ -47,13 +47,13 @@ export const createMilestoneUseCase = async (
   // Create branch
   await deps.gitOps.createBranch(branchName, 'main');
 
-  // Create REQUIREMENTS.md if it doesn't exist
-  if (!(await deps.artifactStore.exists('.tff/REQUIREMENTS.md'))) {
-    await deps.artifactStore.write(
-      '.tff/REQUIREMENTS.md',
-      `# Requirements — ${input.name}\n\n_Define your requirements here._\n`,
-    );
-  }
+  // Create milestone directory with REQUIREMENTS.md
+  const milestoneDir = `.tff/milestones/${formatMilestoneNumber(input.number)}`;
+  await deps.artifactStore.mkdir(`${milestoneDir}/slices`);
+  await deps.artifactStore.write(
+    `${milestoneDir}/REQUIREMENTS.md`,
+    `# Requirements — ${input.name}\n\n_Define your requirements here._\n`,
+  );
 
   return Ok({
     milestone,

--- a/tools/src/application/project/init-project.ts
+++ b/tools/src/application/project/init-project.ts
@@ -41,7 +41,7 @@ export const initProject = async (
   if (!isOk(beadResult)) return beadResult;
 
   await deps.artifactStore.mkdir('.tff');
-  await deps.artifactStore.mkdir('.tff/slices');
+  await deps.artifactStore.mkdir('.tff/milestones');
 
   const projectMd = `# ${project.name}\n\n## Vision\n\n${project.vision}\n`;
   await deps.artifactStore.write('.tff/PROJECT.md', projectMd);

--- a/tools/src/application/slice/create-slice.spec.ts
+++ b/tools/src/application/slice/create-slice.spec.ts
@@ -33,6 +33,6 @@ describe('createSliceUseCase', () => {
       { beadStore, artifactStore },
     );
 
-    expect(await artifactStore.exists('.tff/slices/M01-S01/PLAN.md')).toBe(true);
+    expect(await artifactStore.exists('.tff/milestones/M01/slices/M01-S01/PLAN.md')).toBe(true);
   });
 });

--- a/tools/src/application/slice/create-slice.ts
+++ b/tools/src/application/slice/create-slice.ts
@@ -41,7 +41,8 @@ export const createSliceUseCase = async (
   if (!isOk(beadResult)) return beadResult;
 
   // Create slice directory with stub PLAN.md
-  const sliceDir = `.tff/slices/${slice.sliceId}`;
+  const milestoneDir = `.tff/milestones/M${String(input.milestoneNumber).padStart(2, '0')}`;
+  const sliceDir = `${milestoneDir}/slices/${slice.sliceId}`;
   await deps.artifactStore.mkdir(sliceDir);
   await deps.artifactStore.write(
     `${sliceDir}/PLAN.md`,

--- a/tools/src/application/sync/reconcile-state.spec.ts
+++ b/tools/src/application/sync/reconcile-state.spec.ts
@@ -25,7 +25,7 @@ describe('reconcileState', () => {
     ]);
 
     const result = await reconcileState(
-      { milestoneId: 'ms1', milestoneName: 'MVP' },
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
       { beadStore, artifactStore },
     );
 
@@ -34,7 +34,7 @@ describe('reconcileState', () => {
       expect(result.data.created).toHaveLength(1);
       expect(result.data.created[0].source).toBe('beads');
     }
-    expect(await artifactStore.exists('.tff/slices/Auth/PLAN.md')).toBe(true);
+    expect(await artifactStore.exists('.tff/milestones/M01/slices/Auth/PLAN.md')).toBe(true);
   });
 
   it('should create beads for markdown without beads', async () => {
@@ -42,11 +42,11 @@ describe('reconcileState', () => {
       { id: 'ms1', label: 'tff:milestone', title: 'MVP', status: 'open' },
     ]);
     artifactStore.seed({
-      '.tff/slices/NewSlice/PLAN.md': '# Plan — NewSlice\n\nNew slice content\n',
+      '.tff/milestones/M01/slices/NewSlice/PLAN.md': '# Plan — NewSlice\n\nNew slice content\n',
     });
 
     const result = await reconcileState(
-      { milestoneId: 'ms1', milestoneName: 'MVP' },
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
       { beadStore, artifactStore },
     );
 
@@ -63,11 +63,11 @@ describe('reconcileState', () => {
       { id: 's1', label: 'tff:slice', title: 'Auth', status: 'open', design: 'Old design', parentId: 'ms1' },
     ]);
     artifactStore.seed({
-      '.tff/slices/Auth/PLAN.md': '# Updated plan content',
+      '.tff/milestones/M01/slices/Auth/PLAN.md': '# Updated plan content',
     });
 
     const result = await reconcileState(
-      { milestoneId: 'ms1', milestoneName: 'MVP' },
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
       { beadStore, artifactStore },
     );
 
@@ -85,7 +85,7 @@ describe('reconcileState', () => {
     ]);
 
     await reconcileState(
-      { milestoneId: 'ms1', milestoneName: 'MVP' },
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
       { beadStore, artifactStore },
     );
 
@@ -98,11 +98,11 @@ describe('reconcileState', () => {
       { id: 's1', label: 'tff:slice', title: 'Auth', status: 'executing', design: 'Auth design', parentId: 'ms1' },
     ]);
     artifactStore.seed({
-      '.tff/slices/Auth/PLAN.md': 'Auth design',
+      '.tff/milestones/M01/slices/Auth/PLAN.md': 'Auth design',
     });
 
     const result = await reconcileState(
-      { milestoneId: 'ms1', milestoneName: 'MVP' },
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
       { beadStore, artifactStore },
     );
 
@@ -120,7 +120,7 @@ describe('reconcileState', () => {
     ]);
 
     const result = await reconcileState(
-      { milestoneId: 'ms1', milestoneName: 'MVP' },
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
       { beadStore, artifactStore },
     );
 

--- a/tools/src/application/sync/reconcile-state.ts
+++ b/tools/src/application/sync/reconcile-state.ts
@@ -59,12 +59,15 @@ export const reconcileState = async (
   const sliceBeads = slicesResult.data;
 
   // 2. Load all slice markdown files and extract unique slice directory names
-  const sliceFilesResult = await deps.artifactStore.list('.tff/slices');
+  // Derive milestone number from name (e.g. "Milestone M02: ..." → "M02") or default
+  const milestoneNum = input.milestoneName.match(/(M\d+)/)?.[1] ?? 'M01';
+  const slicesDir = `.tff/milestones/${milestoneNum}/slices`;
+  const sliceFilesResult = await deps.artifactStore.list(slicesDir);
   const sliceFiles = isOk(sliceFilesResult) ? sliceFilesResult.data : [];
 
   // Extract slice IDs from file paths
-  // e.g., ".tff/slices/M01-S01/PLAN.md" → "M01-S01"
-  const prefix = '.tff/slices/';
+  // e.g., ".tff/milestones/M01/slices/M01-S01/PLAN.md" → "M01-S01"
+  const prefix = `${slicesDir}/`;
   const mdSliceIds = new Set(
     sliceFiles
       .filter((f) => f.startsWith(prefix))
@@ -78,7 +81,7 @@ export const reconcileState = async (
 
   // 3. For each bead slice: check if markdown exists
   for (const bead of sliceBeads) {
-    const sliceDir = `.tff/slices/${bead.title}`;
+    const sliceDir = `${slicesDir}/${bead.title}`;
     const planPath = `${sliceDir}/PLAN.md`;
 
     if (!(await deps.artifactStore.exists(planPath))) {
@@ -125,7 +128,7 @@ export const reconcileState = async (
 
   // 4. Remaining mdSliceIds are markdown-only (no bead) → create beads
   for (const sliceId of mdSliceIds) {
-    const planPath = `.tff/slices/${sliceId}/PLAN.md`;
+    const planPath = `${slicesDir}/${sliceId}/PLAN.md`;
     if (await deps.artifactStore.exists(planPath)) {
       const mdResult = await deps.artifactStore.read(planPath);
       const design = isOk(mdResult) ? mdResult.data : '';

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -34,7 +34,7 @@ LOAD @skills/interactive-design.md
 - Revise until approved, then next section
 
 ### 3. Write Spec
-WRITE `.tff/slices/<id>/SPEC.md` w/ validated design
+WRITE `.tff/milestones/<milestone>/slices/<id>/SPEC.md` w/ validated design
 UPDATE bead design field: `beadStore.updateDesign(id, spec_content)`
 
 ### 4. Challenge Spec (F-full only)
@@ -51,7 +51,7 @@ DISPATCH anonymous reviewer via Agent tool (prompt: @skills/interactive-design.m
 Issues → fix, re-dispatch (max 3)
 
 ### 7. User Gate
-AskUserQuestion: "Spec at `.tff/slices/<id>/SPEC.md`. Approve?"
+AskUserQuestion: "Spec at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
 
 ### 8. Transition
 `tff-tools slice:transition <id> researching`

--- a/workflows/new-milestone.md
+++ b/workflows/new-milestone.md
@@ -6,8 +6,7 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 1. ASK user: milestone name (e.g. "MVP", "Auth System"), goal
 2. CREATE: `tff-tools milestone:create "<name>"`
    - creates `tff:milestone` bead + `milestone/M0X` branch (from main)
-3. REQUIREMENTS: ask user for requirements scoped to this milestone → write `.tff/REQUIREMENTS.md`
-   - If REQUIREMENTS.md exists, ask whether to replace or append
+3. REQUIREMENTS: ask user for requirements scoped to this milestone → write `.tff/milestones/<M0X>/REQUIREMENTS.md`
 4. DEFINE SLICES: ask user to break milestone into slices (name, desc, deps)
 5. CREATE slice beads w/ dependencies
 6. SUMMARY: show milestone structure + slice ordering

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -6,13 +6,13 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
 ## Prerequisites
 status = planning
-SPEC.md exists at `.tff/slices/<id>/SPEC.md`
+SPEC.md exists at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`
 
 ## Steps
 
 ### 1. Load Spec
-READ `.tff/slices/<id>/SPEC.md`
-READ `.tff/slices/<id>/RESEARCH.md` (if exists)
+READ `.tff/milestones/<milestone>/slices/<id>/SPEC.md`
+READ `.tff/milestones/<milestone>/slices/<id>/RESEARCH.md` (if exists)
 
 ### 2. File Structure
 Map files to create/modify BEFORE tasks.
@@ -33,7 +33,7 @@ DECOMPOSE spec → tasks:
 - Code snippets, not "implement validation"
 
 ### 4. Write PLAN.md
-WRITE `.tff/slices/<id>/PLAN.md`:
+WRITE `.tff/milestones/<milestone>/slices/<id>/PLAN.md`:
 
 ```
 # [Slice] Implementation Plan
@@ -73,7 +73,7 @@ DISPATCH anonymous reviewer via Agent tool (prompt: @skills/interactive-design.m
 Issues → fix, re-dispatch (max 3)
 
 ### 8. Plannotator Review
-invoke Skill `plannotator-annotate` with arg `.tff/slices/<id>/PLAN.md`
+invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
 feedback → revise ∨ approved → continue
 
 ### 9. Worktree + Transition

--- a/workflows/research-slice.md
+++ b/workflows/research-slice.md
@@ -12,7 +12,7 @@ status = researching
 2. RESEARCH (if needed):
    - Read relevant codebase areas
    - Check dependencies + integration points
-   - Output → `.tff/slices/<slice-id>/RESEARCH.md`
+   - Output → `.tff/milestones/<milestone>/slices/<slice-id>/RESEARCH.md`
 3. TRANSITION: `tff-tools slice:transition <id> planning`
 4. NEXT: @references/next-steps.md
 

--- a/workflows/verify-slice.md
+++ b/workflows/verify-slice.md
@@ -8,7 +8,7 @@ status = verifying
 ## Steps
 1. SPAWN tff-product-lead: {acceptance_criteria from PLAN.md}
    - Verify each criterion against implementation
-2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff/slices/<slice-id>/VERIFICATION.md`
+2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<slice-id>/VERIFICATION.md`
 3. VERDICT:
    - PASS → `tff-tools slice:transition <id> reviewing` → suggest `/tff:ship`
    - FAIL → ask user: fix (→ back to executing, replan) ∨ accept w/ exceptions (→ reviewing)


### PR DESCRIPTION
## Summary
- Restructure `.tff/` to scope artifacts per milestone
- `.tff/slices/<id>/` → `.tff/milestones/<M0X>/slices/<id>/`
- `.tff/REQUIREMENTS.md` → `.tff/milestones/<M0X>/REQUIREMENTS.md`
- 20 files changed across conventions, workflows, CLI use cases, tests, skills, and README

## Files changed
- **Conventions**: directory tree updated
- **Workflows** (4): discuss, plan, research, verify — all slice path refs updated
- **CLI use cases** (6): create-slice, create-milestone, init-project, save/load-checkpoint, reconcile-state
- **Tests** (4): slice, milestone, checkpoint, reconcile specs updated
- **Skills** (2): plannotator-usage, interactive-design
- **README**: example path updated

## Test plan
- [x] 580 tests pass
- [x] Build succeeds
- [x] All path references consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)