### PR TITLE
feat(S10/S11): cleanup automation + auto-rebase milestone on slice close

### DIFF
--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -19,8 +19,11 @@ milestone audit passed
 5. MERGE GATE: AskUserQuestion → "PR merged" or "PR needs changes"
    - merged → continue to step 6
    - needs changes → fix → push → go back to step 5
-6. CLOSE MILESTONE:
+6. CLOSE MILESTONE + CLEANUP:
    - `bd close <milestone-bead-id> --reason "Milestone merged to main"`
    - update STATE.md: `tff-tools sync:state`
+   - delete stale slice branches: `∀ slice branch → git push origin --delete slice/<id>`
+   - delete milestone branch: `git push origin --delete milestone/<milestone>`
+   - delete local branches: `git branch -d milestone/<milestone>`
    - suggest `/tff:new-milestone`
-8. NEXT: @references/next-steps.md
+7. NEXT: @references/next-steps.md

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -24,9 +24,12 @@ status = reviewing
 6. MERGE GATE: AskUserQuestion with options:
    - **"PR merged"** → continue to step 7
    - **"PR needs changes"** → SPAWN tff-fixer with requested changes → push fixes → go back to step 6
-7. CLOSE:
+7. CLOSE + CLEANUP:
    - `tff-tools worktree:delete <slice-id>` (if worktree exists)
    - `bd close <slice-bead-id> --reason "Slice PR merged"`
+   - `git push origin --delete slice/<slice-id>` (delete remote slice branch)
+   - `git branch -d slice/<slice-id>` (delete local slice branch, if exists)
+   - `git fetch origin milestone/<milestone> && git rebase origin/milestone/<milestone>` (keep milestone branch up to date)
    - Log: `[tff] <slice-id>: reviewing → closed`
 8. NEXT: @references/next-steps.md
 


### PR DESCRIPTION
## Summary
- **ship-slice close step**: delete remote+local slice branch, rebase milestone branch after each slice merge
- **complete-milestone close step**: delete all stale slice branches + milestone branch after merge to main
- Prevents branch accumulation (had ~15 stale branches after M01)

## Test plan
- [x] ship-slice.md step 7 includes branch cleanup + milestone rebase
- [x] complete-milestone.md step 6 includes full branch cleanup
- [x] No workflow references stale branches after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)