### PR TITLE
milestone/M04: Critical Robustness Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+.beads/
+.worktrees/

--- a/tools/src/application/checkpoint/checkpoint.spec.ts
+++ b/tools/src/application/checkpoint/checkpoint.spec.ts
@@ -50,4 +50,58 @@ describe('checkpoint', () => {
     const result = await saveCheckpoint(checkpointData, { artifactStore });
     expect(isOk(result)).toBe(false);
   });
+
+  describe('incremental checkpoint', () => {
+    it('should preserve accumulated completedTasks across saves', async () => {
+      const initial = {
+        sliceId: 'M01-S01',
+        baseCommit: 'abc1234',
+        currentWave: 1,
+        completedWaves: [0],
+        completedTasks: ['T01', 'T02'],
+        executorLog: [
+          { taskRef: 'T01', agent: 'dev' },
+          { taskRef: 'T02', agent: 'dev' },
+        ],
+      };
+      await saveCheckpoint(initial, { artifactStore });
+
+      const updated = {
+        ...initial,
+        completedTasks: ['T01', 'T02', 'T03'],
+        executorLog: [...initial.executorLog, { taskRef: 'T03', agent: 'dev' }],
+      };
+      await saveCheckpoint(updated, { artifactStore });
+
+      const result = await loadCheckpoint('M01-S01', { artifactStore });
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.data.completedTasks).toEqual(['T01', 'T02', 'T03']);
+      }
+    });
+
+    it('should load partially completed wave for resume', async () => {
+      const data = {
+        sliceId: 'M01-S01',
+        baseCommit: 'abc1234',
+        currentWave: 1,
+        completedWaves: [0],
+        completedTasks: ['T01', 'T02', 'T03'],
+        executorLog: [
+          { taskRef: 'T01', agent: 'dev' },
+          { taskRef: 'T02', agent: 'dev' },
+          { taskRef: 'T03', agent: 'dev' },
+        ],
+      };
+      await saveCheckpoint(data, { artifactStore });
+
+      const result = await loadCheckpoint('M01-S01', { artifactStore });
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.data.completedWaves).toEqual([0]);
+        expect(result.data.currentWave).toBe(1);
+        expect(result.data.completedTasks).toContain('T03');
+      }
+    });
+  });
 });

--- a/tools/src/application/checkpoint/checkpoint.spec.ts
+++ b/tools/src/application/checkpoint/checkpoint.spec.ts
@@ -44,4 +44,10 @@ describe('checkpoint', () => {
     const result = await loadCheckpoint('M01-S99', { artifactStore });
     expect(isErr(result)).toBe(true);
   });
+
+  it('should return Err when artifact write fails', async () => {
+    artifactStore.simulateWriteFailure('.tff/milestones/M01/slices/M01-S01/CHECKPOINT.md');
+    const result = await saveCheckpoint(checkpointData, { artifactStore });
+    expect(isOk(result)).toBe(false);
+  });
 });

--- a/tools/src/application/checkpoint/save-checkpoint.ts
+++ b/tools/src/application/checkpoint/save-checkpoint.ts
@@ -1,6 +1,6 @@
 import type { DomainError } from '../../domain/errors/domain-error.js';
 import type { ArtifactStore } from '../../domain/ports/artifact-store.port.js';
-import { Ok, type Result } from '../../domain/result.js';
+import { isOk, Ok, type Result } from '../../domain/result.js';
 
 export interface CheckpointData {
   sliceId: string;
@@ -31,8 +31,14 @@ export const saveCheckpoint = async (
     '',
   ];
   const milestoneId = data.sliceId.match(/^(M\d+)/)?.[1] ?? 'M01';
-  const path = `.tff/milestones/${milestoneId}/slices/${data.sliceId}/CHECKPOINT.md`;
-  await deps.artifactStore.mkdir(`.tff/milestones/${milestoneId}/slices/${data.sliceId}`);
-  await deps.artifactStore.write(path, lines.join('\n'));
+  const dir = `.tff/milestones/${milestoneId}/slices/${data.sliceId}`;
+  const path = `${dir}/CHECKPOINT.md`;
+
+  const mkdirResult = await deps.artifactStore.mkdir(dir);
+  if (!isOk(mkdirResult)) return mkdirResult;
+
+  const writeResult = await deps.artifactStore.write(path, lines.join('\n'));
+  if (!isOk(writeResult)) return writeResult;
+
   return Ok(undefined);
 };

