### PR TITLE
feat(M01-S04): Journal system

### DIFF
--- a/tools/src/application/journal/journal-event-handler.spec.ts
+++ b/tools/src/application/journal/journal-event-handler.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createDomainEvent } from '../../domain/events/domain-event.js';
+import { isOk } from '../../domain/result.js';
+import { SimpleEventBus } from '../../infrastructure/adapters/event-bus/simple-event-bus.js';
+import { InMemoryJournalAdapter } from '../../infrastructure/testing/in-memory-journal.adapter.js';
+import { JournalEventHandler } from './journal-event-handler.js';
+
+describe('JournalEventHandler', () => {
+  it('writes phase-changed entry on SLICE_STATUS_CHANGED', () => {
+    const journal = new InMemoryJournalAdapter();
+    const bus = new SimpleEventBus();
+    const handler = new JournalEventHandler(journal);
+    handler.register(bus);
+
+    const event = createDomainEvent('SLICE_STATUS_CHANGED', { sliceId: 'M01-S04', from: 'planning', to: 'executing' });
+    bus.publish(event);
+
+    const result = journal.readAll('M01-S04');
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].type).toBe('phase-changed');
+      if (result.data[0].type === 'phase-changed') {
+        expect(result.data[0].from).toBe('planning');
+        expect(result.data[0].to).toBe('executing');
+      }
+    }
+  });
+
+  it('ignores events it is not subscribed to', () => {
+    const journal = new InMemoryJournalAdapter();
+    const bus = new SimpleEventBus();
+    const handler = new JournalEventHandler(journal);
+    handler.register(bus);
+
+    const event = createDomainEvent('SYNC_CONFLICT', { entityId: 'x', field: 'y', winner: 'markdown' });
+    bus.publish(event);
+
+    // Should not write anything — SYNC_CONFLICT is not subscribed
+    const result = journal.count('x');
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.data).toBe(0);
+  });
+});

--- a/tools/src/application/journal/journal-event-handler.ts
+++ b/tools/src/application/journal/journal-event-handler.ts
@@ -1,0 +1,24 @@
+import type { DomainEvent } from '../../domain/events/domain-event.js';
+import type { EventBus } from '../../domain/ports/event-bus.port.js';
+import type { JournalRepository } from '../../domain/ports/journal-repository.port.js';
+import type { PhaseChangedEntry } from '../../domain/value-objects/journal-entry.js';
+
+export class JournalEventHandler {
+  constructor(private readonly journal: JournalRepository) {}
+
+  register(eventBus: EventBus): void {
+    eventBus.subscribe('SLICE_STATUS_CHANGED', (event) => this.onSliceStatusChanged(event));
+  }
+
+  private onSliceStatusChanged(event: DomainEvent): void {
+    const { sliceId, from, to } = event.payload as { sliceId: string; from: string; to: string };
+    const entry: Omit<PhaseChangedEntry, 'seq'> = {
+      type: 'phase-changed',
+      sliceId,
+      timestamp: event.occurredAt.toISOString(),
+      from,
+      to,
+    };
+    this.journal.append(sliceId, entry);
+  }
+}

--- a/tools/src/application/journal/replay-journal.spec.ts
+++ b/tools/src/application/journal/replay-journal.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { isErr, isOk } from '../../domain/result.js';
+import { JournalEntryBuilder } from '../../domain/value-objects/journal-entry.builder.js';
+import type { JournalEntry } from '../../domain/value-objects/journal-entry.js';
+import { InMemoryJournalAdapter } from '../../infrastructure/testing/in-memory-journal.adapter.js';
+import { replayJournal } from './replay-journal.js';
+
+describe('replayJournal', () => {
+  const sliceId = 'M01-S04';
+  const builder = new JournalEntryBuilder().withSliceId(sliceId);
+
+  it('consistent journal + checkpoint → OK (AC3)', () => {
+    const journal = new InMemoryJournalAdapter();
+    const entries: JournalEntry[] = [
+      { ...builder.buildTaskCompleted({ taskId: 'T01' }), seq: 0 } as JournalEntry,
+      { ...builder.buildCheckpointSaved({ waveIndex: 0, completedTaskCount: 1 }), seq: 1 } as JournalEntry,
+    ];
+    journal.seed(sliceId, entries);
+
+    const result = replayJournal({ sliceId, checkpoint: { completedTasks: ['T01'], currentWave: 1 } }, { journal });
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data.consistent).toBe(true);
+      expect(result.data.completedTaskIds).toContain('T01');
+      expect(result.data.resumeFromWave).toBe(1);
+    }
+  });
+
+  it('checkpoint claims task not in journal → REJECT (AC3)', () => {
+    const journal = new InMemoryJournalAdapter();
+    journal.seed(sliceId, [{ ...builder.buildPhaseChanged(), seq: 0 } as JournalEntry]);
+
+    const result = replayJournal({ sliceId, checkpoint: { completedTasks: ['T01'], currentWave: 0 } }, { journal });
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) expect(result.error.code).toBe('JOURNAL_REPLAY_INCONSISTENT');
+  });
+
+  it('empty journal + empty checkpoint → OK, resume from 0 (AC4)', () => {
+    const journal = new InMemoryJournalAdapter();
+
+    const result = replayJournal({ sliceId, checkpoint: { completedTasks: [], currentWave: 0 } }, { journal });
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.data.consistent).toBe(true);
+      expect(result.data.resumeFromWave).toBe(0);
+    }
+  });
+
+  it('empty journal + non-empty checkpoint → REJECT (AC3)', () => {
+    const journal = new InMemoryJournalAdapter();
+
+    const result = replayJournal({ sliceId, checkpoint: { completedTasks: ['T01'], currentWave: 1 } }, { journal });
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) expect(result.error.code).toBe('JOURNAL_REPLAY_INCONSISTENT');
+  });
+
+  it('uses highest checkpoint-saved wave for resume (AC4)', () => {
+    const journal = new InMemoryJournalAdapter();
+    const entries: JournalEntry[] = [
+      { ...builder.buildTaskCompleted({ taskId: 'T01' }), seq: 0 } as JournalEntry,
+      { ...builder.buildCheckpointSaved({ waveIndex: 0 }), seq: 1 } as JournalEntry,
+      { ...builder.buildTaskCompleted({ taskId: 'T02' }), seq: 2 } as JournalEntry,
+      { ...builder.buildCheckpointSaved({ waveIndex: 1 }), seq: 3 } as JournalEntry,
+    ];
+    journal.seed(sliceId, entries);
+
+    const result = replayJournal({ sliceId, checkpoint: { completedTasks: ['T01', 'T02'], currentWave: 2 } }, { journal });
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.data.resumeFromWave).toBe(2);
+  });
+});

--- a/tools/src/application/journal/replay-journal.spec.ts
+++ b/tools/src/application/journal/replay-journal.spec.ts
@@ -64,7 +64,10 @@ describe('replayJournal', () => {
     ];
     journal.seed(sliceId, entries);
 
-    const result = replayJournal({ sliceId, checkpoint: { completedTasks: ['T01', 'T02'], currentWave: 2 } }, { journal });
+    const result = replayJournal(
+      { sliceId, checkpoint: { completedTasks: ['T01', 'T02'], currentWave: 2 } },
+      { journal },
+    );
     expect(isOk(result)).toBe(true);
     if (isOk(result)) expect(result.data.resumeFromWave).toBe(2);
   });

