### PR TITLE
refactor(S01): tighten S-tier to single-file fixes, default to F-lite

### DIFF
--- a/references/conventions.md
+++ b/references/conventions.md
@@ -94,10 +94,14 @@ Special formats:
 
 ## Complexity Tiers
 
+Classification happens at end of discuss. User confirms the tier — no auto-routing.
+
+**S-tier criteria (ALL must be true):** ≤1 file affected, 0 new files, no investigation needed, no architecture impact, 0 unknowns.
+
 | Tier | Brainstormer | Research | Plan Review | TDD | Fresh Reviewer |
 |---|---|---|---|---|---|
-| S (quick fix) | Skip | Skip | Plannotator (lightweight) | Skip | Always |
-| F-lite (feature) | Yes | Optional | Plannotator | Yes | Always |
+| S (single-file fix) | Skip | Skip | Plannotator (lightweight) | Skip | Always |
+| F-lite (default) | Yes | Optional | Plannotator | Yes | Always |
 | F-full (complex) | Yes | Required | Plannotator | Yes | Always, multi-agent |
 
 ## Beads Best Practices

--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -23185,8 +23185,9 @@ var sliceTransitionCmd = async (args) => {
 var classifyComplexity = (signals) => {
   if (signals.hasExternalIntegrations) return "F-full";
   if (signals.taskCount >= 8 || signals.modulesAffected >= 4) return "F-full";
-  if (signals.taskCount >= 4 || signals.modulesAffected >= 2 || signals.estimatedFilesAffected >= 6 || signals.unknownsSurfaced >= 2) return "F-lite";
-  return "S";
+  const isS = signals.estimatedFilesAffected <= 1 && signals.newFilesCreated === 0 && !signals.requiresInvestigation && !signals.architectureImpact && signals.unknownsSurfaced === 0;
+  if (isS) return "S";
+  return "F-lite";
 };
 
 // tools/src/cli/commands/slice-classify.cmd.ts

--- a/tools/src/application/lifecycle/classify-complexity.spec.ts
+++ b/tools/src/application/lifecycle/classify-complexity.spec.ts
@@ -1,29 +1,54 @@
 import { describe, it, expect } from 'vitest';
 import { classifyComplexity } from './classify-complexity.js';
 
+const base = {
+  taskCount: 1, estimatedFilesAffected: 1, newFilesCreated: 0,
+  modulesAffected: 1, hasExternalIntegrations: false,
+  requiresInvestigation: false, architectureImpact: false, unknownsSurfaced: 0,
+};
+
 describe('classifyComplexity', () => {
-  it('should classify as S when few tasks and single module', () => {
-    const tier = classifyComplexity({ taskCount: 2, estimatedFilesAffected: 3, modulesAffected: 1, hasExternalIntegrations: false, unknownsSurfaced: 0 });
-    expect(tier).toBe('S');
+  it('should classify as S only when single-file, no new files, no investigation, no unknowns', () => {
+    expect(classifyComplexity(base)).toBe('S');
   });
 
-  it('should classify as F-lite for moderate scope', () => {
-    const tier = classifyComplexity({ taskCount: 5, estimatedFilesAffected: 8, modulesAffected: 2, hasExternalIntegrations: false, unknownsSurfaced: 1 });
-    expect(tier).toBe('F-lite');
+  it('should classify as F-lite when multiple files affected', () => {
+    expect(classifyComplexity({ ...base, estimatedFilesAffected: 2 })).toBe('F-lite');
   });
 
-  it('should classify as F-full for complex scope', () => {
-    const tier = classifyComplexity({ taskCount: 12, estimatedFilesAffected: 20, modulesAffected: 4, hasExternalIntegrations: true, unknownsSurfaced: 3 });
-    expect(tier).toBe('F-full');
+  it('should classify as F-lite when new files are created', () => {
+    expect(classifyComplexity({ ...base, newFilesCreated: 1 })).toBe('F-lite');
   });
 
-  it('should classify as F-full when external integrations present regardless of size', () => {
-    const tier = classifyComplexity({ taskCount: 3, estimatedFilesAffected: 5, modulesAffected: 2, hasExternalIntegrations: true, unknownsSurfaced: 0 });
-    expect(tier).toBe('F-full');
+  it('should classify as F-lite when investigation is required', () => {
+    expect(classifyComplexity({ ...base, requiresInvestigation: true })).toBe('F-lite');
   });
 
-  it('should classify as F-lite when many unknowns even with few tasks', () => {
-    const tier = classifyComplexity({ taskCount: 2, estimatedFilesAffected: 3, modulesAffected: 1, hasExternalIntegrations: false, unknownsSurfaced: 3 });
-    expect(tier).toBe('F-lite');
+  it('should classify as F-lite when architecture impact exists', () => {
+    expect(classifyComplexity({ ...base, architectureImpact: true })).toBe('F-lite');
+  });
+
+  it('should classify as F-lite when unknowns are surfaced', () => {
+    expect(classifyComplexity({ ...base, unknownsSurfaced: 1 })).toBe('F-lite');
+  });
+
+  it('should classify as F-full for external integrations regardless of size', () => {
+    expect(classifyComplexity({ ...base, hasExternalIntegrations: true })).toBe('F-full');
+  });
+
+  it('should classify as F-full for large task count', () => {
+    expect(classifyComplexity({ ...base, taskCount: 8 })).toBe('F-full');
+  });
+
+  it('should classify as F-full for many modules', () => {
+    expect(classifyComplexity({ ...base, modulesAffected: 4 })).toBe('F-full');
+  });
+
+  it('should default to F-lite for moderate scope', () => {
+    expect(classifyComplexity({
+      taskCount: 5, estimatedFilesAffected: 8, newFilesCreated: 2,
+      modulesAffected: 2, hasExternalIntegrations: false,
+      requiresInvestigation: true, architectureImpact: false, unknownsSurfaced: 1,
+    })).toBe('F-lite');
   });
 });

--- a/tools/src/application/lifecycle/classify-complexity.ts
+++ b/tools/src/application/lifecycle/classify-complexity.ts
@@ -3,14 +3,29 @@ import { type ComplexityTier } from '../../domain/value-objects/complexity-tier.
 interface ComplexitySignals {
   taskCount: number;
   estimatedFilesAffected: number;
+  newFilesCreated: number;
   modulesAffected: number;
   hasExternalIntegrations: boolean;
+  requiresInvestigation: boolean;
+  architectureImpact: boolean;
   unknownsSurfaced: number;
 }
 
 export const classifyComplexity = (signals: ComplexitySignals): ComplexityTier => {
+  // F-full: external integrations, large scope, or many modules
   if (signals.hasExternalIntegrations) return 'F-full';
   if (signals.taskCount >= 8 || signals.modulesAffected >= 4) return 'F-full';
-  if (signals.taskCount >= 4 || signals.modulesAffected >= 2 || signals.estimatedFilesAffected >= 6 || signals.unknownsSurfaced >= 2) return 'F-lite';
-  return 'S';
+
+  // S-tier: ALL of these must be true — single-file, no new files, known root cause
+  const isS =
+    signals.estimatedFilesAffected <= 1 &&
+    signals.newFilesCreated === 0 &&
+    !signals.requiresInvestigation &&
+    !signals.architectureImpact &&
+    signals.unknownsSurfaced === 0;
+
+  if (isS) return 'S';
+
+  // Default: F-lite (everything that isn't clearly S or F-full)
+  return 'F-lite';
 };


### PR DESCRIPTION
## Summary
- S-tier now requires ALL of: ≤1 file affected, 0 new files, no investigation, no architecture impact, 0 unknowns
- Added 3 new signals: `newFilesCreated`, `requiresInvestigation`, `architectureImpact`
- Default changed from S to F-lite — classifier no longer defaults to the lightest tier
- Conventions table updated with new S-tier criteria and "user confirms" note

## Test plan
- [x] 590 tests pass (10 new classifier tests)
- [x] Build succeeds
- [x] S-tier test: only passes with all strict criteria met
- [x] Any deviation (2+ files, new files, investigation needed) → F-lite

🤖 Generated with [Claude Code](https://claude.com/claude-code)