--- a/tools/src/application/claims/check-stale-claims.spec.ts
+++ b/tools/src/application/claims/check-stale-claims.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { isOk } from '../../domain/result.js';
 import { InMemoryBeadStore } from '../../infrastructure/testing/in-memory-bead-store.js';
+import { checkStaleClaims } from './check-stale-claims.js';
 
 describe('InMemoryBeadStore — claim + stale detection', () => {
   let store: InMemoryBeadStore;
@@ -43,6 +44,26 @@ describe('InMemoryBeadStore — claim + stale detection', () => {
     expect(isOk(result)).toBe(true);
     if (isOk(result)) {
       expect(result.data).toHaveLength(0);
+    }
+  });
+});
+
+describe('checkStaleClaims use case', () => {
+  let store: InMemoryBeadStore;
+  beforeEach(() => {
+    store = new InMemoryBeadStore();
+  });
+
+  it('should return stale claims with given TTL', async () => {
+    const thirtyOneMinutesAgo = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    store.seed([
+      { id: 't1', label: 'tff:task', title: 'Task 1', status: 'in_progress', claimedAt: thirtyOneMinutesAgo },
+    ]);
+    const result = await checkStaleClaims({ ttlMinutes: 30 }, { beadStore: store });
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data.staleClaims).toHaveLength(1);
+      expect(result.data.staleClaims[0].id).toBe('t1');
     }
   });
 });

--- a/tools/src/application/claims/check-stale-claims.spec.ts
+++ b/tools/src/application/claims/check-stale-claims.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { isOk } from '../../domain/result.js';
+import { InMemoryBeadStore } from '../../infrastructure/testing/in-memory-bead-store.js';
+
+describe('InMemoryBeadStore — claim + stale detection', () => {
+  let store: InMemoryBeadStore;
+
+  beforeEach(() => {
+    store = new InMemoryBeadStore();
+  });
+
+  it('should record claimedAt timestamp on claim', async () => {
+    store.seed([{ id: 't1', label: 'tff:task', title: 'Task 1', status: 'open' }]);
+    const before = new Date().toISOString();
+    await store.claim('t1');
+    const result = await store.get('t1');
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data.status).toBe('in_progress');
+      expect(result.data.claimedAt).toBeDefined();
+      expect(result.data.claimedAt! >= before).toBe(true);
+    }
+  });
+
+  it('should list stale claims exceeding TTL', async () => {
+    const thirtyOneMinutesAgo = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    store.seed([
+      { id: 't1', label: 'tff:task', title: 'Task 1', status: 'in_progress', claimedAt: thirtyOneMinutesAgo },
+      { id: 't2', label: 'tff:task', title: 'Task 2', status: 'in_progress', claimedAt: new Date().toISOString() },
+      { id: 't3', label: 'tff:task', title: 'Task 3', status: 'open' },
+    ]);
+    const result = await store.listStaleClaims(30);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('t1');
+    }
+  });
+
+  it('should return empty array when no stale claims', async () => {
+    store.seed([{ id: 't1', label: 'tff:task', title: 'Task 1', status: 'open' }]);
+    const result = await store.listStaleClaims(30);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data).toHaveLength(0);
+    }
+  });
+});

--- a/tools/src/application/claims/check-stale-claims.ts
+++ b/tools/src/application/claims/check-stale-claims.ts
@@ -1,0 +1,25 @@
+import type { DomainError } from '../../domain/errors/domain-error.js';
+import type { BeadData, BeadStore } from '../../domain/ports/bead-store.port.js';
+import { Ok, type Result } from '../../domain/result.js';
+
+interface CheckStaleClaimsInput {
+  ttlMinutes?: number;
+}
+interface CheckStaleClaimsDeps {
+  beadStore: BeadStore;
+}
+interface CheckStaleClaimsOutput {
+  staleClaims: BeadData[];
+}
+
+const DEFAULT_TTL_MINUTES = 30;
+
+export const checkStaleClaims = async (
+  input: CheckStaleClaimsInput,
+  deps: CheckStaleClaimsDeps,
+): Promise<Result<CheckStaleClaimsOutput, DomainError>> => {
+  const ttl = input.ttlMinutes ?? DEFAULT_TTL_MINUTES;
+  const result = await deps.beadStore.listStaleClaims(ttl);
+  if (!result.ok) return result;
+  return Ok({ staleClaims: result.data });
+};

