### PR TITLE
feat(S08): expand CI to all PRs, add lint step, fix test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'milestone/*']
   pull_request:
-    branches: [main]
 
 jobs:
   test:
@@ -23,11 +22,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Type check
         run: npm run typecheck
 
       - name: Run tests
-        run: cd tools && npx vitest run
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Type check
         run: npm run typecheck
 
       - name: Run tests
-        run: cd tools && npx vitest run
+        run: npm test
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- CI triggers on `milestone/*` branches and ALL pull requests (was `main` only)
- Added biome lint step before typecheck in both CI and release workflows
- Fixed test command: `cd tools && npx vitest run` → `npm test`

## Test plan
- [x] ci.yml triggers on push to main + milestone/*, and all PRs
- [x] Lint step runs `npm run lint` (biome)
- [x] release.yml has same lint step

🤖 Generated with [Claude Code](https://claude.com/claude-code)