--- a/tools/src/application/journal/replay-journal.ts
+++ b/tools/src/application/journal/replay-journal.ts
@@ -1,0 +1,69 @@
+import { createDomainError, type DomainError } from '../../domain/errors/domain-error.js';
+import type { JournalRepository } from '../../domain/ports/journal-repository.port.js';
+import { Err, Ok, type Result } from '../../domain/result.js';
+
+interface ReplayInput {
+  sliceId: string;
+  checkpoint: {
+    completedTasks: readonly string[];
+    currentWave: number;
+  };
+}
+
+export interface ReplayResult {
+  resumeFromWave: number;
+  completedTaskIds: string[];
+  lastProcessedSeq: number;
+  consistent: boolean;
+}
+
+interface ReplayDeps {
+  journal: JournalRepository;
+}
+
+export const replayJournal = (input: ReplayInput, deps: ReplayDeps): Result<ReplayResult, DomainError> => {
+  const readResult = deps.journal.readAll(input.sliceId);
+  if (!readResult.ok) {
+    return Err(createDomainError('JOURNAL_REPLAY_INCONSISTENT', readResult.error.message));
+  }
+
+  const entries = readResult.data;
+
+  // Empty journal + non-empty checkpoint → reject
+  if (entries.length === 0 && input.checkpoint.completedTasks.length > 0) {
+    return Err(
+      createDomainError('JOURNAL_REPLAY_INCONSISTENT', 'Journal is empty but checkpoint has completed tasks', { reason: 'empty-journal-nonempty-checkpoint' }),
+    );
+  }
+
+  const completedTaskIds = new Set<string>();
+  let highestWave = -1;
+  let lastProcessedSeq = -1;
+
+  for (const entry of entries) {
+    lastProcessedSeq = entry.seq;
+    if (entry.type === 'task-completed') completedTaskIds.add(entry.taskId);
+    if (entry.type === 'checkpoint-saved') highestWave = Math.max(highestWave, entry.waveIndex);
+  }
+
+  // Cross-validate: every task the checkpoint claims must exist in journal
+  for (const taskId of input.checkpoint.completedTasks) {
+    if (!completedTaskIds.has(taskId)) {
+      return Err(
+        createDomainError('JOURNAL_REPLAY_INCONSISTENT', `Checkpoint claims task ${taskId} completed but no journal entry found`, { reason: 'missing-task-completed', taskId }),
+      );
+    }
+  }
+
+  // Determine resume wave
+  let resumeFromWave: number;
+  if (entries.length === 0) {
+    resumeFromWave = 0;
+  } else if (highestWave >= 0) {
+    resumeFromWave = Math.max(highestWave + 1, input.checkpoint.currentWave);
+  } else {
+    resumeFromWave = input.checkpoint.currentWave;
+  }
+
+  return Ok({ resumeFromWave, completedTaskIds: [...completedTaskIds], lastProcessedSeq, consistent: true });
+};

--- a/tools/src/application/journal/replay-journal.ts
+++ b/tools/src/application/journal/replay-journal.ts
@@ -32,7 +32,9 @@ export const replayJournal = (input: ReplayInput, deps: ReplayDeps): Result<Repl
   // Empty journal + non-empty checkpoint → reject
   if (entries.length === 0 && input.checkpoint.completedTasks.length > 0) {
     return Err(
-      createDomainError('JOURNAL_REPLAY_INCONSISTENT', 'Journal is empty but checkpoint has completed tasks', { reason: 'empty-journal-nonempty-checkpoint' }),
+      createDomainError('JOURNAL_REPLAY_INCONSISTENT', 'Journal is empty but checkpoint has completed tasks', {
+        reason: 'empty-journal-nonempty-checkpoint',
+      }),
     );
   }
 
@@ -50,7 +52,11 @@ export const replayJournal = (input: ReplayInput, deps: ReplayDeps): Result<Repl
   for (const taskId of input.checkpoint.completedTasks) {
     if (!completedTaskIds.has(taskId)) {
       return Err(
-        createDomainError('JOURNAL_REPLAY_INCONSISTENT', `Checkpoint claims task ${taskId} completed but no journal entry found`, { reason: 'missing-task-completed', taskId }),
+        createDomainError(
+          'JOURNAL_REPLAY_INCONSISTENT',
+          `Checkpoint claims task ${taskId} completed but no journal entry found`,
+          { reason: 'missing-task-completed', taskId },
+        ),
       );
     }
   }

--- a/tools/src/application/lifecycle/transition-slice.spec.ts
+++ b/tools/src/application/lifecycle/transition-slice.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { isErr, isOk } from '../../domain/result.js';
 import { InMemoryStateAdapter } from '../../infrastructure/testing/in-memory-state-adapter.js';
 import { transitionSliceUseCase } from './transition-slice.js';
@@ -32,5 +32,25 @@ describe('transitionSliceUseCase', () => {
     );
     expect(isErr(result)).toBe(true);
     if (isErr(result)) expect(result.error.code).toBe('INVALID_TRANSITION');
+  });
+});
+
+describe('transitionSlice with EventBus', () => {
+  it('publishes SLICE_STATUS_CHANGED event via EventBus (AC13)', async () => {
+    const adapter = new InMemoryStateAdapter();
+    adapter.saveProject({ name: 'Test', vision: 'v' });
+    adapter.createMilestone({ number: 1, name: 'M01' });
+    adapter.createSlice({ milestoneId: 'M01', number: 1, title: 'Test' });
+
+    const publishFn = vi.fn();
+    const eventBus = { publish: publishFn, subscribe: () => {} };
+
+    const result = await transitionSliceUseCase(
+      { sliceId: 'M01-S01', targetStatus: 'researching' },
+      { sliceStore: adapter, eventBus },
+    );
+    expect(isOk(result)).toBe(true);
+    expect(publishFn).toHaveBeenCalledOnce();
+    expect(publishFn.mock.calls[0][0].type).toBe('SLICE_STATUS_CHANGED');
   });
 });

--- a/tools/src/application/lifecycle/transition-slice.ts
+++ b/tools/src/application/lifecycle/transition-slice.ts
@@ -2,6 +2,7 @@ import type { Slice } from '../../domain/entities/slice.js';
 import type { DomainError } from '../../domain/errors/domain-error.js';
 import { createDomainError } from '../../domain/errors/domain-error.js';
 import type { DomainEvent } from '../../domain/events/domain-event.js';
+import type { EventBus } from '../../domain/ports/event-bus.port.js';
 import type { SliceStore } from '../../domain/ports/slice-store.port.js';
 import { Err, isOk, type Result } from '../../domain/result.js';
 import type { SliceStatus } from '../../domain/value-objects/slice-status.js';