--- a/tools/src/application/sync/reconcile-state.spec.ts
+++ b/tools/src/application/sync/reconcile-state.spec.ts
@@ -102,6 +102,39 @@ describe('reconcileState', () => {
     }
   });
 
+  it('should return Err on artifact write failure', async () => {
+    beadStore.seed([
+      { id: 'ms1', label: 'tff:milestone', title: 'MVP', status: 'open' },
+      { id: 's1', label: 'tff:slice', title: 'FailSlice', status: 'open', design: 'design', parentId: 'ms1' },
+    ]);
+    artifactStore.simulateWriteFailure('.tff/milestones/M01/slices/FailSlice/PLAN.md');
+    const result = await reconcileState(
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
+      { beadStore, artifactStore },
+    );
+    expect(isOk(result)).toBe(false);
+    if (!isOk(result)) {
+      expect(result.error.code).toBe('WRITE_FAILURE');
+    }
+  });
+
+  it('should return Err on bead updateDesign failure', async () => {
+    beadStore.seed([
+      { id: 'ms1', label: 'tff:milestone', title: 'MVP', status: 'open' },
+      { id: 's1', label: 'tff:slice', title: 'Auth', status: 'open', design: 'Old design', parentId: 'ms1' },
+    ]);
+    artifactStore.seed({ '.tff/milestones/M01/slices/Auth/PLAN.md': '# Updated plan content' });
+    beadStore.simulateUpdateFailure('s1');
+    const result = await reconcileState(
+      { milestoneId: 'ms1', milestoneName: 'M01: MVP' },
+      { beadStore, artifactStore },
+    );
+    expect(isOk(result)).toBe(false);
+    if (!isOk(result)) {
+      expect(result.error.code).toBe('WRITE_FAILURE');
+    }
+  });
+
   it('should return empty report when everything is in sync', async () => {
     beadStore.seed([{ id: 'ms1', label: 'tff:milestone', title: 'MVP', status: 'open' }]);
 

--- a/tools/src/application/sync/reconcile-state.ts
+++ b/tools/src/application/sync/reconcile-state.ts
@@ -78,9 +78,11 @@ export const reconcileState = async (
 
     if (!(await deps.artifactStore.exists(planPath))) {
       // Bead exists but no markdown → generate markdown from bead
-      await deps.artifactStore.mkdir(sliceDir);
+      const mkdirResult = await deps.artifactStore.mkdir(sliceDir);
+      if (!isOk(mkdirResult)) return mkdirResult;
       const content = `# Plan — ${bead.title}\n\n${bead.design ?? '_No plan yet._'}\n`;
-      await deps.artifactStore.write(planPath, content);
+      const writeResult = await deps.artifactStore.write(planPath, content);
+      if (!isOk(writeResult)) return writeResult;
       report.created.push({ entityId: bead.id, source: 'beads' });
     } else {
       // Both exist → sync content and status
@@ -92,7 +94,8 @@ export const reconcileState = async (
         // Content: markdown wins (unless empty)
         const winner = resolveContentConflict(mdContent, beadDesign);
         if (winner !== beadDesign && mdContent.length > 0) {
-          await deps.beadStore.updateDesign(bead.id, winner);
+          const updateResult = await deps.beadStore.updateDesign(bead.id, winner);
+          if (!isOk(updateResult)) return updateResult;
           report.updated.push({
             entityId: bead.id,
             field: 'design',
@@ -132,14 +135,14 @@ export const reconcileState = async (
         parentId: input.milestoneId,
       });
 
-      if (isOk(beadResult)) {
-        report.created.push({ entityId: beadResult.data.id, source: 'markdown' });
-      }
+      if (!isOk(beadResult)) return beadResult;
+      report.created.push({ entityId: beadResult.data.id, source: 'markdown' });
     }
   }
 
   // 5. Regenerate STATE.md (always derived from beads)
-  await generateState(input, deps);
+  const stateResult = await generateState(input, deps);
+  if (!isOk(stateResult)) return stateResult;
 
   return Ok(report);
 };

--- a/tools/src/cli/commands/claim-check-stale.cmd.ts
+++ b/tools/src/cli/commands/claim-check-stale.cmd.ts
@@ -1,0 +1,30 @@
+import { checkStaleClaims } from '../../application/claims/check-stale-claims.js';
+import { isOk } from '../../domain/result.js';
+import { createBeadAdapter } from '../../infrastructure/adapters/beads/bead-adapter-factory.js';
+
+export const claimCheckStaleCmd = async (args: string[]): Promise<string> => {
+  const ttlMinutes = args[0] ? parseInt(args[0], 10) : 30;
+  if (isNaN(ttlMinutes) || ttlMinutes <= 0) {
+    return JSON.stringify({
+      ok: false,
+      error: { code: 'INVALID_ARGS', message: 'Usage: claim:check-stale [ttl-minutes]' },
+    });
+  }
+  const { store: beadStore } = await createBeadAdapter();
+  const result = await checkStaleClaims({ ttlMinutes }, { beadStore });
+  if (isOk(result)) {
+    return JSON.stringify({
+      ok: true,
+      data: {
+        staleClaims: result.data.staleClaims.map((b) => ({
+          id: b.id,
+          title: b.title,
+          claimedAt: b.claimedAt,
+          label: b.label,
+        })),
+        count: result.data.staleClaims.length,
+      },
+    });
+  }
+  return JSON.stringify({ ok: false, error: result.error });
+};

--- a/tools/src/cli/commands/slice-transition.cmd.spec.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+describe('slice-transition result format', () => {
+  it('should include warnings array in success result', () => {
+    const successResult = { ok: true, data: { status: 'executing' }, warnings: [] as string[] };
+    expect(successResult).toHaveProperty('warnings');
+    expect(Array.isArray(successResult.warnings)).toBe(true);
+  });
+
+  it('should populate warnings for non-critical failures', () => {
+    const resultWithWarnings = {
+      ok: true,
+      data: { status: 'executing' },
+      warnings: ['snapshot failed: Error: ENOENT', 'dolt sync failed: Error: connection refused'],
+    };
+    expect(resultWithWarnings.ok).toBe(true);
+    expect(resultWithWarnings.warnings).toHaveLength(2);
+  });
+
+  it('should block transition on checkpoint failure', () => {
+    const blockedResult = {
+      ok: false,
+      error: { code: 'CHECKPOINT_FAILED', message: 'Checkpoint save failed: Error: disk full' },
+    };
+    expect(blockedResult.ok).toBe(false);
+    expect(blockedResult.error.code).toBe('CHECKPOINT_FAILED');
+  });
+});

--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -64,15 +64,19 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
   );
 
   if (isOk(result)) {
-    // Auto-snapshot after successful transition
+    const warnings: string[] = [];
+
+    // Auto-snapshot (non-critical)
     try {
       const { snapshotSaveCmd } = await import('./snapshot-save.cmd.js');
       await snapshotSaveCmd([]);
     } catch (e) {
-      tffWarn('snapshot failed', { error: String(e) });
+      const msg = `snapshot failed: ${String(e)}`;
+      tffWarn(msg);
+      warnings.push(msg);
     }
 
-    // Auto-sync to Dolt remote if configured
+    // Auto-sync to Dolt (non-critical)
     try {
       const { readFile } = await import('node:fs/promises');
       const { loadProjectSettings } = await import('../../domain/value-objects/project-settings.js');
@@ -83,18 +87,22 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
         await doltPush(settings.dolt.remote);
       }
     } catch (e) {
-      tffWarn('dolt sync failed', { error: String(e) });
+      const msg = `dolt sync failed: ${String(e)}`;
+      tffWarn(msg);
+      warnings.push(msg);
     }
 
-    // Auto-regenerate STATE.md
+    // Auto-regenerate STATE.md (non-critical)
     try {
       const { syncStateCmd } = await import('./sync-state.cmd.js');
       await syncStateCmd([bead.parentId ?? '']);
     } catch (e) {
-      tffWarn('state sync failed', { error: String(e) });
+      const msg = `state sync failed: ${String(e)}`;
+      tffWarn(msg);
+      warnings.push(msg);
     }
 
-    // Auto-save CHECKPOINT.md
+    // Auto-save CHECKPOINT.md (CRITICAL — blocks transition)
     try {
       const { checkpointSaveCmd } = await import('./checkpoint-save.cmd.js');
       const checkpointData = JSON.stringify({
@@ -107,10 +115,14 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
       });
       await checkpointSaveCmd([checkpointData]);
     } catch (e) {
-      tffWarn('checkpoint save failed', { error: String(e) });
+      return JSON.stringify({
+        ok: false,
+        error: { code: 'CHECKPOINT_FAILED', message: `Checkpoint save failed: ${String(e)}` },
+        warnings,
+      });
     }
 
-    return JSON.stringify({ ok: true, data: { status: result.data.slice.status } });
+    return JSON.stringify({ ok: true, data: { status: result.data.slice.status }, warnings });
   }
   return JSON.stringify({ ok: false, error: result.error });
 };

--- a/tools/src/cli/index.ts
+++ b/tools/src/cli/index.ts
@@ -1,5 +1,6 @@
 import { checkpointLoadCmd } from './commands/checkpoint-load.cmd.js';
 import { checkpointSaveCmd } from './commands/checkpoint-save.cmd.js';
+import { claimCheckStaleCmd } from './commands/claim-check-stale.cmd.js';
 import { composeDetectCmd } from './commands/compose-detect.cmd.js';
 import { milestoneCreateCmd } from './commands/milestone-create.cmd.js';
 import { milestoneListCmd } from './commands/milestone-list.cmd.js';
@@ -58,6 +59,7 @@ const commands: Record<string, CommandFn> = {
   'snapshot:save': snapshotSaveCmd,
   'snapshot:load': snapshotLoadCmd,
   'snapshot:merge': snapshotMergeCmd,
+  'claim:check-stale': claimCheckStaleCmd,
 };
 
 const main = async () => {

--- a/tools/src/domain/errors/domain-error.ts
+++ b/tools/src/domain/errors/domain-error.ts
@@ -7,6 +7,8 @@ export const DomainErrorCodeSchema = z.enum([
   'FRESH_REVIEWER_VIOLATION',
   'NOT_FOUND',
   'VALIDATION_ERROR',
+  'STALE_CLAIM',
+  'WRITE_FAILURE',
 ]);
 
 export type DomainErrorCode = z.infer<typeof DomainErrorCodeSchema>;

--- a/tools/src/domain/ports/bead-store.port.ts
+++ b/tools/src/domain/ports/bead-store.port.ts
@@ -12,6 +12,7 @@ export interface BeadData {
   blocks?: string[];
   validates?: string[];
   metadata?: Record<string, string>;
+  claimedAt?: string;
 }
 
 export interface BeadStore {
@@ -52,4 +53,7 @@ export interface BeadStore {
   addDependency(fromId: string, toId: string, type: 'blocks' | 'validates'): Promise<Result<void, DomainError>>;
 
   close(id: string, reason?: string): Promise<Result<void, DomainError>>;
+
+  /** List tasks with stale claims (claimed but not completed within ttlMinutes) */
+  listStaleClaims(ttlMinutes: number): Promise<Result<BeadData[], DomainError>>;
 }

--- a/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/bd-cli.adapter.ts
@@ -85,6 +85,7 @@ const normalizeBeadData = (raw: Record<string, unknown>): Result<BeadData, Domai
     blocks: raw.blocks as string[] | undefined,
     validates: raw.validates as string[] | undefined,
     metadata: raw.metadata as Record<string, string> | undefined,
+    claimedAt: (raw.metadata as Record<string, string> | undefined)?.claimedAt,
   });
 };
 
