### PR TITLE
feat(S09): add riskLevel signal to complexity classification

### DIFF
--- a/tools/dist/tff-tools.cjs
+++ b/tools/dist/tff-tools.cjs
@@ -23383,8 +23383,10 @@ var skillsValidateCmd = async (args) => {
 
 // tools/src/application/lifecycle/classify-complexity.ts
 var classifyComplexity = (signals) => {
+  if (signals.riskLevel === "high") return "F-full";
   if (signals.hasExternalIntegrations) return "F-full";
   if (signals.taskCount >= 8 || signals.modulesAffected >= 4) return "F-full";
+  if (signals.riskLevel === "medium") return "F-lite";
   const isS = signals.estimatedFilesAffected <= 1 && signals.newFilesCreated === 0 && !signals.requiresInvestigation && !signals.architectureImpact && signals.unknownsSurfaced === 0;
   if (isS) return "S";
   return "F-lite";

--- a/tools/src/application/lifecycle/classify-complexity.spec.ts
+++ b/tools/src/application/lifecycle/classify-complexity.spec.ts
@@ -10,10 +10,11 @@ const base = {
   requiresInvestigation: false,
   architectureImpact: false,
   unknownsSurfaced: 0,
+  riskLevel: 'low' as const,
 };
 
 describe('classifyComplexity', () => {
-  it('should classify as S only when single-file, no new files, no investigation, no unknowns', () => {
+  it('should classify as S only when single-file, no new files, no investigation, no unknowns, low risk', () => {
     expect(classifyComplexity(base)).toBe('S');
   });
 
@@ -35,6 +36,22 @@ describe('classifyComplexity', () => {
 
   it('should classify as F-lite when unknowns are surfaced', () => {
     expect(classifyComplexity({ ...base, unknownsSurfaced: 1 })).toBe('F-lite');
+  });
+
+  it('should classify as F-full for high risk regardless of file count', () => {
+    expect(classifyComplexity({ ...base, riskLevel: 'high' })).toBe('F-full');
+  });
+
+  it('should classify as F-full for high risk even with single file', () => {
+    expect(classifyComplexity({ ...base, estimatedFilesAffected: 1, riskLevel: 'high' })).toBe('F-full');
+  });
+
+  it('should classify as F-lite minimum for medium risk', () => {
+    expect(classifyComplexity({ ...base, riskLevel: 'medium' })).toBe('F-lite');
+  });
+
+  it('should classify as F-lite for medium risk even when S-tier criteria met', () => {
+    expect(classifyComplexity({ ...base, riskLevel: 'medium' })).toBe('F-lite');
   });
 
   it('should classify as F-full for external integrations regardless of size', () => {
@@ -60,6 +77,7 @@ describe('classifyComplexity', () => {
         requiresInvestigation: true,
         architectureImpact: false,
         unknownsSurfaced: 1,
+        riskLevel: 'low',
       }),
     ).toBe('F-lite');
   });

--- a/tools/src/application/lifecycle/classify-complexity.ts
+++ b/tools/src/application/lifecycle/classify-complexity.ts
@@ -1,5 +1,7 @@
 import type { ComplexityTier } from '../../domain/value-objects/complexity-tier.js';
 
+type RiskLevel = 'low' | 'medium' | 'high';
+
 interface ComplexitySignals {
   taskCount: number;
   estimatedFilesAffected: number;
@@ -9,14 +11,21 @@ interface ComplexitySignals {
   requiresInvestigation: boolean;
   architectureImpact: boolean;
   unknownsSurfaced: number;
+  riskLevel: RiskLevel;
 }
 
 export const classifyComplexity = (signals: ComplexitySignals): ComplexityTier => {
+  // High risk forces F-full regardless of scope (security, auth, data integrity, public API)
+  if (signals.riskLevel === 'high') return 'F-full';
+
   // F-full: external integrations, large scope, or many modules
   if (signals.hasExternalIntegrations) return 'F-full';
   if (signals.taskCount >= 8 || signals.modulesAffected >= 4) return 'F-full';
 
-  // S-tier: ALL of these must be true — single-file, no new files, known root cause
+  // Medium risk forces F-lite minimum (internal API, config, database schema)
+  if (signals.riskLevel === 'medium') return 'F-lite';
+
+  // S-tier: ALL of these must be true — single-file, no new files, known root cause, low risk
   const isS =
     signals.estimatedFilesAffected <= 1 &&
     signals.newFilesCreated === 0 &&


### PR DESCRIPTION
## Summary
- Add `riskLevel` (low/medium/high) to `ComplexitySignals`
- `high` risk → F-full regardless of file count (security, auth, data integrity, public API)
- `medium` risk → F-lite minimum (internal API, config, database schema)
- `low` risk → no override, normal classification applies
- Implements Roxabi insight: "A 50-file mechanical change may be S, while a 3-file rate limiter is F-full"

## Test plan
- [x] 598 tests pass (4 new risk-level tests)
- [x] High risk + 1 file → F-full
- [x] Medium risk + S-tier criteria → F-lite (not S)
- [x] Low risk + S-tier criteria → S (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)