### PR TITLE
refactor(S03): unify pipeline across tiers, remove plannotator from code review

### DIFF
--- a/references/conventions.md
+++ b/references/conventions.md
@@ -98,11 +98,13 @@ Classification happens at end of discuss. User confirms the tier — no auto-rou
 
 **S-tier criteria (ALL must be true):** ≤1 file affected, 0 new files, no investigation needed, no architecture impact, 0 unknowns.
 
-| Tier | Brainstormer | Research | Plan Review | TDD | Fresh Reviewer |
+All tiers follow the same pipeline. Tiers control **depth**, not which steps run.
+
+| Tier | Discuss | Research | Plan Review | Execute | Code Review |
 |---|---|---|---|---|---|
-| S (single-file fix) | Skip | Skip | Plannotator (lightweight) | Skip | Always |
-| F-lite (default) | Yes | Optional | Plannotator | Yes | Always |
-| F-full (complex) | Yes | Required | Plannotator | Yes | Always, multi-agent |
+| S (single-file fix) | Lightweight | Skip | Plannotator | No TDD | Agent-only |
+| F-lite (default) | Full | Optional | Plannotator | TDD | Agent-only |
+| F-full (complex) | Full + brainstormer | Required | Plannotator | TDD | Agent-only, multi-reviewer |
 
 ## Beads Best Practices
 

--- a/skills/plannotator-usage.md
+++ b/skills/plannotator-usage.md
@@ -1,6 +1,6 @@
 ---
 name: Plannotator Usage
-description: How to invoke plannotator for plan, verification, and code review
+description: How to invoke plannotator for plan approval and verification review
 token-budget: background
 ---
 
@@ -8,22 +8,21 @@ token-budget: background
 
 ## When to Use
 
-∀ workflows needing plannotator (plan review, verification review, code review).
+∀ workflows needing plannotator (plan approval, verification review).
 
 ## Integration Points
 
 | Point | Workflow | Command | Input |
 |---|---|---|---|
-| Plan review | /tff:plan | invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md` | PLAN.md |
+| Plan review | /tff:plan, /tff:quick, /tff:debug | invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md` | PLAN.md |
 | Verification | /tff:verify | invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/VERIFICATION.md` | VERIFICATION.md |
-| Code review | /tff:ship | invoke Skill `plannotator-review` | git diff |
 
 ∀ points: opens interactive UI → user annotates → feedback returns to stdout → agent processes
 
 ## Command Frontmatter
 
 ```yaml
-allowed-tools: Skill(plannotator-annotate, plannotator-review)
+allowed-tools: Skill(plannotator-annotate)
 ```
 
 ## Loop

--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -12,15 +12,14 @@ milestone audit passed
    - if not merged → warn user, block milestone completion
 2. PR: `gh pr create` milestone/<milestone> → main — **ALWAYS show PR URL**
 3. SPAWN tff-security-auditor: milestone-level review
-4. REVIEW: invoke Skill `plannotator-review` for interactive milestone review
-5. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
+4. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
 
 **tff NEVER merges — only creates PR.**
 
-6. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
-   - merged → continue to step 7
-   - needs changes → fix → push → go back to step 6
-7. CLOSE MILESTONE:
+5. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
+   - merged → continue to step 6
+   - needs changes → fix → push → go back to step 5
+6. CLOSE MILESTONE:
    - `bd close <milestone-bead-id> --reason "Milestone merged to main"`
    - update STATE.md: `tff-tools sync:state`
    - suggest `/tff:new-milestone`

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -16,20 +16,19 @@ status = reviewing
    REQUEST_CHANGES → SPAWN tff-fixer → loop until APPROVE
 4. Stage 3 (security) — SPAWN tff-security-auditor: {diff, @references/security-baseline.md}
    critical ∨ high → blocks PR → SPAWN tff-fixer → re-audit
-5. USER REVIEW: invoke Skill `plannotator-review` for interactive code review of the diff
-6. PR: `gh pr create` — `slice/<slice-id>` → `milestone/<milestone>`
+5. PR: `gh pr create` — `slice/<slice-id>` → `milestone/<milestone>`
    **Show PR URL to user**
 
 **tff NEVER merges — only creates PR.**
 
-7. MERGE GATE: AskUserQuestion with options:
-   - **"PR merged"** → continue to step 8
-   - **"PR needs changes"** → SPAWN tff-fixer with requested changes → push fixes → go back to step 7
-8. CLOSE:
+6. MERGE GATE: AskUserQuestion with options:
+   - **"PR merged"** → continue to step 7
+   - **"PR needs changes"** → SPAWN tff-fixer with requested changes → push fixes → go back to step 6
+7. CLOSE:
    - `tff-tools worktree:delete <slice-id>` (if worktree exists)
    - `bd close <slice-bead-id> --reason "Slice PR merged"`
    - Log: `[tff] <slice-id>: reviewing → closed`
-9. NEXT: @references/next-steps.md
+8. NEXT: @references/next-steps.md
 
 ## Auto-Transition
 After completing all steps above:


### PR DESCRIPTION
## Summary
- Conventions table: tiers control depth, not which steps run. No step is ever skipped.
- Remove `plannotator-review` from ship-slice (was step 5) and complete-milestone (was step 4)
- Code review is now agent-only (spec-reviewer + code-reviewer + security-auditor)
- Plannotator stays for plan approval (plan-slice, quick, debug) and verification review
- plannotator-usage.md updated: removed code review row, removed `plannotator-review` from allowed tools

## Test plan
- [x] ship-slice.md has no plannotator reference
- [x] complete-milestone.md has no plannotator reference
- [x] plannotator-usage.md lists only plan + verification points
- [x] conventions table shows unified pipeline with depth differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)