@@ -12,6 +13,7 @@ interface TransitionInput {
 }
 interface TransitionDeps {
   sliceStore: SliceStore;
+  eventBus?: EventBus;
 }
 interface TransitionOutput {
   slice: Slice;
@@ -24,6 +26,12 @@ export const transitionSliceUseCase = async (
 ): Promise<Result<TransitionOutput, DomainError>> => {
   const transitionResult = deps.sliceStore.transitionSlice(input.sliceId, input.targetStatus);
   if (!isOk(transitionResult)) return transitionResult;
+
+  if (deps.eventBus) {
+    for (const event of transitionResult.data) {
+      deps.eventBus.publish(event);
+    }
+  }
 
   const sliceResult = deps.sliceStore.getSlice(input.sliceId);
   if (!isOk(sliceResult)) return sliceResult;

--- a/tools/src/domain/errors/domain-error.spec.ts
+++ b/tools/src/domain/errors/domain-error.spec.ts
@@ -1,43 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { alreadyClaimedError } from './already-claimed.error.js';
-import { DomainErrorCodeSchema } from './domain-error.js';
-import { hasOpenChildrenError } from './has-open-children.error.js';
-import { versionMismatchError } from './version-mismatch.error.js';
+import { DomainErrorCodeSchema, createDomainError } from './domain-error.js';
 
-describe('DomainErrorCodeSchema', () => {
-  it('includes ALREADY_CLAIMED', () => {
-    expect(DomainErrorCodeSchema.safeParse('ALREADY_CLAIMED').success).toBe(true);
-  });
-  it('includes VERSION_MISMATCH', () => {
-    expect(DomainErrorCodeSchema.safeParse('VERSION_MISMATCH').success).toBe(true);
-  });
-  it('includes HAS_OPEN_CHILDREN', () => {
-    expect(DomainErrorCodeSchema.safeParse('HAS_OPEN_CHILDREN').success).toBe(true);
-  });
-});
-
-describe('DomainErrorCodeSchema S03 codes', () => {
-  it('should accept new S03 error codes', () => {
-    for (const code of ['SYNC_FAILED', 'MERGE_CONFLICT', 'CORRUPTED_STATE', 'STATE_BRANCH_NOT_FOUND']) {
+describe('journal error codes', () => {
+  it('should accept journal error codes', () => {
+    for (const code of ['JOURNAL_WRITE_FAILED', 'JOURNAL_READ_FAILED', 'JOURNAL_REPLAY_INCONSISTENT']) {
       expect(DomainErrorCodeSchema.safeParse(code).success).toBe(true);
     }
   });
-});
 
-describe('Error factories', () => {
-  it('alreadyClaimedError creates correct error', () => {
-    const err = alreadyClaimedError('task-1');
-    expect(err.code).toBe('ALREADY_CLAIMED');
-    expect(err.message).toContain('task-1');
-  });
-  it('versionMismatchError creates correct error', () => {
-    const err = versionMismatchError(5, 3);
-    expect(err.code).toBe('VERSION_MISMATCH');
-    expect(err.message).toContain('5');
-  });
-  it('hasOpenChildrenError creates correct error', () => {
-    const err = hasOpenChildrenError('milestone-1', 3);
-    expect(err.code).toBe('HAS_OPEN_CHILDREN');
-    expect(err.message).toContain('3');
+  it('should create journal domain errors with context', () => {
+    const error = createDomainError('JOURNAL_READ_FAILED', 'Corrupt entry at line 5', { lineNumber: 5 });
+    expect(error.code).toBe('JOURNAL_READ_FAILED');
+    expect(error.context?.lineNumber).toBe(5);
   });
 });

--- a/tools/src/domain/errors/domain-error.spec.ts
+++ b/tools/src/domain/errors/domain-error.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { alreadyClaimedError } from './already-claimed.error.js';
-import { DomainErrorCodeSchema, createDomainError } from './domain-error.js';
+import { createDomainError, DomainErrorCodeSchema } from './domain-error.js';
 import { hasOpenChildrenError } from './has-open-children.error.js';
 import { versionMismatchError } from './version-mismatch.error.js';
 

--- a/tools/src/domain/errors/domain-error.spec.ts
+++ b/tools/src/domain/errors/domain-error.spec.ts
@@ -1,7 +1,30 @@
 import { describe, expect, it } from 'vitest';
+import { alreadyClaimedError } from './already-claimed.error.js';
 import { DomainErrorCodeSchema, createDomainError } from './domain-error.js';
+import { hasOpenChildrenError } from './has-open-children.error.js';
+import { versionMismatchError } from './version-mismatch.error.js';
 
-describe('journal error codes', () => {
+describe('DomainErrorCodeSchema', () => {
+  it('includes ALREADY_CLAIMED', () => {
+    expect(DomainErrorCodeSchema.safeParse('ALREADY_CLAIMED').success).toBe(true);
+  });
+  it('includes VERSION_MISMATCH', () => {
+    expect(DomainErrorCodeSchema.safeParse('VERSION_MISMATCH').success).toBe(true);
+  });
+  it('includes HAS_OPEN_CHILDREN', () => {
+    expect(DomainErrorCodeSchema.safeParse('HAS_OPEN_CHILDREN').success).toBe(true);
+  });
+});
+
+describe('DomainErrorCodeSchema S03 codes', () => {
+  it('should accept new S03 error codes', () => {
+    for (const code of ['SYNC_FAILED', 'MERGE_CONFLICT', 'CORRUPTED_STATE', 'STATE_BRANCH_NOT_FOUND']) {
+      expect(DomainErrorCodeSchema.safeParse(code).success).toBe(true);
+    }
+  });
+});
+
+describe('DomainErrorCodeSchema S04 journal codes', () => {
   it('should accept journal error codes', () => {
     for (const code of ['JOURNAL_WRITE_FAILED', 'JOURNAL_READ_FAILED', 'JOURNAL_REPLAY_INCONSISTENT']) {
       expect(DomainErrorCodeSchema.safeParse(code).success).toBe(true);
@@ -12,5 +35,23 @@ describe('journal error codes', () => {
     const error = createDomainError('JOURNAL_READ_FAILED', 'Corrupt entry at line 5', { lineNumber: 5 });
     expect(error.code).toBe('JOURNAL_READ_FAILED');
     expect(error.context?.lineNumber).toBe(5);
+  });
+});
+
+describe('Error factories', () => {
+  it('alreadyClaimedError creates correct error', () => {
+    const err = alreadyClaimedError('task-1');
+    expect(err.code).toBe('ALREADY_CLAIMED');
+    expect(err.message).toContain('task-1');
+  });
+  it('versionMismatchError creates correct error', () => {
+    const err = versionMismatchError(5, 3);
+    expect(err.code).toBe('VERSION_MISMATCH');
+    expect(err.message).toContain('5');
+  });
+  it('hasOpenChildrenError creates correct error', () => {
+    const err = hasOpenChildrenError('milestone-1', 3);
+    expect(err.code).toBe('HAS_OPEN_CHILDREN');
+    expect(err.message).toContain('3');
   });
 });

--- a/tools/src/domain/errors/domain-error.ts
+++ b/tools/src/domain/errors/domain-error.ts
@@ -16,6 +16,9 @@ export const DomainErrorCodeSchema = z.enum([
   'MERGE_CONFLICT',
   'CORRUPTED_STATE',
   'STATE_BRANCH_NOT_FOUND',
+  'JOURNAL_WRITE_FAILED',
+  'JOURNAL_READ_FAILED',
+  'JOURNAL_REPLAY_INCONSISTENT',
 ]);
 
 export type DomainErrorCode = z.infer<typeof DomainErrorCodeSchema>;

--- a/tools/src/domain/index.ts
+++ b/tools/src/domain/index.ts
@@ -31,7 +31,9 @@ export type { ArtifactStore } from './ports/artifact-store.port.js';
 export type { BeadData, BeadStore } from './ports/bead-store.port.js';
 export type { DatabaseInit } from './ports/database-init.port.js';
 export type { DependencyStore } from './ports/dependency-store.port.js';
+export type { EventBus } from './ports/event-bus.port.js';
 export type { GitOps } from './ports/git-ops.port.js';
+export type { JournalRepository } from './ports/journal-repository.port.js';
 export type { MilestoneStore } from './ports/milestone-store.port.js';
 // Observation store port
 export type { ObservationStore } from './ports/observation-store.port.js';
@@ -53,6 +55,9 @@ export type { ComplexityTier, TierConfig } from './value-objects/complexity-tier
 export { ComplexityTierSchema, tierConfig } from './value-objects/complexity-tier.js';
 export type { Dependency } from './value-objects/dependency.js';
 export { DependencySchema, DependencyTypeSchema } from './value-objects/dependency.js';
+// Journal
+export type { JournalEntry } from './value-objects/journal-entry.js';
+export { JournalEntrySchema } from './value-objects/journal-entry.js';
 export type { MilestoneProps } from './value-objects/milestone-props.js';
 export { MilestonePropsSchema } from './value-objects/milestone-props.js';
 export type { MilestoneStatus } from './value-objects/milestone-status.js';
@@ -84,9 +89,3 @@ export type { Wave } from './value-objects/wave.js';
 export { WaveSchema } from './value-objects/wave.js';
 export type { WorkflowSession } from './value-objects/workflow-session.js';
 export { WorkflowSessionSchema } from './value-objects/workflow-session.js';
-
-// Journal
-export type { JournalEntry } from './value-objects/journal-entry.js';
-export { JournalEntrySchema } from './value-objects/journal-entry.js';
-export type { JournalRepository } from './ports/journal-repository.port.js';
-export type { EventBus } from './ports/event-bus.port.js';

--- a/tools/src/domain/index.ts
+++ b/tools/src/domain/index.ts
@@ -84,3 +84,9 @@ export type { Wave } from './value-objects/wave.js';
 export { WaveSchema } from './value-objects/wave.js';
 export type { WorkflowSession } from './value-objects/workflow-session.js';
 export { WorkflowSessionSchema } from './value-objects/workflow-session.js';
+
+// Journal
+export type { JournalEntry } from './value-objects/journal-entry.js';
+export { JournalEntrySchema } from './value-objects/journal-entry.js';
+export type { JournalRepository } from './ports/journal-repository.port.js';
+export type { EventBus } from './ports/event-bus.port.js';

--- a/tools/src/domain/ports/event-bus.port.spec.ts
+++ b/tools/src/domain/ports/event-bus.port.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import type { EventBus } from './event-bus.port.js';
+
+describe('EventBus port', () => {
+  it('interface exists and is importable', () => {
+    const bus: EventBus = {
+      publish: () => {},
+      subscribe: () => {},
+    };
+    expect(bus.publish).toBeDefined();
+    expect(bus.subscribe).toBeDefined();
+  });
+});

--- a/tools/src/domain/ports/event-bus.port.ts
+++ b/tools/src/domain/ports/event-bus.port.ts
@@ -1,0 +1,6 @@
+import type { DomainEvent, DomainEventType } from '../events/domain-event.js';
+
+export interface EventBus {
+  publish(event: DomainEvent): void;
+  subscribe(type: DomainEventType, handler: (event: DomainEvent) => void): void;
+}

--- a/tools/src/domain/ports/journal-repository.contract.spec.ts
+++ b/tools/src/domain/ports/journal-repository.contract.spec.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+// Run with InMemory adapter when executed standalone (avoids "No test suite found" error)
+import { InMemoryJournalAdapter } from '../../infrastructure/testing/in-memory-journal.adapter.js';
 import { isOk } from '../result.js';
 import { JournalEntryBuilder } from '../value-objects/journal-entry.builder.js';
 import type { JournalRepository } from './journal-repository.port.js';
@@ -65,3 +67,5 @@ export function runJournalContractTests(name: string, factory: () => JournalRepo
     });
   });
 }
+
+runJournalContractTests('InMemoryJournalAdapter', () => new InMemoryJournalAdapter());

--- a/tools/src/domain/ports/journal-repository.contract.spec.ts
+++ b/tools/src/domain/ports/journal-repository.contract.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { isOk } from '../result.js';
+import { JournalEntryBuilder } from '../value-objects/journal-entry.builder.js';
+import type { JournalRepository } from './journal-repository.port.js';
+
+export function runJournalContractTests(
+  name: string,
+  factory: () => JournalRepository & { reset(): void },
+) {
+  describe(`${name} contract`, () => {
+    let repo: JournalRepository & { reset(): void };
+    const sliceId = crypto.randomUUID();
+    const builder = new JournalEntryBuilder().withSliceId(sliceId);
+
+    beforeEach(() => {
+      repo = factory();
+      repo.reset();
+    });
+
+    it('append assigns monotonic seq starting at 0 (AC2)', () => {
+      const r0 = repo.append(sliceId, builder.buildTaskStarted());
+      expect(isOk(r0) && r0.data).toBe(0);
+      const r1 = repo.append(sliceId, builder.buildTaskCompleted());
+      expect(isOk(r1) && r1.data).toBe(1);
+      const r2 = repo.append(sliceId, builder.buildPhaseChanged());
+      expect(isOk(r2) && r2.data).toBe(2);
+    });
+
+    it('readAll returns entries in seq order (AC2)', () => {
+      repo.append(sliceId, builder.buildTaskStarted());
+      repo.append(sliceId, builder.buildTaskCompleted());
+      repo.append(sliceId, builder.buildPhaseChanged());
+      const result = repo.readAll(sliceId);
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.data).toHaveLength(3);
+        expect(result.data[0].seq).toBe(0);
+        expect(result.data[1].seq).toBe(1);
+        expect(result.data[2].seq).toBe(2);
+      }
+    });
+
+    it('readSince filters entries after specified seq (AC9)', () => {
+      for (let i = 0; i < 10; i++) {
+        repo.append(sliceId, builder.buildTaskStarted());
+      }
+      const result = repo.readSince(sliceId, 5);
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.data).toHaveLength(4);
+        expect(result.data[0].seq).toBe(6);
+        expect(result.data[3].seq).toBe(9);
+      }
+    });
+
+    it('count matches appended entries', () => {
+      repo.append(sliceId, builder.buildTaskStarted());
+      repo.append(sliceId, builder.buildTaskCompleted());
+      const result = repo.count(sliceId);
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) expect(result.data).toBe(2);
+    });
+
+    it('readAll returns empty for unknown slice', () => {
+      const result = repo.readAll(crypto.randomUUID());
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) expect(result.data).toHaveLength(0);
+    });
+  });
+}

--- a/tools/src/domain/ports/journal-repository.contract.spec.ts
+++ b/tools/src/domain/ports/journal-repository.contract.spec.ts
@@ -3,10 +3,7 @@ import { isOk } from '../result.js';
 import { JournalEntryBuilder } from '../value-objects/journal-entry.builder.js';
 import type { JournalRepository } from './journal-repository.port.js';
 
-export function runJournalContractTests(
-  name: string,
-  factory: () => JournalRepository & { reset(): void },
-) {
+export function runJournalContractTests(name: string, factory: () => JournalRepository & { reset(): void }) {
   describe(`${name} contract`, () => {
     let repo: JournalRepository & { reset(): void };
     const sliceId = crypto.randomUUID();

--- a/tools/src/domain/ports/journal-repository.port.spec.ts
+++ b/tools/src/domain/ports/journal-repository.port.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import type { JournalRepository } from './journal-repository.port.js';
+
+describe('JournalRepository port', () => {
+  it('interface exists and is importable', () => {
+    const port: JournalRepository = {
+      append: () => ({ ok: true, data: 0 }),
+      readAll: () => ({ ok: true, data: [] }),
+      readSince: () => ({ ok: true, data: [] }),
+      count: () => ({ ok: true, data: 0 }),
+    };
+    expect(port.append).toBeDefined();
+    expect(port.readAll).toBeDefined();
+    expect(port.readSince).toBeDefined();
+    expect(port.count).toBeDefined();
+  });
+});

--- a/tools/src/domain/ports/journal-repository.port.ts
+++ b/tools/src/domain/ports/journal-repository.port.ts
@@ -1,0 +1,10 @@
+import type { DomainError } from '../errors/domain-error.js';
+import type { Result } from '../result.js';
+import type { JournalEntry } from '../value-objects/journal-entry.js';
+
+export interface JournalRepository {
+  append(sliceId: string, entry: Omit<JournalEntry, 'seq'>): Result<number, DomainError>;
+  readAll(sliceId: string): Result<readonly JournalEntry[], DomainError>;
+  readSince(sliceId: string, afterSeq: number): Result<readonly JournalEntry[], DomainError>;
+  count(sliceId: string): Result<number, DomainError>;
+}

--- a/tools/src/domain/value-objects/journal-entry.builder.spec.ts
+++ b/tools/src/domain/value-objects/journal-entry.builder.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { JournalEntryBuilder } from './journal-entry.builder.js';
+import { JournalEntrySchema } from './journal-entry.js';
+
+describe('JournalEntryBuilder', () => {
+  const builder = new JournalEntryBuilder().withSliceId('M01-S04');
+
+  it('builds valid task-started entry', () => {
+    const entry = builder.buildTaskStarted();
+    expect(entry.type).toBe('task-started');
+    expect(entry.sliceId).toBe('M01-S04');
+    expect(JournalEntrySchema.safeParse({ ...entry, seq: 0 }).success).toBe(true);
+  });
+
+  it('builds valid task-completed with overrides', () => {
+    const entry = builder.buildTaskCompleted({ taskId: 'T01', commitHash: 'abc' });
+    expect(entry.taskId).toBe('T01');
+    expect(entry.commitHash).toBe('abc');
+  });
+
+  it('builds valid phase-changed entry', () => {
+    const entry = builder.buildPhaseChanged({ from: 'planning', to: 'executing' });
+    expect(entry.from).toBe('planning');
+    expect(entry.to).toBe('executing');
+  });
+
+  it('builds valid checkpoint-saved entry', () => {
+    const entry = builder.buildCheckpointSaved({ waveIndex: 2, completedTaskCount: 5 });
+    expect(entry.waveIndex).toBe(2);
+    expect(entry.completedTaskCount).toBe(5);
+  });
+
+  it('builds all 10 entry types that pass Zod validation', () => {
+    const entries = [
+      builder.buildTaskStarted(),
+      builder.buildTaskCompleted(),
+      builder.buildTaskFailed(),
+      builder.buildFileWritten(),
+      builder.buildCheckpointSaved(),
+      builder.buildPhaseChanged(),
+      builder.buildArtifactWritten(),
+      builder.buildGuardrailViolation(),
+      builder.buildOverseerIntervention(),
+      builder.buildExecutionLifecycle(),
+    ];
+    for (const entry of entries) {
+      expect(JournalEntrySchema.safeParse({ ...entry, seq: 0 }).success).toBe(true);
+    }
+  });
+});

--- a/tools/src/domain/value-objects/journal-entry.builder.ts
+++ b/tools/src/domain/value-objects/journal-entry.builder.ts
@@ -1,0 +1,226 @@
+import type {
+  ArtifactWrittenEntry,
+  CheckpointSavedEntry,
+  ExecutionLifecycleEntry,
+  FileWrittenEntry,
+  GuardrailViolationEntry,
+  OverseerInterventionEntry,
+  PhaseChangedEntry,
+  TaskCompletedEntry,
+  TaskFailedEntry,
+  TaskStartedEntry,
+} from './journal-entry.js';
+
+export class JournalEntryBuilder {
+  private _sliceId: string = crypto.randomUUID();
+  private _timestamp = new Date().toISOString();
+  private _correlationId: string | undefined = undefined;
+
+  withSliceId(id: string): this {
+    this._sliceId = id;
+    return this;
+  }
+
+  withTimestamp(ts: string): this {
+    this._timestamp = ts;
+    return this;
+  }
+
+  withCorrelationId(id: string): this {
+    this._correlationId = id;
+    return this;
+  }
+
+  buildTaskStarted(
+    overrides?: Partial<{
+      taskId: string;
+      waveIndex: number;
+      agentIdentity: string;
+    }>,
+  ): Omit<TaskStartedEntry, 'seq'> {
+    return {
+      type: 'task-started',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      taskId: overrides?.taskId ?? crypto.randomUUID(),
+      waveIndex: overrides?.waveIndex ?? 0,
+      agentIdentity: overrides?.agentIdentity ?? 'opus',
+    };
+  }
+
+  buildTaskCompleted(
+    overrides?: Partial<{
+      taskId: string;
+      waveIndex: number;
+      durationMs: number;
+      commitHash: string;
+    }>,
+  ): Omit<TaskCompletedEntry, 'seq'> {
+    return {
+      type: 'task-completed',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      taskId: overrides?.taskId ?? crypto.randomUUID(),
+      waveIndex: overrides?.waveIndex ?? 0,
+      durationMs: overrides?.durationMs ?? 1000,
+      commitHash: overrides?.commitHash,
+    };
+  }
+
+  buildTaskFailed(
+    overrides?: Partial<{
+      taskId: string;
+      waveIndex: number;
+      errorCode: string;
+      errorMessage: string;
+      retryable: boolean;
+    }>,
+  ): Omit<TaskFailedEntry, 'seq'> {
+    return {
+      type: 'task-failed',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      taskId: overrides?.taskId ?? crypto.randomUUID(),
+      waveIndex: overrides?.waveIndex ?? 0,
+      errorCode: overrides?.errorCode ?? 'AGENT.FAILURE',
+      errorMessage: overrides?.errorMessage ?? 'Task failed',
+      retryable: overrides?.retryable ?? true,
+    };
+  }
+
+  buildFileWritten(
+    overrides?: Partial<{
+      taskId: string;
+      filePath: string;
+      operation: 'created' | 'modified' | 'deleted';
+    }>,
+  ): Omit<FileWrittenEntry, 'seq'> {
+    return {
+      type: 'file-written',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      taskId: overrides?.taskId ?? crypto.randomUUID(),
+      filePath: overrides?.filePath ?? 'src/test-file.ts',
+      operation: overrides?.operation ?? 'created',
+    };
+  }
+
+  buildCheckpointSaved(
+    overrides?: Partial<{
+      waveIndex: number;
+      completedTaskCount: number;
+    }>,
+  ): Omit<CheckpointSavedEntry, 'seq'> {
+    return {
+      type: 'checkpoint-saved',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      waveIndex: overrides?.waveIndex ?? 0,
+      completedTaskCount: overrides?.completedTaskCount ?? 0,
+    };
+  }
+
+  buildPhaseChanged(
+    overrides?: Partial<{
+      from: string;
+      to: string;
+    }>,
+  ): Omit<PhaseChangedEntry, 'seq'> {
+    return {
+      type: 'phase-changed',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      from: overrides?.from ?? 'planning',
+      to: overrides?.to ?? 'executing',
+    };
+  }
+
+  buildArtifactWritten(
+    overrides?: Partial<{
+      artifactPath: string;
+      artifactType: 'spec' | 'plan' | 'research' | 'checkpoint';
+    }>,
+  ): Omit<ArtifactWrittenEntry, 'seq'> {
+    return {
+      type: 'artifact-written',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      artifactPath: overrides?.artifactPath ?? '.tff/milestones/M01/slices/M01-S04/SPEC.md',
+      artifactType: overrides?.artifactType ?? 'spec',
+    };
+  }
+
+  buildGuardrailViolation(
+    overrides?: Partial<{
+      taskId: string;
+      waveIndex: number;
+      action: 'blocked' | 'warned';
+    }>,
+  ): Omit<GuardrailViolationEntry, 'seq'> {
+    return {
+      type: 'guardrail-violation',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      taskId: overrides?.taskId ?? crypto.randomUUID(),
+      waveIndex: overrides?.waveIndex ?? 0,
+      violations: [
+        {
+          ruleId: 'NO_SECRETS',
+          message: 'Secret detected',
+          severity: 'error',
+        },
+      ],
+      action: overrides?.action ?? 'blocked',
+    };
+  }
+
+  buildOverseerIntervention(
+    overrides?: Partial<{
+      taskId: string;
+      strategy: string;
+      reason: string;
+      action: 'aborted' | 'retrying' | 'escalated';
+      retryCount: number;
+    }>,
+  ): Omit<OverseerInterventionEntry, 'seq'> {
+    return {
+      type: 'overseer-intervention',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      taskId: overrides?.taskId ?? crypto.randomUUID(),
+      strategy: overrides?.strategy ?? 'timeout',
+      reason: overrides?.reason ?? 'Timed out',
+      action: overrides?.action ?? 'aborted',
+      retryCount: overrides?.retryCount ?? 0,
+    };
+  }
+
+  buildExecutionLifecycle(
+    overrides?: Partial<{
+      sessionId: string;
+      action: 'started' | 'paused' | 'resumed' | 'completed' | 'failed';
+      resumeCount: number;
+      failureReason: string;
+    }>,
+  ): Omit<ExecutionLifecycleEntry, 'seq'> {
+    return {
+      type: 'execution-lifecycle',
+      sliceId: this._sliceId,
+      timestamp: this._timestamp,
+      correlationId: this._correlationId,
+      sessionId: overrides?.sessionId ?? crypto.randomUUID(),
+      action: overrides?.action ?? 'started',
+      resumeCount: overrides?.resumeCount ?? 0,
+      failureReason: overrides?.failureReason,
+    };
+  }
+}

--- a/tools/src/domain/value-objects/journal-entry.spec.ts
+++ b/tools/src/domain/value-objects/journal-entry.spec.ts
@@ -15,12 +15,27 @@ describe('JournalEntrySchema', () => {
   });
 
   it('validates task-completed with optional commitHash', () => {
-    const entry = { ...base, type: 'task-completed', taskId: 'T01', waveIndex: 0, durationMs: 1000, commitHash: 'abc123' };
+    const entry = {
+      ...base,
+      type: 'task-completed',
+      taskId: 'T01',
+      waveIndex: 0,
+      durationMs: 1000,
+      commitHash: 'abc123',
+    };
     expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
   });
 
   it('validates task-failed entry', () => {
-    const entry = { ...base, type: 'task-failed', taskId: 'T01', waveIndex: 0, errorCode: 'AGENT.FAILURE', errorMessage: 'fail', retryable: true };
+    const entry = {
+      ...base,
+      type: 'task-failed',
+      taskId: 'T01',
+      waveIndex: 0,
+      errorCode: 'AGENT.FAILURE',
+      errorMessage: 'fail',
+      retryable: true,
+    };
     expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
   });
 
@@ -40,17 +55,37 @@ describe('JournalEntrySchema', () => {
   });
 
   it('validates artifact-written entry', () => {
-    const entry = { ...base, type: 'artifact-written', artifactPath: '.tff/milestones/M01/slices/M01-S04/SPEC.md', artifactType: 'spec' };
+    const entry = {
+      ...base,
+      type: 'artifact-written',
+      artifactPath: '.tff/milestones/M01/slices/M01-S04/SPEC.md',
+      artifactType: 'spec',
+    };
     expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
   });
 
   it('validates guardrail-violation entry', () => {
-    const entry = { ...base, type: 'guardrail-violation', taskId: 'T01', waveIndex: 0, violations: [{ ruleId: 'NO_SECRETS', message: 'Secret detected', severity: 'error' }], action: 'blocked' };
+    const entry = {
+      ...base,
+      type: 'guardrail-violation',
+      taskId: 'T01',
+      waveIndex: 0,
+      violations: [{ ruleId: 'NO_SECRETS', message: 'Secret detected', severity: 'error' }],
+      action: 'blocked',
+    };
     expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
   });
 
   it('validates overseer-intervention entry', () => {
-    const entry = { ...base, type: 'overseer-intervention', taskId: 'T01', strategy: 'timeout', reason: 'Took too long', action: 'aborted', retryCount: 0 };
+    const entry = {
+      ...base,
+      type: 'overseer-intervention',
+      taskId: 'T01',
+      strategy: 'timeout',
+      reason: 'Took too long',
+      action: 'aborted',
+      retryCount: 0,
+    };
     expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
   });
 

--- a/tools/src/domain/value-objects/journal-entry.spec.ts
+++ b/tools/src/domain/value-objects/journal-entry.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { JournalEntrySchema } from './journal-entry.js';
+
+describe('JournalEntrySchema', () => {
+  const base = { seq: 0, sliceId: 'M01-S04', timestamp: new Date().toISOString() };
+
+  it('validates task-started entry', () => {
+    const entry = { ...base, type: 'task-started', taskId: 'T01', waveIndex: 0, agentIdentity: 'opus' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates task-completed entry', () => {
+    const entry = { ...base, type: 'task-completed', taskId: 'T01', waveIndex: 0, durationMs: 1000 };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates task-completed with optional commitHash', () => {
+    const entry = { ...base, type: 'task-completed', taskId: 'T01', waveIndex: 0, durationMs: 1000, commitHash: 'abc123' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates task-failed entry', () => {
+    const entry = { ...base, type: 'task-failed', taskId: 'T01', waveIndex: 0, errorCode: 'AGENT.FAILURE', errorMessage: 'fail', retryable: true };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates file-written entry', () => {
+    const entry = { ...base, type: 'file-written', taskId: 'T01', filePath: 'src/foo.ts', operation: 'created' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates checkpoint-saved entry', () => {
+    const entry = { ...base, type: 'checkpoint-saved', waveIndex: 0, completedTaskCount: 3 };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates phase-changed entry', () => {
+    const entry = { ...base, type: 'phase-changed', from: 'planning', to: 'executing' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates artifact-written entry', () => {
+    const entry = { ...base, type: 'artifact-written', artifactPath: '.tff/milestones/M01/slices/M01-S04/SPEC.md', artifactType: 'spec' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates guardrail-violation entry', () => {
+    const entry = { ...base, type: 'guardrail-violation', taskId: 'T01', waveIndex: 0, violations: [{ ruleId: 'NO_SECRETS', message: 'Secret detected', severity: 'error' }], action: 'blocked' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates overseer-intervention entry', () => {
+    const entry = { ...base, type: 'overseer-intervention', taskId: 'T01', strategy: 'timeout', reason: 'Took too long', action: 'aborted', retryCount: 0 };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates execution-lifecycle entry', () => {
+    const entry = { ...base, type: 'execution-lifecycle', sessionId: 'sess-1', action: 'started', resumeCount: 0 };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('validates optional correlationId', () => {
+    const entry = { ...base, type: 'phase-changed', from: 'a', to: 'b', correlationId: 'corr-1' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('rejects invalid type', () => {
+    const entry = { ...base, type: 'unknown-type' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const entry = { ...base, type: 'task-started' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(false);
+  });
+
+  it('rejects negative seq', () => {
+    const entry = { ...base, seq: -1, type: 'phase-changed', from: 'a', to: 'b' };
+    expect(JournalEntrySchema.safeParse(entry).success).toBe(false);
+  });
+});

--- a/tools/src/domain/value-objects/journal-entry.ts
+++ b/tools/src/domain/value-objects/journal-entry.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+
+const JournalEntryBaseSchema = z.object({
+  seq: z.number().int().min(0),
+  sliceId: z.string().min(1),
+  timestamp: z.string().datetime(),
+  correlationId: z.string().min(1).optional(),
+});
+
+export const TaskStartedEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('task-started'),
+  taskId: z.string().min(1),
+  waveIndex: z.number().int().min(0),
+  agentIdentity: z.string().min(1),
+});
+export type TaskStartedEntry = z.infer<typeof TaskStartedEntrySchema>;
+
+export const TaskCompletedEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('task-completed'),
+  taskId: z.string().min(1),
+  waveIndex: z.number().int().min(0),
+  durationMs: z.number().int().min(0),
+  commitHash: z.string().optional(),
+});
+export type TaskCompletedEntry = z.infer<typeof TaskCompletedEntrySchema>;
+
+export const TaskFailedEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('task-failed'),
+  taskId: z.string().min(1),
+  waveIndex: z.number().int().min(0),
+  errorCode: z.string(),
+  errorMessage: z.string(),
+  retryable: z.boolean(),
+});
+export type TaskFailedEntry = z.infer<typeof TaskFailedEntrySchema>;
+
+export const FileWrittenEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('file-written'),
+  taskId: z.string().min(1),
+  filePath: z.string().min(1),
+  operation: z.enum(['created', 'modified', 'deleted']),
+});
+export type FileWrittenEntry = z.infer<typeof FileWrittenEntrySchema>;
+
+export const CheckpointSavedEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('checkpoint-saved'),
+  waveIndex: z.number().int().min(0),
+  completedTaskCount: z.number().int().min(0),
+});
+export type CheckpointSavedEntry = z.infer<typeof CheckpointSavedEntrySchema>;
+
+export const PhaseChangedEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('phase-changed'),
+  from: z.string(),
+  to: z.string(),
+});
+export type PhaseChangedEntry = z.infer<typeof PhaseChangedEntrySchema>;
+
+export const ArtifactWrittenEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('artifact-written'),
+  artifactPath: z.string().min(1),
+  artifactType: z.enum(['spec', 'plan', 'research', 'checkpoint']),
+});
+export type ArtifactWrittenEntry = z.infer<typeof ArtifactWrittenEntrySchema>;
+
+const GuardrailViolationItemSchema = z.object({
+  ruleId: z.string(),
+  message: z.string(),
+  severity: z.string(),
+});
+
+export const GuardrailViolationEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('guardrail-violation'),
+  taskId: z.string().min(1),
+  waveIndex: z.number().int().min(0),
+  violations: z.array(GuardrailViolationItemSchema),
+  action: z.enum(['blocked', 'warned']),
+});
+export type GuardrailViolationEntry = z.infer<typeof GuardrailViolationEntrySchema>;
+
+export const OverseerInterventionEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('overseer-intervention'),
+  taskId: z.string().min(1),
+  strategy: z.string().min(1),
+  reason: z.string().min(1),
+  action: z.enum(['aborted', 'retrying', 'escalated']),
+  retryCount: z.number().int().min(0),
+});
+export type OverseerInterventionEntry = z.infer<typeof OverseerInterventionEntrySchema>;
+
+export const ExecutionLifecycleEntrySchema = JournalEntryBaseSchema.extend({
+  type: z.literal('execution-lifecycle'),
+  sessionId: z.string().min(1),
+  action: z.enum(['started', 'paused', 'resumed', 'completed', 'failed']),
+  resumeCount: z.number().int().min(0),
+  failureReason: z.string().optional(),
+  wavesCompleted: z.number().int().min(0).optional(),
+  totalWaves: z.number().int().min(0).optional(),
+});
+export type ExecutionLifecycleEntry = z.infer<typeof ExecutionLifecycleEntrySchema>;
+
+export const JournalEntrySchema = z.discriminatedUnion('type', [
+  TaskStartedEntrySchema,
+  TaskCompletedEntrySchema,
+  TaskFailedEntrySchema,
+  FileWrittenEntrySchema,
+  CheckpointSavedEntrySchema,
+  PhaseChangedEntrySchema,
+  ArtifactWrittenEntrySchema,
+  GuardrailViolationEntrySchema,
+  OverseerInterventionEntrySchema,
+  ExecutionLifecycleEntrySchema,
+]);
+export type JournalEntry = z.infer<typeof JournalEntrySchema>;

--- a/tools/src/infrastructure/adapters/event-bus/simple-event-bus.spec.ts
+++ b/tools/src/infrastructure/adapters/event-bus/simple-event-bus.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDomainEvent } from '../../../domain/events/domain-event.js';
+import { SimpleEventBus } from './simple-event-bus.js';
+
+describe('SimpleEventBus', () => {
+  it('delivers event to subscriber', () => {
+    const bus = new SimpleEventBus();
+    const handler = vi.fn();
+    bus.subscribe('SLICE_STATUS_CHANGED', handler);
+    const event = createDomainEvent('SLICE_STATUS_CHANGED', { sliceId: 'M01-S04', from: 'planning', to: 'executing' });
+    bus.publish(event);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  it('delivers to multiple subscribers for same event', () => {
+    const bus = new SimpleEventBus();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    bus.subscribe('TASK_COMPLETED', h1);
+    bus.subscribe('TASK_COMPLETED', h2);
+    const event = createDomainEvent('TASK_COMPLETED', { taskId: 'T01', sliceId: 'M01-S04', executor: 'opus' });
+    bus.publish(event);
+    expect(h1).toHaveBeenCalledOnce();
+    expect(h2).toHaveBeenCalledOnce();
+  });
+
+  it('does not deliver to unsubscribed event types', () => {
+    const bus = new SimpleEventBus();
+    const handler = vi.fn();
+    bus.subscribe('TASK_COMPLETED', handler);
+    const event = createDomainEvent('SLICE_STATUS_CHANGED', { sliceId: 'M01-S04', from: 'a', to: 'b' });
+    bus.publish(event);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when publishing with no subscribers', () => {
+    const bus = new SimpleEventBus();
+    const event = createDomainEvent('SYNC_CONFLICT', { entityId: 'x', field: 'y', winner: 'markdown' });
+    expect(() => bus.publish(event)).not.toThrow();
+  });
+});

--- a/tools/src/infrastructure/adapters/event-bus/simple-event-bus.ts
+++ b/tools/src/infrastructure/adapters/event-bus/simple-event-bus.ts
@@ -1,0 +1,18 @@
+import type { DomainEvent, DomainEventType } from '../../../domain/events/domain-event.js';
+import type { EventBus } from '../../../domain/ports/event-bus.port.js';
+
+export class SimpleEventBus implements EventBus {
+  private handlers = new Map<DomainEventType, Array<(event: DomainEvent) => void>>();
+
+  publish(event: DomainEvent): void {
+    const handlers = this.handlers.get(event.type) ?? [];
+    for (const handler of handlers) {
+      handler(event);
+    }
+  }
+
+  subscribe(type: DomainEventType, handler: (event: DomainEvent) => void): void {
+    const existing = this.handlers.get(type) ?? [];
+    this.handlers.set(type, [...existing, handler]);
+  }
+}

--- a/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.spec.ts
+++ b/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.spec.ts
@@ -64,3 +64,7 @@ describe('JsonlJournalAdapter — adapter-specific', () => {
     expect(isOk(result)).toBe(true);
   });
 });
+
+import { runJournalContractTests } from '../../../domain/ports/journal-repository.contract.spec.js';
+
+runJournalContractTests('JsonlJournalAdapter', () => new JsonlJournalAdapter(basePath));

--- a/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.spec.ts
+++ b/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.spec.ts
@@ -1,0 +1,66 @@
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isOk } from '../../../domain/result.js';
+import { JournalEntryBuilder } from '../../../domain/value-objects/journal-entry.builder.js';
+import { JsonlJournalAdapter } from './jsonl-journal.adapter.js';
+
+let basePath: string;
+
+beforeAll(() => {
+  basePath = mkdtempSync(join(tmpdir(), 'tff-journal-'));
+});
+
+afterAll(() => {
+  rmSync(basePath, { recursive: true, force: true });
+});
+
+describe('JsonlJournalAdapter — adapter-specific', () => {
+  it('survives process restart (AC1)', () => {
+    const sliceId = crypto.randomUUID();
+    const builder = new JournalEntryBuilder().withSliceId(sliceId);
+    const repo1 = new JsonlJournalAdapter(basePath);
+    repo1.append(sliceId, builder.buildPhaseChanged());
+    const repo2 = new JsonlJournalAdapter(basePath);
+    const result = repo2.readAll(sliceId);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.data).toHaveLength(1);
+  });
+
+  it('skips corrupt lines and returns valid entries (AC7)', () => {
+    const sliceId = crypto.randomUUID();
+    const builder = new JournalEntryBuilder().withSliceId(sliceId);
+    const repo = new JsonlJournalAdapter(basePath);
+    repo.append(sliceId, builder.buildPhaseChanged());
+    appendFileSync(join(basePath, `${sliceId}.jsonl`), '{truncated\n', 'utf-8');
+    repo.append(sliceId, builder.buildPhaseChanged({ from: 'executing', to: 'verifying' }));
+    const result = repo.readAll(sliceId);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.data.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns empty array for missing file (AC12)', () => {
+    const repo = new JsonlJournalAdapter(basePath);
+    const result = repo.readAll('nonexistent-slice');
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.data).toHaveLength(0);
+  });
+
+  it('returns empty array for empty file (AC12)', () => {
+    const sliceId = crypto.randomUUID();
+    writeFileSync(join(basePath, `${sliceId}.jsonl`), '', 'utf-8');
+    const repo = new JsonlJournalAdapter(basePath);
+    const result = repo.readAll(sliceId);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.data).toHaveLength(0);
+  });
+
+  it('auto-creates directory on first append (AC11)', () => {
+    const nestedPath = join(basePath, 'nested', 'dir');
+    const repo = new JsonlJournalAdapter(nestedPath);
+    const builder = new JournalEntryBuilder().withSliceId('test');
+    const result = repo.append('test', builder.buildPhaseChanged());
+    expect(isOk(result)).toBe(true);
+  });
+});

