### PR TITLE
refactor(S02): move classification to end of discuss, user confirms

### DIFF
--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -11,17 +11,15 @@ status = discussing
 
 ### 1. Load Context
 CHECK: read slice bead + notes
-CLASSIFY: `tff-tools slice:classify '<signals>'`
-tier = S → auto-transition to planning, skip discuss + research (plan approval still required via plannotator)
 
-### 2. Interactive Design (F-lite ∧ F-full)
+### 2. Interactive Design
 LOAD @skills/interactive-design.md
 
 **Phase 1 — Scope** (2-4 questions via AskUserQuestion)
 - What problem does this solve? Who benefits?
 - What constraints? (time, tech, dependencies)
 - What does success look like?
-- (F-full) What are the known unknowns?
+- What are the known unknowns?
 
 **Phase 2 — Approach** (1 message)
 - Propose 2-3 approaches w/ trade-offs
@@ -37,7 +35,7 @@ LOAD @skills/interactive-design.md
 WRITE `.tff/milestones/<milestone>/slices/<id>/SPEC.md` w/ validated design
 UPDATE bead design field: `beadStore.updateDesign(id, spec_content)`
 
-### 4. Challenge Spec (F-full only)
+### 4. Challenge Spec (F-full only — determined in step 8)
 SPAWN tff-brainstormer: {spec_content}
 REVISE → critical issues → loop Phase 3 (max 2) ∨ escalate
 APPROVE → note concerns in spec, proceed
@@ -53,8 +51,24 @@ Issues → fix, re-dispatch (max 3)
 ### 7. User Gate
 AskUserQuestion: "Spec at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
 
-### 8. Transition
-`tff-tools slice:transition <id> researching`
+### 8. Classify Complexity
+Based on what was learned during discuss, build `ComplexitySignals`:
+- `estimatedFilesAffected`, `newFilesCreated`, `modulesAffected`
+- `requiresInvestigation`, `architectureImpact`, `hasExternalIntegrations`
+- `taskCount`, `unknownsSurfaced`
+
+RUN: `tff-tools slice:classify '<signals-json>'`
+
+PRESENT result to user via AskUserQuestion:
+- "Based on scope: **<tier>** (S / F-lite / F-full). Confirm or override?"
+- Options: S (single-file fix), F-lite (standard), F-full (complex)
+
+User confirms → record tier on bead.
+If F-full confirmed → run step 4 (Challenge Spec) now if not already done.
+
+### 9. Transition
+tier = S → `tff-tools slice:transition <id> planning` (skip research)
+tier = F-lite ∨ F-full → `tff-tools slice:transition <id> researching`
 CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
 
 ## Auto-Transition
@@ -64,4 +78,4 @@ After completing all steps above:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask the user
    - Human gates (plan approval, spec approval, completion): pause and ask
 3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
-4. Log: `[tff] <slice-id>: discussing → researching`
+4. Log: `[tff] <slice-id>: discussing → researching|planning`


### PR DESCRIPTION
## Summary
- Remove upfront auto-classification from step 1 (was `CLASSIFY → S-tier → skip discuss`)
- All slices now go through the full discuss pipeline (scope, design, spec, review)
- New step 8: classify based on real signals gathered during discussion
- User confirms or overrides tier via AskUserQuestion (S / F-lite / F-full)
- S-tier skips research only; F-full triggers brainstormer if not already done

## Root cause
Classification at step 1 used vague signal strings → always defaulted to S-tier → skipped the entire discuss phase.

## Test plan
- [x] discuss-slice.md restructured: classify moved from step 1 to step 8
- [x] No auto-routing — user always confirms tier
- [x] F-full brainstormer runs conditionally after classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)