### PR TITLE
fix(S06/S07): mandatory plannotator review for all tiers

### DIFF
--- a/references/conventions.md
+++ b/references/conventions.md
@@ -92,11 +92,11 @@ Special formats:
 
 ## Complexity Tiers
 
-| Tier | Brainstormer | Research | TDD | Fresh Reviewer |
-|---|---|---|---|---|
-| S (quick fix) | Skip | Skip | Skip | Always |
-| F-lite (feature) | Yes | Optional | Yes | Always |
-| F-full (complex) | Yes | Required | Yes | Always, multi-agent |
+| Tier | Brainstormer | Research | Plan Review | TDD | Fresh Reviewer |
+|---|---|---|---|---|---|
+| S (quick fix) | Skip | Skip | Plannotator (lightweight) | Skip | Always |
+| F-lite (feature) | Yes | Optional | Plannotator | Yes | Always |
+| F-full (complex) | Yes | Required | Plannotator | Yes | Always, multi-agent |
 
 ## Beads Best Practices
 

--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -32,11 +32,14 @@ exploration, spawn Explore subagents and reason about their findings.
 6. CREATE slice as S-tier:
    - Create slice bead via `tff-tools`
    - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
-7. SPAWN domain agent (working in `.tff/worktrees/<slice-id>/`) with: root cause description, fix strategy, implicated files
-8. VERIFY: spawn tff-product-lead for sanity check
-9. SHIP: fresh reviewer enforcement, code-only review (no spec review — no SPEC.md), create slice PR
-   **Show PR URL to user**
-10. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
+7. PLAN (lightweight): write fix strategy as single task in PLAN.md
+   REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+   feedback → revise ∨ approved → continue
+8. SPAWN domain agent (working in `.tff/worktrees/<slice-id>/`) with: root cause description, fix strategy, implicated files
+9. VERIFY: spawn tff-product-lead for sanity check
+10. SHIP: fresh reviewer enforcement, code-only review (no spec review — no SPEC.md), create slice PR
+    **Show PR URL to user**
+11. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
     - merged → `bd close <slice-bead-id> --reason "Slice PR merged"`
-    - needs changes → fix → push → go back to step 10
-11. NEXT: @references/next-steps.md
+    - needs changes → fix → push → go back to step 11
+12. NEXT: @references/next-steps.md

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -12,7 +12,7 @@ status = discussing
 ### 1. Load Context
 CHECK: read slice bead + notes
 CLASSIFY: `tff-tools slice:classify '<signals>'`
-tier = S → auto-transition researching, skip discuss
+tier = S → auto-transition to planning, skip discuss + research (plan approval still required via plannotator)
 
 ### 2. Interactive Design (F-lite ∧ F-full)
 LOAD @skills/interactive-design.md

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -11,7 +11,9 @@ active milestone exists
 1. CREATE slice as S-tier:
    - Create slice bead via `tff-tools`
    - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
-2. PLAN (lightweight): ask user for 1-2 sentence desc → single task in PLAN.md, skip plannotator
+2. PLAN (lightweight): ask user for 1-2 sentence desc → single task in PLAN.md
+   REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+   feedback → revise ∨ approved → continue
 3. EXECUTE: single wave, single task, spawn domain agent (working in `.tff/worktrees/<slice-id>/`), no TDD (S-tier)
 4. VERIFY: spawn tff-product-lead for quick sanity check
 5. SHIP: fresh reviewer enforcement, spec + code review (lightweight), create slice PR


### PR DESCRIPTION
## Summary
- All workflows now invoke `plannotator-annotate` for plan review, including S-tier
- `quick.md`: replaced "skip plannotator" with plannotator review step
- `debug.md`: added plan + plannotator review between slice creation and execution
- `discuss-slice.md`: S-tier shortcut updated to skip discuss+research but require plan approval
- `conventions.md`: complexity tiers table now shows Plan Review column (plannotator for all tiers)

## Root cause
S-tier workflows explicitly skipped plannotator by design. Combined with inline plan approval via AskUserQuestion, plannotator was never invoked for any of the last 5 slices.

## Test plan
- [x] quick.md has plannotator-annotate step
- [x] debug.md has plannotator-annotate step  
- [x] discuss-slice.md S-tier no longer says "skip discuss" without mentioning plan approval
- [x] conventions table shows Plan Review for all tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)