--- a/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.ts
+++ b/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.ts
@@ -24,12 +24,15 @@ export class JsonlJournalAdapter implements JournalRepository {
     const countResult = this.count(sliceId);
     if (!countResult.ok) return countResult;
     const seq = countResult.data;
-    const fullEntry = { ...entry, seq };
+    const fullEntry = JournalEntrySchema.parse({ ...entry, seq });
     try {
       mkdirSync(this.basePath, { recursive: true });
       appendFileSync(this.filePath(sliceId), `${JSON.stringify(fullEntry)}\n`, 'utf-8');
       return Ok(seq);
     } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'ZodError') {
+        return Err(createDomainError('JOURNAL_WRITE_FAILED', `Invalid journal entry: ${error.message}`));
+      }
       return Err(createDomainError('JOURNAL_WRITE_FAILED', error instanceof Error ? error.message : String(error)));
     }
   }

--- a/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.ts
+++ b/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.ts
@@ -1,0 +1,80 @@
+import { appendFileSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DomainError } from '../../../domain/errors/domain-error.js';
+import { createDomainError } from '../../../domain/errors/domain-error.js';
+import type { JournalRepository } from '../../../domain/ports/journal-repository.port.js';
+import { Err, Ok, type Result } from '../../../domain/result.js';
+import { type JournalEntry, JournalEntrySchema } from '../../../domain/value-objects/journal-entry.js';
+
+function isNodeError(error: unknown): error is Error & { code: string } {
+  if (!(error instanceof Error)) return false;
+  if (!('code' in error)) return false;
+  const descriptor = Object.getOwnPropertyDescriptor(error, 'code');
+  return descriptor !== undefined && typeof descriptor.value === 'string';
+}
+
+export class JsonlJournalAdapter implements JournalRepository {
+  constructor(private readonly basePath: string) {}
+
+  private filePath(sliceId: string): string {
+    return join(this.basePath, `${sliceId}.jsonl`);
+  }
+
+  append(sliceId: string, entry: Omit<JournalEntry, 'seq'>): Result<number, DomainError> {
+    const countResult = this.count(sliceId);
+    if (!countResult.ok) return countResult;
+    const seq = countResult.data;
+    const fullEntry = { ...entry, seq };
+    try {
+      mkdirSync(this.basePath, { recursive: true });
+      appendFileSync(this.filePath(sliceId), `${JSON.stringify(fullEntry)}\n`, 'utf-8');
+      return Ok(seq);
+    } catch (error: unknown) {
+      return Err(createDomainError('JOURNAL_WRITE_FAILED', error instanceof Error ? error.message : String(error)));
+    }
+  }
+
+  readAll(sliceId: string): Result<readonly JournalEntry[], DomainError> {
+    let content: string;
+    try {
+      content = readFileSync(this.filePath(sliceId), 'utf-8');
+    } catch (error: unknown) {
+      if (isNodeError(error) && error.code === 'ENOENT') return Ok([]);
+      return Err(createDomainError('JOURNAL_READ_FAILED', error instanceof Error ? error.message : String(error)));
+    }
+    const lines = content.split('\n').filter((l) => l.trim());
+    const entries: JournalEntry[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      try {
+        const raw: unknown = JSON.parse(lines[i]);
+        entries.push(JournalEntrySchema.parse(raw));
+      } catch {
+        // Skip corrupt lines
+      }
+    }
+    return Ok(entries);
+  }
+
+  readSince(sliceId: string, afterSeq: number): Result<readonly JournalEntry[], DomainError> {
+    const result = this.readAll(sliceId);
+    if (!result.ok) return result;
+    return Ok(result.data.filter((e) => e.seq > afterSeq));
+  }
+
+  count(sliceId: string): Result<number, DomainError> {
+    const result = this.readAll(sliceId);
+    if (!result.ok) return result;
+    return Ok(result.data.length);
+  }
+
+  reset(): void {
+    try {
+      const files = readdirSync(this.basePath);
+      for (const file of files) {
+        if (file.endsWith('.jsonl')) unlinkSync(join(this.basePath, file));
+      }
+    } catch {
+      /* basePath doesn't exist yet */
+    }
+  }
+}

