### PR TITLE
fix(S08): document bd dep add and remove bd link references

### DIFF
--- a/references/conventions.md
+++ b/references/conventions.md
@@ -106,6 +106,14 @@ Special formats:
 
 Use `bd update <id> --claim` to atomically claim a task (sets assignee + status to in_progress). Never manually set status and assignee separately.
 
+### Adding Dependencies
+
+Use `bd dep add` to create blocking dependencies between slices or tasks:
+```bash
+bd dep add <from-id> <to-id> -t blocks
+```
+This means `<from-id>` depends on (is blocked by) `<to-id>`. Do NOT use `bd link` — it does not exist.
+
 ### Finding Ready Work
 
 Use `bd ready --json` to list unblocked tasks. This respects the dependency graph — only tasks whose blockers are all resolved appear.

--- a/workflows/new-milestone.md
+++ b/workflows/new-milestone.md
@@ -8,7 +8,9 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
    - creates `tff:milestone` bead + `milestone/M0X` branch (from main)
 3. REQUIREMENTS: ask user for requirements scoped to this milestone → write `.tff/milestones/<M0X>/REQUIREMENTS.md`
 4. DEFINE SLICES: ask user to break milestone into slices (name, desc, deps)
-5. CREATE slice beads w/ dependencies
+5. CREATE slice beads:
+   - ∀ slice: `tff-tools slice:create --title "<name>"`
+   - ∀ dependency: `bd dep add <from-id> <to-id> -t blocks` (NOT `bd link` — does not exist)
 6. SUMMARY: show milestone structure + slice ordering
    - suggest `/tff:discuss`
 7. NEXT: @references/next-steps.md


### PR DESCRIPTION
## Summary
- Add "Adding Dependencies" section to conventions.md with correct `bd dep add` syntax
- Update new-milestone.md step 5 with explicit `tff-tools slice:create` and `bd dep add` commands
- Prevents agents from using non-existent `bd link` command

## Root cause
The conventions had no documentation for `bd dep add`. Agents guessed `bd link` (which was the old command removed in v0.2.0). The CHANGELOG noted the fix but conventions were never updated.

## Test plan
- [x] conventions.md has "Adding Dependencies" section with `bd dep add` example
- [x] new-milestone.md step 5 shows explicit commands
- [x] No remaining `bd link` references anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)