### PR TITLE
refactor(S04): make quick/debug entry points into standard pipeline

### DIFF
--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -2,7 +2,7 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-Diagnose first (no slice), fix second (slice + worktree).
+Diagnose first (no slice), fix second (converges on standard pipeline).
 
 ## Prerequisites
 active milestone exists — if ∄ milestone:
@@ -27,19 +27,17 @@ exploration, spawn Explore subagents and reason about their findings.
    - If root cause is external (dependency, system, infra) → exit with diagnostic report,
      suggest workaround options (patch, pin version, upstream issue), do not enter Phase 2
 
-## Phase 2: Fix (slice + worktree, like quick)
+## Phase 2: Fix (converges on standard pipeline)
 
-6. CREATE slice as S-tier:
+6. CREATE slice:
    - Create slice bead via `tff-tools`
    - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
-7. PLAN (lightweight): write fix strategy as single task in PLAN.md
-   REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
-   feedback → revise ∨ approved → continue
-8. SPAWN domain agent (working in `.tff/worktrees/<slice-id>/`) with: root cause description, fix strategy, implicated files
-9. VERIFY: spawn tff-product-lead for sanity check
-10. SHIP: fresh reviewer enforcement, code-only review (no spec review — no SPEC.md), create slice PR
-    **Show PR URL to user**
-11. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
-    - merged → `bd close <slice-bead-id> --reason "Slice PR merged"`
-    - needs changes → fix → push → go back to step 11
-12. NEXT: @references/next-steps.md
+7. CLASSIFY: AskUserQuestion → user picks tier (S / F-lite / F-full)
+   - Default suggestion based on diagnosis: single-file root cause → S, multi-file → F-lite
+8. PLAN: write fix strategy + implicated files in PLAN.md
+   - Write to `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+9. HAND OFF to standard pipeline:
+   - invoke plan-slice workflow from step 8 (Plannotator Review) onward
+   - then: execute-slice → verify-slice → ship-slice (standard workflows)
+
+Debug Phase 2 is an entry point, not a parallel pipeline.

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -1,24 +1,22 @@
-# Quick (S-tier Shortcut)
+# Quick (Entry-Point Shortcut)
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-Skip discuss + research → straight to plan, execute, ship.
+Skips discuss + research. Creates slice, writes lightweight plan, then hands off to standard pipeline.
 
 ## Prerequisites
 active milestone exists
 
 ## Steps
-1. CREATE slice as S-tier:
+1. CREATE slice:
    - Create slice bead via `tff-tools`
    - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
-2. PLAN (lightweight): ask user for 1-2 sentence desc → single task in PLAN.md
-   REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
-   feedback → revise ∨ approved → continue
-3. EXECUTE: single wave, single task, spawn domain agent (working in `.tff/worktrees/<slice-id>/`), no TDD (S-tier)
-4. VERIFY: spawn tff-product-lead for quick sanity check
-5. SHIP: fresh reviewer enforcement, spec + code review (lightweight), create slice PR
-   **Show PR URL to user**
-6. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
-   - merged → `bd close <slice-bead-id> --reason "Slice PR merged"`
-   - needs changes → fix → push → go back to step 6
-7. NEXT: @references/next-steps.md
+2. CLASSIFY: AskUserQuestion → user picks tier (S / F-lite / F-full)
+   - Default suggestion: S (if user described a single-file fix) or F-lite
+3. PLAN (lightweight): ask user for 1-2 sentence desc → single task in PLAN.md
+   - Write to `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+4. HAND OFF to standard pipeline:
+   - invoke plan-slice workflow from step 8 (Plannotator Review) onward
+   - then: execute-slice → verify-slice → ship-slice (standard workflows)
+
+Quick is an entry point, not a parallel pipeline.


### PR DESCRIPTION
## Summary
- Quick and debug workflows no longer duplicate plan/execute/verify/ship steps
- Both now: create slice → classify (user confirms tier) → write lightweight plan → hand off to standard pipeline
- Standard pipeline takes over from plan-slice step 8 (plannotator review) onward
- Removes ~30 lines of duplicated workflow logic from each file

## Test plan
- [x] quick.md hands off to plan-slice → execute-slice → verify-slice → ship-slice
- [x] debug.md Phase 2 hands off to same standard pipeline
- [x] Both include user-confirmed tier classification
- [x] No more inline verify/ship steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)