--- a/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.ts
+++ b/tools/src/infrastructure/adapters/journal/jsonl-journal.adapter.ts
@@ -24,8 +24,8 @@ export class JsonlJournalAdapter implements JournalRepository {
     const countResult = this.count(sliceId);
     if (!countResult.ok) return countResult;
     const seq = countResult.data;
-    const fullEntry = JournalEntrySchema.parse({ ...entry, seq });
     try {
+      const fullEntry = JournalEntrySchema.parse({ ...entry, seq });
       mkdirSync(this.basePath, { recursive: true });
       appendFileSync(this.filePath(sliceId), `${JSON.stringify(fullEntry)}\n`, 'utf-8');
       return Ok(seq);

--- a/tools/src/infrastructure/testing/in-memory-journal.adapter.spec.ts
+++ b/tools/src/infrastructure/testing/in-memory-journal.adapter.spec.ts
@@ -13,3 +13,7 @@ describe('InMemoryJournalAdapter', () => {
     expect(typeof adapter.reset).toBe('function');
   });
 });
+
+import { runJournalContractTests } from '../../domain/ports/journal-repository.contract.spec.js';
+
+runJournalContractTests('InMemoryJournalAdapter', () => new InMemoryJournalAdapter());

--- a/tools/src/infrastructure/testing/in-memory-journal.adapter.spec.ts
+++ b/tools/src/infrastructure/testing/in-memory-journal.adapter.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryJournalAdapter } from './in-memory-journal.adapter.js';
+
+describe('InMemoryJournalAdapter', () => {
+  it('can be instantiated', () => {
+    const adapter = new InMemoryJournalAdapter();
+    expect(adapter).toBeDefined();
+  });
+
+  it('has seed and reset methods', () => {
+    const adapter = new InMemoryJournalAdapter();
+    expect(typeof adapter.seed).toBe('function');
+    expect(typeof adapter.reset).toBe('function');
+  });
+});

