### PR TITLE
fix(S05): use --all flag to include closed beads in numbering scans

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -14506,6 +14506,7 @@ var init_bd_cli_adapter = __esm({
       }
       async list(filter) {
         const args = ["list", "--json"];
+        if (filter.includeAll) args.push("--all");
         if (filter.label) args.push("-l", filter.label);
         if (filter.parentId) args.push("--parent", filter.parentId);
         if (filter.status) args.push("-s", filter.status);
@@ -22867,7 +22868,7 @@ var milestoneCreateCmd = async (args) => {
     return JSON.stringify({ ok: false, error: { code: "NOT_FOUND", message: "No tff project found. Run /tff:new first." } });
   }
   const projectBeadId = projectResult.data[0].id;
-  const milestonesResult = await beadStore.list({ label: "tff:milestone" });
+  const milestonesResult = await beadStore.list({ label: "tff:milestone", includeAll: true });
   let maxMilestoneNumber = 0;
   if (isOk(milestonesResult)) {
     for (const m of milestonesResult.data) {
@@ -23065,8 +23066,9 @@ var sliceCreateCmd = async (args) => {
   const openMilestones = milestonesResult.data.filter((m) => m.status !== "closed");
   const milestone = openMilestones.length > 0 ? openMilestones[0] : milestonesResult.data[0];
   const milestoneBeadId = milestone.id;
-  const milestoneNumber = milestonesResult.data.indexOf(milestone) + 1;
-  const slicesResult = await beadStore.list({ label: "tff:slice", parentId: milestoneBeadId });
+  const milestoneMatch = milestone.design?.match(/M(\d+)/);
+  const milestoneNumber = milestoneMatch ? parseInt(milestoneMatch[1], 10) : 1;
+  const slicesResult = await beadStore.list({ label: "tff:slice", parentId: milestoneBeadId, includeAll: true });
   let maxSliceNumber = 0;
   if (isOk(slicesResult)) {
     for (const s of slicesResult.data) {

--- a/tools/src/cli/commands/milestone-create.cmd.ts
+++ b/tools/src/cli/commands/milestone-create.cmd.ts
@@ -23,7 +23,7 @@ export const milestoneCreateCmd = async (args: string[]): Promise<string> => {
   const projectBeadId = projectResult.data[0].id;
 
   // Auto-number: find highest existing milestone number and increment
-  const milestonesResult = await beadStore.list({ label: 'tff:milestone' });
+  const milestonesResult = await beadStore.list({ label: 'tff:milestone', includeAll: true });
   let maxMilestoneNumber = 0;
   if (isOk(milestonesResult)) {
     for (const m of milestonesResult.data) {

--- a/tools/src/cli/commands/slice-create.cmd.ts
+++ b/tools/src/cli/commands/slice-create.cmd.ts
@@ -38,11 +38,12 @@ export const sliceCreateCmd = async (args: string[]): Promise<string> => {
   const milestone = openMilestones.length > 0 ? openMilestones[0] : milestonesResult.data[0];
   const milestoneBeadId = milestone.id;
 
-  // Detect milestone number from title (e.g., "Milestone M02: ..." → 2) or count
-  const milestoneNumber = milestonesResult.data.indexOf(milestone) + 1;
+  // Detect milestone number from design field (e.g., "Milestone M02: ..." → 2)
+  const milestoneMatch = milestone.design?.match(/M(\d+)/);
+  const milestoneNumber = milestoneMatch ? parseInt(milestoneMatch[1], 10) : 1;
 
   // Auto-number slice: find highest existing slice number and increment from there
-  const slicesResult = await beadStore.list({ label: 'tff:slice', parentId: milestoneBeadId });
+  const slicesResult = await beadStore.list({ label: 'tff:slice', parentId: milestoneBeadId, includeAll: true });
   let maxSliceNumber = 0;
   if (isOk(slicesResult)) {
     for (const s of slicesResult.data) {

--- a/tools/src/domain/ports/bead-store.port.ts
+++ b/tools/src/domain/ports/bead-store.port.ts
@@ -34,6 +34,7 @@ export interface BeadStore {
     label?: BeadLabel;
     parentId?: string;
     status?: string;
+    includeAll?: boolean;
   }): Promise<Result<BeadData[], DomainError>>;
 
   /** List unblocked tasks ready for work (bd ready) */

--- a/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
@@ -175,8 +175,10 @@ export class BdCliAdapter implements BeadStore {
     label?: BeadLabel;
     parentId?: string;
     status?: string;
+    includeAll?: boolean;
   }): Promise<Result<BeadData[], DomainError>> {
     const args = ['list', '--json'];
+    if (filter.includeAll) args.push('--all');
     if (filter.label) args.push('-l', filter.label);
     if (filter.parentId) args.push('--parent', filter.parentId);
     if (filter.status) args.push('-s', filter.status);

--- a/tools/src/infrastructure/adapters/beads/markdown-bead.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/markdown-bead.adapter.ts
@@ -57,6 +57,7 @@ export class MarkdownBeadAdapter implements BeadStore {
     label?: BeadLabel;
     parentId?: string;
     status?: string;
+    includeAll?: boolean;
   }): Promise<Result<BeadData[], DomainError>> {
     const allResult = await this.readAll();
     if (!isOk(allResult)) return allResult;

--- a/tools/src/infrastructure/testing/in-memory-bead-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-bead-store.ts
@@ -45,6 +45,7 @@ export class InMemoryBeadStore implements BeadStore {
     label?: BeadLabel;
     parentId?: string;
     status?: string;
+    includeAll?: boolean;
   }): Promise<Result<BeadData[], DomainError>> {
     let results = [...this.beads.values()];
     if (filter.label) results = results.filter((b) => b.label === filter.label);


### PR DESCRIPTION
## Summary
- Add `includeAll?: boolean` to `BeadStore.list()` port — passes `--all` to `bd list`
- `milestone:create` and `slice:create` now use `includeAll: true` when scanning for max numbers
- Fixes duplicate M01/S01 creation after closing previous milestones/slices
- Also fixed `slice-create` milestone number derivation: parse design field instead of `indexOf`

## Root cause
`bd list` excludes closed beads by default. After closing M01 and M02, max scan returned 0 → new milestone got number 1 → duplicate `milestone/M01` branch.

## Test plan
- [x] 590 tests pass
- [x] Build succeeds
- [x] All 3 adapters (bd-cli, markdown, in-memory) accept `includeAll` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)