@@ -198,7 +199,20 @@ export class BdCliAdapter implements BeadStore {
     // Atomically sets assignee + status to in_progress
     const r = await runBdRetry(['update', id, '--claim']);
     if (!r.ok) return r;
+    const metaR = await runBd(['kv', 'set', `${id}.claimedAt`, new Date().toISOString()]);
+    if (!metaR.ok) return metaR;
     return Ok(undefined);
+  }
+
+  async listStaleClaims(ttlMinutes: number): Promise<Result<BeadData[], DomainError>> {
+    const allResult = await this.list({ status: 'in_progress', includeAll: true });
+    if (!allResult.ok) return allResult;
+    const cutoff = new Date(Date.now() - ttlMinutes * 60 * 1000).toISOString();
+    const stale = allResult.data.filter((b) => {
+      const claimedAt = b.metadata?.claimedAt ?? b.claimedAt;
+      return claimedAt != null && claimedAt < cutoff;
+    });
+    return Ok(stale);
   }
 
   async updateDesign(id: string, design: string): Promise<Result<void, DomainError>> {

--- a/tools/src/infrastructure/adapters/beads/markdown-bead.adapter.ts
+++ b/tools/src/infrastructure/adapters/beads/markdown-bead.adapter.ts
@@ -83,7 +83,22 @@ export class MarkdownBeadAdapter implements BeadStore {
   }
 
   async claim(id: string): Promise<Result<void, DomainError>> {
-    return this.updateStatus(id, 'in_progress');
+    const result = await this.get(id);
+    if (!isOk(result)) return result;
+    result.data.status = 'in_progress';
+    result.data.claimedAt = new Date().toISOString();
+    await this.writeBead(result.data);
+    return Ok(undefined);
+  }
+
+  async listStaleClaims(ttlMinutes: number): Promise<Result<BeadData[], DomainError>> {
+    const allResult = await this.readAll();
+    if (!isOk(allResult)) return allResult;
+    const cutoff = new Date(Date.now() - ttlMinutes * 60 * 1000).toISOString();
+    const stale = allResult.data.filter(
+      (b) => b.status === 'in_progress' && b.claimedAt != null && b.claimedAt < cutoff,
+    );
+    return Ok(stale);
   }
 
   async updateDesign(id: string, design: string): Promise<Result<void, DomainError>> {

--- a/tools/src/infrastructure/testing/in-memory-artifact-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-artifact-store.ts
@@ -4,6 +4,11 @@ import { Err, Ok, type Result } from '../../domain/result.js';
 
 export class InMemoryArtifactStore implements ArtifactStore {
   private files = new Map<string, string>();
+  private failOnWritePaths = new Set<string>();
+
+  simulateWriteFailure(path: string): void {
+    this.failOnWritePaths.add(path);
+  }
 
   async read(path: string): Promise<Result<string, DomainError>> {
     const content = this.files.get(path);
@@ -12,6 +17,9 @@ export class InMemoryArtifactStore implements ArtifactStore {
   }
 
   async write(path: string, content: string): Promise<Result<void, DomainError>> {
+    if (this.failOnWritePaths.has(path)) {
+      return Err(createDomainError('WRITE_FAILURE', `Simulated write failure for: ${path}`, { path }));
+    }
     this.files.set(path, content);
     return Ok(undefined);
   }

--- a/tools/src/infrastructure/testing/in-memory-bead-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-bead-store.ts
@@ -75,7 +75,16 @@ export class InMemoryBeadStore implements BeadStore {
     const bead = this.beads.get(id);
     if (!bead) return Err(createDomainError('NOT_FOUND', `Bead "${id}" not found`, { id }));
     bead.status = 'in_progress';
+    bead.claimedAt = new Date().toISOString();
     return Ok(undefined);
+  }
+
+  async listStaleClaims(ttlMinutes: number): Promise<Result<BeadData[], DomainError>> {
+    const cutoff = new Date(Date.now() - ttlMinutes * 60 * 1000).toISOString();
+    const stale = [...this.beads.values()].filter(
+      (b) => b.status === 'in_progress' && b.claimedAt != null && b.claimedAt < cutoff,
+    );
+    return Ok(stale);
   }
 
   async updateDesign(id: string, design: string): Promise<Result<void, DomainError>> {

--- a/tools/src/infrastructure/testing/in-memory-bead-store.ts
+++ b/tools/src/infrastructure/testing/in-memory-bead-store.ts
@@ -6,6 +6,11 @@ import type { BeadLabel } from '../../domain/value-objects/bead-label.js';
 export class InMemoryBeadStore implements BeadStore {
   private beads = new Map<string, BeadData>();
   private nextId = 1;
+  private failOnUpdateIds = new Set<string>();
+
+  simulateUpdateFailure(id: string): void {
+    this.failOnUpdateIds.add(id);
+  }
 
   async init(): Promise<Result<void, DomainError>> {
     return Ok(undefined);
@@ -88,6 +93,9 @@ export class InMemoryBeadStore implements BeadStore {
   }
 
   async updateDesign(id: string, design: string): Promise<Result<void, DomainError>> {
+    if (this.failOnUpdateIds.has(id)) {
+      return Err(createDomainError('WRITE_FAILURE', `Simulated update failure for bead: ${id}`, { id }));
+    }
     const bead = this.beads.get(id);
     if (!bead) return Err(createDomainError('NOT_FOUND', `Bead "${id}" not found`, { id }));
     bead.design = design;

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -70,6 +70,8 @@ If F-full confirmed → run step 4 (Challenge Spec) now if not already done.
 tier = S → `tff-tools slice:transition <id> planning` (skip research)
 tier = F-lite ∨ F-full → `tff-tools slice:transition <id> researching`
 CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
+  IF `ok` = true ∧ `warnings.length > 0`:
+    ∀ warning ∈ warnings: display `⚠ <warning>` to user
 
 ## Auto-Transition
 After completing all steps above:

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -24,6 +24,7 @@ status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
 3. EXECUTE:
 ```
 ∀ wave ∈ waves (sequential):
+  STALE-CHECK: `tff-tools claim:check-stale` → if count > 0: warn user, list stale tasks, offer to continue or abort
   checkpoint:save <slice-id> '<data-json>'
   tier ∈ {F-lite, F-full} → ∀ task: SPAWN tff-tester: {task.criteria, task.files}
     tester writes failing .spec.ts + commits in worktree

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -37,6 +37,8 @@ status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
 ```
 4. TRANSITION: `tff-tools slice:transition <id> verifying`
    CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
+  IF `ok` = true ∧ `warnings.length > 0`:
+    ∀ warning ∈ warnings: display `⚠ <warning>` to user
 5. NEXT: @references/next-steps.md
 
 ## Auto-Transition

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -19,7 +19,9 @@ status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
    - Worktree not required. Proceed in main repo.
 
 ## Steps
-1. RESUME: `tff-tools checkpoint:load <slice-id>` → skip completed waves
+1. RESUME: `tff-tools checkpoint:load <slice-id>` →
+   - Skip fully completed waves (wave ∈ completedWaves)
+   - For current wave: skip tasks already in completedTasks, retry remaining
 2. DETECT: `tff-tools waves:detect '<tasks-json>'`
 3. EXECUTE:
 ```
@@ -29,11 +31,13 @@ status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
   tier ∈ {F-lite, F-full} → ∀ task: SPAWN tff-tester: {task.criteria, task.files}
     tester writes failing .spec.ts + commits in worktree
   ∀ task ∈ wave (parallel):
+    IF task.ref ∈ checkpoint.completedTasks → SKIP
     bd update <id> --claim
     SPAWN executor_agent: {task.description, task.criteria, task.files, @references/conventions.md}
     agent works in worktree → implement → tests pass → commit
     record executor → bead metadata
     bd close <id> --reason "Completed"
+    checkpoint:save <slice-id> '<updated-data-json>'   ← per-task checkpoint
   sync:state
 ```
 4. TRANSITION: `tff-tools slice:transition <id> verifying`

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -7,6 +7,17 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 ## Prerequisites
 status = executing ∧ worktree exists at `.tff/worktrees/<slice-id>/`
 
+## Pre-Execute Validation
+1. READ slice classification from SPEC.md → tier ∈ {S-tier, F-lite, F-full}
+2. IF tier ∈ {F-lite, F-full}:
+   - CHECK: `tff-tools worktree:list` → verify worktree exists for `<slice-id>`
+   - IF worktree MISSING:
+     ❌ BLOCKED: Worktree required for F-lite/F-full execution but not found.
+     Recovery: `tff-tools worktree:create <slice-id>`
+     → STOP execution. Do NOT proceed.
+3. IF tier = S-tier:
+   - Worktree not required. Proceed in main repo.
+
 ## Steps
 1. RESUME: `tff-tools checkpoint:load <slice-id>` → skip completed waves
 2. DETECT: `tff-tools waves:detect '<tasks-json>'`

--- a/workflows/health.md
+++ b/workflows/health.md
@@ -13,7 +13,11 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
        - report as stale: `⚠ <slice-id>: bead is <status> but PR #<N> is merged`
    - `bd list --label tff:milestone --json` → for each non-closed milestone:
      - if all child slices are closed → report: `⚠ <milestone>: all slices closed but milestone bead is still open`
-5. REPORT:
+5. CHECK stale claims: `tff-tools claim:check-stale`
+   - Parse result → if `count > 0`:
+     - ∀ stale claim: report `⚠ Task <id> (<title>) claimed at <claimedAt> — exceeds 30min TTL`
+   - Add row to health report table: `| Stale claims | OK/X stale |`
+6. REPORT:
    ```
    | Check | Status |
    |---|---|
@@ -21,10 +25,11 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
    | plannotator | OK/MISSING |
    | State consistency | OK/X mismatches |
    | Bead-PR sync | OK/X stale beads |
+   | Stale claims | OK/X stale |
    | Worktrees | OK/X orphans |
    ```
-6. stale beads found → AskUserQuestion: "Close stale beads?" → yes → `bd close <id> --reason "PR already merged"`
-7. other issues found → offer `/tff:sync` to reconcile
+7. stale beads found → AskUserQuestion: "Close stale beads?" → yes → `bd close <id> --reason "PR already merged"`
+8. other issues found → offer `/tff:sync` to reconcile
 
 ## Adapter Mode
 Check `bd --version`:
@@ -40,4 +45,4 @@ Check `bd --version`:
   Then:    /tff:sync to hydrate from existing state
   ```
 
-6. NEXT: @references/next-steps.md
+9. NEXT: @references/next-steps.md

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -81,6 +81,8 @@ feedback → revise ∨ approved → continue
 CHECK: `ok` = true → continue | `ok` = false → warn (worktree failure is non-blocking at plan time; execute-slice will block F-lite/F-full if worktree is still missing)
 `tff-tools slice:transition <id> executing`
 CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
+  IF `ok` = true ∧ `warnings.length > 0`:
+    ∀ warning ∈ warnings: display `⚠ <warning>` to user
 
 ## Auto-Transition
 After completing all steps above:

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -78,7 +78,7 @@ feedback → revise ∨ approved → continue
 
 ### 9. Worktree + Transition
 `tff-tools worktree:create <id>`
-CHECK: `ok` = true → continue | `ok` = false → warn (worktree failure is non-blocking)
+CHECK: `ok` = true → continue | `ok` = false → warn (worktree failure is non-blocking at plan time; execute-slice will block F-lite/F-full if worktree is still missing)
 `tff-tools slice:transition <id> executing`
 CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
 

--- a/workflows/research-slice.md
+++ b/workflows/research-slice.md
@@ -15,6 +15,8 @@ status = researching
    - Output → `.tff/milestones/<milestone>/slices/<slice-id>/RESEARCH.md`
 3. TRANSITION: `tff-tools slice:transition <id> planning`
    CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry or abort
+  IF `ok` = true ∧ `warnings.length > 0`:
+    ∀ warning ∈ warnings: display `⚠ <warning>` to user
 4. NEXT: @references/next-steps.md
 
 ## Auto-Transition


### PR DESCRIPTION
## Summary
- **S01 — Task Claiming Timeout:** Added `claimedAt` tracking to all bead adapters, `listStaleClaims` port method, `checkStaleClaims` use case, and `claim:check-stale` CLI command with configurable TTL
- **S02 — Per-Task Checkpoint Updates:** `saveCheckpoint` now checks write results and returns errors; incremental checkpoint save/load verified; `execute-slice.md` updated for per-task checkpoints and partial wave resume
- **S03 — Worktree Validation:** `execute-slice.md` blocks F-lite/F-full execution when worktree is missing; `plan-slice.md` clarifies deferred validation
- **S04 — Reconcile Write-Failure Handling:** `reconcileState` fails fast on write errors (mkdir, write, updateDesign, create, generateState) instead of silently continuing
- **S05 — Auto-Recovery Failure Surfacing:** `slice:transition` accumulates warnings for non-critical failures (snapshot, dolt sync, state sync) and blocks on checkpoint failure; all workflows display transition warnings

## Test plan
- [x] 311 tests passing (12 new), 0 failures
- [x] All existing tests unaffected (no regressions)
- [ ] Manual: verify `tff-tools claim:check-stale` returns expected JSON
- [ ] Manual: verify `slice:transition` returns `warnings` array in response
- [ ] Manual: verify reconcile surfaces write errors instead of silently ignoring