--- a/tools/src/infrastructure/testing/in-memory-journal.adapter.ts
+++ b/tools/src/infrastructure/testing/in-memory-journal.adapter.ts
@@ -1,0 +1,38 @@
+import type { DomainError } from '../../domain/errors/domain-error.js';
+import type { JournalRepository } from '../../domain/ports/journal-repository.port.js';
+import type { Result } from '../../domain/result.js';
+import { Ok } from '../../domain/result.js';
+import { JournalEntrySchema, type JournalEntry } from '../../domain/value-objects/journal-entry.js';
+
+export class InMemoryJournalAdapter implements JournalRepository {
+  private store = new Map<string, JournalEntry[]>();
+
+  append(sliceId: string, entry: Omit<JournalEntry, 'seq'>): Result<number, DomainError> {
+    const entries = this.store.get(sliceId) ?? [];
+    const seq = entries.length;
+    const fullEntry = JournalEntrySchema.parse({ ...entry, seq });
+    this.store.set(sliceId, [...entries, fullEntry]);
+    return Ok(seq);
+  }
+
+  readAll(sliceId: string): Result<readonly JournalEntry[], DomainError> {
+    return Ok(this.store.get(sliceId) ?? []);
+  }
+
+  readSince(sliceId: string, afterSeq: number): Result<readonly JournalEntry[], DomainError> {
+    const entries = this.store.get(sliceId) ?? [];
+    return Ok(entries.filter((e) => e.seq > afterSeq));
+  }
+
+  count(sliceId: string): Result<number, DomainError> {
+    return Ok((this.store.get(sliceId) ?? []).length);
+  }
+
+  seed(sliceId: string, entries: JournalEntry[]): void {
+    this.store.set(sliceId, entries);
+  }
+
+  reset(): void {
+    this.store.clear();
+  }
+}

--- a/tools/src/infrastructure/testing/in-memory-journal.adapter.ts
+++ b/tools/src/infrastructure/testing/in-memory-journal.adapter.ts
@@ -2,7 +2,7 @@ import type { DomainError } from '../../domain/errors/domain-error.js';
 import type { JournalRepository } from '../../domain/ports/journal-repository.port.js';
 import type { Result } from '../../domain/result.js';
 import { Ok } from '../../domain/result.js';
-import { JournalEntrySchema, type JournalEntry } from '../../domain/value-objects/journal-entry.js';
+import { type JournalEntry, JournalEntrySchema } from '../../domain/value-objects/journal-entry.js';
 
 export class InMemoryJournalAdapter implements JournalRepository {
   private store = new Map<string, JournalEntry[]>();


### PR DESCRIPTION
## Summary

- Append-only per-slice JSONL journal with 10 entry types (Zod discriminated union)
- `JournalRepository` port (sync) with `JsonlJournalAdapter` + `InMemoryJournalAdapter`
- `EventBus` port with `SimpleEventBus` implementation
- `JournalEventHandler` maps `SLICE_STATUS_CHANGED` → `phase-changed` journal entries
- `ReplayJournal` use case validates checkpoint consistency against journal
- `transitionSlice` wired to publish events via optional `EventBus`

## Files

- 14 new files (ports, adapters, use cases, tests, builder)
- 3 modified files (error codes, transition-slice, domain index)
- 1130 tests pass, 0 failures

## Acceptance Criteria

All 13 ACs verified: JSONL persistence (AC1), monotonic seq (AC2), replay inconsistency detection (AC3-4), EventBus delivery (AC5), Zod validation at write time (AC6), corruption resilience (AC7), contract tests (AC8), readSince filtering (AC9), ObservationStore independence (AC10), directory auto-creation (AC11), empty file handling (AC12), transitionSlice EventBus wiring (AC13).

## Test plan

- [x] Full test suite passes (1130 tests)
- [x] Contract tests pass for both JSONL and InMemory adapters
- [x] Spec review: APPROVE
- [x] Code review: APPROVE (after fixes)
- [x] Security audit: APPROVE (2 MEDIUM for follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)