### PR TITLE
feat(M01-S05): Post-Checkout Hook + Restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ docs/
 .dolt/
 *.db
 .beads/
-.worktrees/branch-meta.json
+.worktrees/
+/branch-meta.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ docs/
 .dolt/
 *.db
 .beads/
-.worktrees/
+.worktrees/branch-meta.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
+        "proper-lockfile": "^4.1.2",
         "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.5.0",
+        "@types/proper-lockfile": "^4.1.4",
         "fast-check": "^4.6.0",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
@@ -1406,6 +1408,23 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -1942,6 +1961,12 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2560,6 +2585,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -2638,6 +2674,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rolldown": {
@@ -2756,6 +2801,12 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/simple-concat": {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
   "author": "MonsieurBarti",
   "dependencies": {
     "better-sqlite3": "^12.8.0",
+    "proper-lockfile": "^4.1.2",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.5.0",
+    "@types/proper-lockfile": "^4.1.4",
     "fast-check": "^4.6.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",

--- a/tools/src/cli/commands/claim-check-stale.cmd.ts
+++ b/tools/src/cli/commands/claim-check-stale.cmd.ts
@@ -1,6 +1,6 @@
 import { checkStaleClaims } from '../../application/claims/check-stale-claims.js';
 import { isOk } from '../../domain/result.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const claimCheckStaleCmd = async (args: string[]): Promise<string> => {
   const ttlMinutes = args[0] ? parseInt(args[0], 10) : 30;
@@ -10,20 +10,21 @@ export const claimCheckStaleCmd = async (args: string[]): Promise<string> => {
       error: { code: 'INVALID_ARGS', message: 'Usage: claim:check-stale [ttl-minutes]' },
     });
   }
-  const { taskStore } = createStateStores();
-  const result = await checkStaleClaims({ ttlMinutes }, { taskStore });
-  if (isOk(result)) {
-    return JSON.stringify({
-      ok: true,
-      data: {
-        staleClaims: result.data.staleClaims.map((t) => ({
-          id: t.id,
-          title: t.title,
-          claimedAt: t.claimedAt,
-        })),
-        count: result.data.staleClaims.length,
-      },
-    });
-  }
-  return JSON.stringify({ ok: false, error: result.error });
+  return withBranchGuard(async ({ taskStore }) => {
+    const result = await checkStaleClaims({ ttlMinutes }, { taskStore });
+    if (isOk(result)) {
+      return JSON.stringify({
+        ok: true,
+        data: {
+          staleClaims: result.data.staleClaims.map((t) => ({
+            id: t.id,
+            title: t.title,
+            claimedAt: t.claimedAt,
+          })),
+          count: result.data.staleClaims.length,
+        },
+      });
+    }
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/hook-post-checkout.cmd.spec.ts
+++ b/tools/src/cli/commands/hook-post-checkout.cmd.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { hookPostCheckoutCmd } from './hook-post-checkout.cmd.js';
+
+describe('hookPostCheckoutCmd', () => {
+  it('returns INVALID_ARGS when no branch provided', async () => {
+    const result = JSON.parse(await hookPostCheckoutCmd([]));
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe('INVALID_ARGS');
+  });
+});

--- a/tools/src/cli/commands/hook-post-checkout.cmd.ts
+++ b/tools/src/cli/commands/hook-post-checkout.cmd.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { restoreBranchUseCase } from '../../application/state-branch/restore-branch.js';
+import { isOk } from '../../domain/result.js';
+import { BranchMetaSchema } from '../../domain/value-objects/branch-meta.js';
+import { GitCliAdapter } from '../../infrastructure/adapters/git/git-cli.adapter.js';
+import { GitStateBranchAdapter } from '../../infrastructure/adapters/git/git-state-branch.adapter.js';
+import { readLocalStamp, writeLocalStamp, writeSyntheticStamp } from '../../infrastructure/hooks/branch-meta-stamp.js';
+import { acquireRestoreLock } from '../../infrastructure/locking/tff-lock.js';
+
+export const hookPostCheckoutCmd = async (args: string[]): Promise<string> => {
+  const [codeBranch] = args;
+  if (!codeBranch) {
+    return JSON.stringify({
+      ok: false,
+      error: { code: 'INVALID_ARGS', message: 'Usage: hook:post-checkout <branch>' },
+    });
+  }
+
+  const cwd = process.cwd();
+  const tffDir = path.join(cwd, '.tff');
+
+  try {
+    // 1. Check if state branch exists
+    const gitOps = new GitCliAdapter(cwd);
+    const stateBranch = new GitStateBranchAdapter(gitOps, cwd);
+    const existsResult = await stateBranch.exists(codeBranch);
+    if (!isOk(existsResult) || !existsResult.data) {
+      return JSON.stringify({
+        ok: true,
+        data: { action: 'skipped', reason: `No state branch for "${codeBranch}"` },
+      });
+    }
+
+    // 2. Check if stamp already matches
+    const stamp = readLocalStamp(tffDir);
+    if (stamp && stamp.codeBranch === codeBranch) {
+      return JSON.stringify({
+        ok: true,
+        data: { action: 'skipped', reason: 'Stamp already matches current branch' },
+      });
+    }
+
+    // 3. Acquire exclusive lock (timeout 5s)
+    const dbPath = path.join(tffDir, 'state.db');
+    let release: (() => Promise<void>) | null = null;
+    if (existsSync(dbPath)) {
+      release = await acquireRestoreLock(dbPath, 5000);
+      if (!release) {
+        return JSON.stringify({
+          ok: true,
+          data: { action: 'skipped', reason: 'Lock held by another process' },
+        });
+      }
+    }
+
+    try {
+      // 4. Restore
+      const result = await restoreBranchUseCase({ codeBranch, targetDir: cwd }, { stateBranch });
+
+      if (!isOk(result) || result.data === null) {
+        writeSyntheticStamp(tffDir, codeBranch);
+        return JSON.stringify({
+          ok: true,
+          data: { action: 'skipped', reason: 'Restore returned null' },
+        });
+      }
+
+      // 5. Write stamp — read stateId from root-level branch-meta.json
+      const rootMetaPath = path.join(cwd, 'branch-meta.json');
+      try {
+        if (existsSync(rootMetaPath)) {
+          const raw = JSON.parse(readFileSync(rootMetaPath, 'utf8'));
+          const meta = BranchMetaSchema.parse(raw);
+          writeLocalStamp(tffDir, {
+            stateId: meta.stateId,
+            codeBranch,
+            parentStateBranch: meta.parentStateBranch,
+            createdAt: meta.createdAt,
+          });
+        } else {
+          writeSyntheticStamp(tffDir, codeBranch);
+        }
+      } catch {
+        writeSyntheticStamp(tffDir, codeBranch);
+      }
+
+      return JSON.stringify({
+        ok: true,
+        data: { action: 'restored', filesRestored: result.data.filesRestored },
+      });
+    } finally {
+      if (release) await release();
+    }
+  } catch (e) {
+    // Hook should never fail — always return ok
+    return JSON.stringify({
+      ok: true,
+      data: { action: 'error', reason: String(e) },
+    });
+  }
+};

--- a/tools/src/cli/commands/milestone-create.cmd.ts
+++ b/tools/src/cli/commands/milestone-create.cmd.ts
@@ -2,7 +2,7 @@ import { createMilestoneUseCase } from '../../application/milestone/create-miles
 import { isOk } from '../../domain/result.js';
 import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js';
 import { GitCliAdapter } from '../../infrastructure/adapters/git/git-cli.adapter.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const milestoneCreateCmd = async (args: string[]): Promise<string> => {
   const name = args[0];
@@ -11,19 +11,20 @@ export const milestoneCreateCmd = async (args: string[]): Promise<string> => {
     return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Usage: milestone:create <name>' } });
   }
 
-  const { milestoneStore } = createStateStores();
-  const artifactStore = new MarkdownArtifactAdapter(process.cwd());
-  const gitOps = new GitCliAdapter(process.cwd());
+  return withBranchGuard(async ({ milestoneStore }) => {
+    const artifactStore = new MarkdownArtifactAdapter(process.cwd());
+    const gitOps = new GitCliAdapter(process.cwd());
 
-  // Auto-number: count existing milestones and increment
-  const milestonesResult = milestoneStore.listMilestones();
-  if (!isOk(milestonesResult)) {
-    return JSON.stringify({ ok: false, error: milestonesResult.error });
-  }
-  const number = milestonesResult.data.length + 1;
+    // Auto-number: count existing milestones and increment
+    const milestonesResult = milestoneStore.listMilestones();
+    if (!isOk(milestonesResult)) {
+      return JSON.stringify({ ok: false, error: milestonesResult.error });
+    }
+    const number = milestonesResult.data.length + 1;
 
-  const result = await createMilestoneUseCase({ name, number }, { milestoneStore, artifactStore, gitOps });
+    const result = await createMilestoneUseCase({ name, number }, { milestoneStore, artifactStore, gitOps });
 
-  if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
-  return JSON.stringify({ ok: false, error: result.error });
+    if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/milestone-list.cmd.ts
+++ b/tools/src/cli/commands/milestone-list.cmd.ts
@@ -1,10 +1,11 @@
 import { listMilestones } from '../../application/milestone/list-milestones.js';
 import { isOk } from '../../domain/result.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const milestoneListCmd = async (_args: string[]): Promise<string> => {
-  const { milestoneStore } = createStateStores();
-  const result = await listMilestones({ milestoneStore });
-  if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
-  return JSON.stringify({ ok: false, error: result.error });
+  return withBranchGuard(async ({ milestoneStore }) => {
+    const result = await listMilestones({ milestoneStore });
+    if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/project-get.cmd.ts
+++ b/tools/src/cli/commands/project-get.cmd.ts
@@ -1,18 +1,19 @@
 import { getProject } from '../../application/project/get-project.js';
 import { isOk } from '../../domain/result.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const projectGetCmd = async (_args: string[]): Promise<string> => {
-  const { projectStore } = createStateStores();
-  const result = await getProject({ projectStore });
-  if (isOk(result)) {
-    if (result.data === null) {
-      return JSON.stringify({
-        ok: false,
-        error: { code: 'NOT_FOUND', message: 'No tff project found. Run /tff:new first.' },
-      });
+  return withBranchGuard(async ({ projectStore }) => {
+    const result = await getProject({ projectStore });
+    if (isOk(result)) {
+      if (result.data === null) {
+        return JSON.stringify({
+          ok: false,
+          error: { code: 'NOT_FOUND', message: 'No tff project found. Run /tff:new first.' },
+        });
+      }
+      return JSON.stringify({ ok: true, data: result.data });
     }
-    return JSON.stringify({ ok: true, data: result.data });
-  }
-  return JSON.stringify({ ok: false, error: result.error });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/project-init.cmd.ts
+++ b/tools/src/cli/commands/project-init.cmd.ts
@@ -2,6 +2,7 @@ import { initProject } from '../../application/project/init-project.js';
 import { isOk } from '../../domain/result.js';
 import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js';
 import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { installPostCheckoutHook } from '../../infrastructure/hooks/install-post-checkout.js';
 
 export const projectInitCmd = async (args: string[]): Promise<string> => {
   const name = args[0];
@@ -15,6 +16,13 @@ export const projectInitCmd = async (args: string[]): Promise<string> => {
   const artifactStore = new MarkdownArtifactAdapter(process.cwd());
 
   const result = await initProject({ name, vision }, { projectStore, artifactStore });
-  if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
+  if (isOk(result)) {
+    try {
+      installPostCheckoutHook(process.cwd());
+    } catch {
+      // Hook installation is best-effort
+    }
+    return JSON.stringify({ ok: true, data: result.data });
+  }
   return JSON.stringify({ ok: false, error: result.error });
 };

--- a/tools/src/cli/commands/review-check-fresh.cmd.ts
+++ b/tools/src/cli/commands/review-check-fresh.cmd.ts
@@ -1,6 +1,6 @@
 import { enforceFreshReviewer } from '../../application/review/enforce-fresh-reviewer.js';
 import { isOk } from '../../domain/result.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const reviewCheckFreshCmd = async (args: string[]): Promise<string> => {
   const [sliceId, agent] = args;
@@ -9,8 +9,9 @@ export const reviewCheckFreshCmd = async (args: string[]): Promise<string> => {
       ok: false,
       error: { code: 'INVALID_ARGS', message: 'Usage: review:check-fresh <slice-id> <agent>' },
     });
-  const { taskStore, reviewStore } = createStateStores();
-  const result = await enforceFreshReviewer({ sliceId, reviewerAgent: agent }, { taskStore, reviewStore });
-  if (isOk(result)) return JSON.stringify({ ok: true, data: null });
-  return JSON.stringify({ ok: false, error: result.error });
+  return withBranchGuard(async ({ taskStore, reviewStore }) => {
+    const result = await enforceFreshReviewer({ sliceId, reviewerAgent: agent }, { taskStore, reviewStore });
+    if (isOk(result)) return JSON.stringify({ ok: true, data: null });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/review-record.cmd.ts
+++ b/tools/src/cli/commands/review-record.cmd.ts
@@ -1,7 +1,7 @@
 import { recordReviewUseCase } from '../../application/review/record-review.js';
 import { isOk } from '../../domain/result.js';
 import { ReviewTypeSchema } from '../../domain/value-objects/review-record.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const reviewRecordCmd = async (args: string[]): Promise<string> => {
   const [sliceId, agent, verdict, type, commitSha] = args;
@@ -28,17 +28,18 @@ export const reviewRecordCmd = async (args: string[]): Promise<string> => {
       error: { code: 'INVALID_ARGS', message: `Invalid verdict "${verdict}". Must be: approved, changes_requested` },
     });
   }
-  const { reviewStore } = createStateStores();
-  const result = await recordReviewUseCase(
-    {
-      sliceId,
-      reviewer: agent,
-      verdict: verdict as 'approved' | 'changes_requested',
-      type: parsedType.data,
-      commitSha,
-    },
-    { reviewStore },
-  );
-  if (isOk(result)) return JSON.stringify({ ok: true, data: null });
-  return JSON.stringify({ ok: false, error: result.error });
+  return withBranchGuard(async ({ reviewStore }) => {
+    const result = await recordReviewUseCase(
+      {
+        sliceId,
+        reviewer: agent,
+        verdict: verdict as 'approved' | 'changes_requested',
+        type: parsedType.data,
+        commitSha,
+      },
+      { reviewStore },
+    );
+    if (isOk(result)) return JSON.stringify({ ok: true, data: null });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/slice-create.cmd.ts
+++ b/tools/src/cli/commands/slice-create.cmd.ts
@@ -47,7 +47,10 @@ export const sliceCreateCmd = async (args: string[]): Promise<string> => {
         : milestonesResult.data[milestonesResult.data.length - 1];
     const milestoneId = milestone.id;
 
-    const result = await createSliceUseCase({ milestoneId, title: name }, { milestoneStore, sliceStore, artifactStore });
+    const result = await createSliceUseCase(
+      { milestoneId, title: name },
+      { milestoneStore, sliceStore, artifactStore },
+    );
 
     if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
     return JSON.stringify({ ok: false, error: result.error });

--- a/tools/src/cli/commands/slice-create.cmd.ts
+++ b/tools/src/cli/commands/slice-create.cmd.ts
@@ -1,7 +1,7 @@
 import { createSliceUseCase } from '../../application/slice/create-slice.js';
 import { isOk } from '../../domain/result.js';
 import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const sliceCreateCmd = async (args: string[]): Promise<string> => {
   // Parse --title flag or fall back to positional arg
@@ -28,27 +28,28 @@ export const sliceCreateCmd = async (args: string[]): Promise<string> => {
     });
   }
 
-  const { milestoneStore, sliceStore } = createStateStores();
-  const artifactStore = new MarkdownArtifactAdapter(process.cwd());
+  return withBranchGuard(async ({ milestoneStore, sliceStore }) => {
+    const artifactStore = new MarkdownArtifactAdapter(process.cwd());
 
-  // Auto-detect active milestone (most recent open one)
-  const milestonesResult = milestoneStore.listMilestones();
-  if (!isOk(milestonesResult) || milestonesResult.data.length === 0) {
-    return JSON.stringify({
-      ok: false,
-      error: { code: 'NOT_FOUND', message: 'No milestone found. Run /tff:new-milestone first.' },
-    });
-  }
-  // Use the last open milestone, or the last one if none are open
-  const openMilestones = milestonesResult.data.filter((m) => m.status !== 'closed');
-  const milestone =
-    openMilestones.length > 0
-      ? openMilestones[openMilestones.length - 1]
-      : milestonesResult.data[milestonesResult.data.length - 1];
-  const milestoneId = milestone.id;
+    // Auto-detect active milestone (most recent open one)
+    const milestonesResult = milestoneStore.listMilestones();
+    if (!isOk(milestonesResult) || milestonesResult.data.length === 0) {
+      return JSON.stringify({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: 'No milestone found. Run /tff:new-milestone first.' },
+      });
+    }
+    // Use the last open milestone, or the last one if none are open
+    const openMilestones = milestonesResult.data.filter((m) => m.status !== 'closed');
+    const milestone =
+      openMilestones.length > 0
+        ? openMilestones[openMilestones.length - 1]
+        : milestonesResult.data[milestonesResult.data.length - 1];
+    const milestoneId = milestone.id;
 
-  const result = await createSliceUseCase({ milestoneId, title: name }, { milestoneStore, sliceStore, artifactStore });
+    const result = await createSliceUseCase({ milestoneId, title: name }, { milestoneStore, sliceStore, artifactStore });
 
-  if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
-  return JSON.stringify({ ok: false, error: result.error });
+    if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -36,7 +36,10 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
 
       // Auto-regenerate STATE.md (non-critical)
       try {
-        await generateState({ milestoneId: slice.milestoneId }, { milestoneStore, sliceStore, taskStore, artifactStore });
+        await generateState(
+          { milestoneId: slice.milestoneId },
+          { milestoneStore, sliceStore, taskStore, artifactStore },
+        );
       } catch (e) {
         const msg = `state sync failed: ${String(e)}`;
         tffWarn(msg);

--- a/tools/src/cli/commands/slice-transition.cmd.ts
+++ b/tools/src/cli/commands/slice-transition.cmd.ts
@@ -7,10 +7,8 @@ import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesyste
 import { GitCliAdapter } from '../../infrastructure/adapters/git/git-cli.adapter.js';
 import { GitStateBranchAdapter } from '../../infrastructure/adapters/git/git-state-branch.adapter.js';
 import { tffWarn } from '../../infrastructure/adapters/logging/warn.js';
-import {
-  createClosableStateStores,
-  createStateStores,
-} from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { createClosableStateStoresUnchecked } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
   const [sliceId, targetStatus] = args;
@@ -27,71 +25,72 @@ export const sliceTransitionCmd = async (args: string[]): Promise<string> => {
     return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: `Invalid status: ${targetStatus}` } });
   }
 
-  const { sliceStore, milestoneStore, taskStore } = createStateStores();
-  const artifactStore = new MarkdownArtifactAdapter(process.cwd());
+  return withBranchGuard(async ({ sliceStore, milestoneStore, taskStore }) => {
+    const artifactStore = new MarkdownArtifactAdapter(process.cwd());
 
-  const result = await transitionSliceUseCase({ sliceId, targetStatus: targetStatus as SliceStatus }, { sliceStore });
+    const result = await transitionSliceUseCase({ sliceId, targetStatus: targetStatus as SliceStatus }, { sliceStore });
 
-  if (isOk(result)) {
-    const warnings: string[] = [];
-    const { slice } = result.data;
+    if (isOk(result)) {
+      const warnings: string[] = [];
+      const { slice } = result.data;
 
-    // Auto-regenerate STATE.md (non-critical)
-    try {
-      await generateState({ milestoneId: slice.milestoneId }, { milestoneStore, sliceStore, taskStore, artifactStore });
-    } catch (e) {
-      const msg = `state sync failed: ${String(e)}`;
-      tffWarn(msg);
-      warnings.push(msg);
-    }
-
-    // Auto-sync state branch (S03)
-    try {
-      const closableStores = createClosableStateStores();
+      // Auto-regenerate STATE.md (non-critical)
       try {
-        closableStores.checkpoint();
-      } finally {
-        closableStores.close();
+        await generateState({ milestoneId: slice.milestoneId }, { milestoneStore, sliceStore, taskStore, artifactStore });
+      } catch (e) {
+        const msg = `state sync failed: ${String(e)}`;
+        tffWarn(msg);
+        warnings.push(msg);
       }
-      const gitOps = new GitCliAdapter(process.cwd());
-      const stateBranchAdapter = new GitStateBranchAdapter(gitOps, process.cwd());
-      const branchR = await gitOps.getCurrentBranch();
-      if (isOk(branchR)) {
-        const existsR = await stateBranchAdapter.exists(branchR.data);
-        if (isOk(existsR) && existsR.data) {
-          await syncBranchUseCase(
-            { codeBranch: branchR.data, message: `sync: ${sliceId} -> ${targetStatus}` },
-            { stateBranch: stateBranchAdapter },
-          );
+
+      // Auto-sync state branch (S03)
+      try {
+        const closableStores = createClosableStateStoresUnchecked();
+        try {
+          closableStores.checkpoint();
+        } finally {
+          closableStores.close();
         }
+        const gitOps = new GitCliAdapter(process.cwd());
+        const stateBranchAdapter = new GitStateBranchAdapter(gitOps, process.cwd());
+        const branchR = await gitOps.getCurrentBranch();
+        if (isOk(branchR)) {
+          const existsR = await stateBranchAdapter.exists(branchR.data);
+          if (isOk(existsR) && existsR.data) {
+            await syncBranchUseCase(
+              { codeBranch: branchR.data, message: `sync: ${sliceId} -> ${targetStatus}` },
+              { stateBranch: stateBranchAdapter },
+            );
+          }
+        }
+      } catch (e) {
+        const syncMsg = `state branch sync failed: ${String(e)}`;
+        tffWarn(syncMsg);
+        warnings.push(syncMsg);
       }
-    } catch (e) {
-      const syncMsg = `state branch sync failed: ${String(e)}`;
-      tffWarn(syncMsg);
-      warnings.push(syncMsg);
-    }
 
-    // Auto-save CHECKPOINT.md (CRITICAL — blocks transition)
-    try {
-      const { checkpointSaveCmd } = await import('./checkpoint-save.cmd.js');
-      const checkpointData = JSON.stringify({
-        sliceId,
-        baseCommit: '',
-        currentWave: 0,
-        completedWaves: [],
-        completedTasks: [],
-        executorLog: [],
-      });
-      await checkpointSaveCmd([checkpointData]);
-    } catch (e) {
-      return JSON.stringify({
-        ok: false,
-        error: { code: 'CHECKPOINT_FAILED', message: `Checkpoint save failed: ${String(e)}` },
-        warnings,
-      });
-    }
+      // Auto-save CHECKPOINT.md (CRITICAL — blocks transition)
+      try {
+        const { checkpointSaveCmd } = await import('./checkpoint-save.cmd.js');
+        const checkpointData = JSON.stringify({
+          sliceId,
+          baseCommit: '',
+          currentWave: 0,
+          completedWaves: [],
+          completedTasks: [],
+          executorLog: [],
+        });
+        await checkpointSaveCmd([checkpointData]);
+      } catch (e) {
+        return JSON.stringify({
+          ok: false,
+          error: { code: 'CHECKPOINT_FAILED', message: `Checkpoint save failed: ${String(e)}` },
+          warnings,
+        });
+      }
 
-    return JSON.stringify({ ok: true, data: { status: slice.status }, warnings });
-  }
-  return JSON.stringify({ ok: false, error: result.error });
+      return JSON.stringify({ ok: true, data: { status: slice.status }, warnings });
+    }
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/commands/sync-branch.cmd.ts
+++ b/tools/src/cli/commands/sync-branch.cmd.ts
@@ -17,7 +17,10 @@ export const syncBranchCmd = async (args: string[]): Promise<string> => {
     const stateBranch = new GitStateBranchAdapter(gitOps, process.cwd());
     try {
       stores.checkpoint();
-      const result = await syncBranchUseCase({ codeBranch, message: message ?? `sync: ${codeBranch}` }, { stateBranch });
+      const result = await syncBranchUseCase(
+        { codeBranch, message: message ?? `sync: ${codeBranch}` },
+        { stateBranch },
+      );
       if (isOk(result)) return JSON.stringify({ ok: true, data: { synced: codeBranch } });
       return JSON.stringify({ ok: false, error: result.error });
     } finally {

--- a/tools/src/cli/commands/sync-branch.cmd.ts
+++ b/tools/src/cli/commands/sync-branch.cmd.ts
@@ -2,7 +2,7 @@ import { syncBranchUseCase } from '../../application/state-branch/sync-branch.js
 import { isOk } from '../../domain/result.js';
 import { GitCliAdapter } from '../../infrastructure/adapters/git/git-cli.adapter.js';
 import { GitStateBranchAdapter } from '../../infrastructure/adapters/git/git-state-branch.adapter.js';
-import { createClosableStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withClosableBranchGuard } from '../with-branch-guard.js';
 
 export const syncBranchCmd = async (args: string[]): Promise<string> => {
   const [codeBranch, message] = args;
@@ -12,16 +12,16 @@ export const syncBranchCmd = async (args: string[]): Promise<string> => {
       error: { code: 'INVALID_ARGS', message: 'Usage: sync:branch <code-branch> [message]' },
     });
 
-  const gitOps = new GitCliAdapter(process.cwd());
-  const stateBranch = new GitStateBranchAdapter(gitOps, process.cwd());
-  const stores = createClosableStateStores();
-
-  try {
-    stores.checkpoint();
-    const result = await syncBranchUseCase({ codeBranch, message: message ?? `sync: ${codeBranch}` }, { stateBranch });
-    if (isOk(result)) return JSON.stringify({ ok: true, data: { synced: codeBranch } });
-    return JSON.stringify({ ok: false, error: result.error });
-  } finally {
-    stores.close();
-  }
+  return withClosableBranchGuard(async (stores) => {
+    const gitOps = new GitCliAdapter(process.cwd());
+    const stateBranch = new GitStateBranchAdapter(gitOps, process.cwd());
+    try {
+      stores.checkpoint();
+      const result = await syncBranchUseCase({ codeBranch, message: message ?? `sync: ${codeBranch}` }, { stateBranch });
+      if (isOk(result)) return JSON.stringify({ ok: true, data: { synced: codeBranch } });
+      return JSON.stringify({ ok: false, error: result.error });
+    } finally {
+      stores.close();
+    }
+  });
 };

--- a/tools/src/cli/commands/sync-state.cmd.ts
+++ b/tools/src/cli/commands/sync-state.cmd.ts
@@ -1,7 +1,7 @@
 import { generateState } from '../../application/sync/generate-state.js';
 import { isOk } from '../../domain/result.js';
 import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js';
-import { createStateStores } from '../../infrastructure/adapters/sqlite/create-state-stores.js';
+import { withBranchGuard } from '../with-branch-guard.js';
 
 export const syncStateCmd = async (args: string[]): Promise<string> => {
   const [milestoneId] = args;
@@ -11,9 +11,10 @@ export const syncStateCmd = async (args: string[]): Promise<string> => {
       error: { code: 'INVALID_ARGS', message: 'Usage: sync:state <milestone-id>' },
     });
   }
-  const { milestoneStore, sliceStore, taskStore } = createStateStores();
-  const artifactStore = new MarkdownArtifactAdapter(process.cwd());
-  const result = await generateState({ milestoneId }, { milestoneStore, sliceStore, taskStore, artifactStore });
-  if (isOk(result)) return JSON.stringify({ ok: true, data: null });
-  return JSON.stringify({ ok: false, error: result.error });
+  return withBranchGuard(async ({ milestoneStore, sliceStore, taskStore }) => {
+    const artifactStore = new MarkdownArtifactAdapter(process.cwd());
+    const result = await generateState({ milestoneId }, { milestoneStore, sliceStore, taskStore, artifactStore });
+    if (isOk(result)) return JSON.stringify({ ok: true, data: null });
+    return JSON.stringify({ ok: false, error: result.error });
+  });
 };

--- a/tools/src/cli/index.ts
+++ b/tools/src/cli/index.ts
@@ -3,6 +3,7 @@ import { checkpointLoadCmd } from './commands/checkpoint-load.cmd.js';
 import { checkpointSaveCmd } from './commands/checkpoint-save.cmd.js';
 import { claimCheckStaleCmd } from './commands/claim-check-stale.cmd.js';
 import { composeDetectCmd } from './commands/compose-detect.cmd.js';
+import { hookPostCheckoutCmd } from './commands/hook-post-checkout.cmd.js';
 import { milestoneCreateCmd } from './commands/milestone-create.cmd.js';
 import { milestoneListCmd } from './commands/milestone-list.cmd.js';
 import { observeRecordCmd } from './commands/observe-record.cmd.js';
@@ -62,6 +63,7 @@ const commands: Record<string, CommandFn> = {
   'sync:branch': syncBranchCmd,
   'restore:branch': restoreBranchCmd,
   'branch:merge': branchMergeCmd,
+  'hook:post-checkout': hookPostCheckoutCmd,
 };
 
 const main = async () => {

--- a/tools/src/cli/with-branch-guard.spec.ts
+++ b/tools/src/cli/with-branch-guard.spec.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BranchMismatchError } from '../domain/errors/branch-mismatch.error.js';
+
+/**
+ * Helper: mock the BranchMismatchError module so the dynamically-imported
+ * `with-branch-guard.ts` gets the *same* class reference as the test file.
+ * Without this, `vi.resetModules()` gives the implementation a fresh class
+ * and `instanceof` checks fail.
+ */
+function mockBranchMismatchError(): void {
+  vi.doMock('../domain/errors/branch-mismatch.error.js', () => ({
+    BranchMismatchError,
+  }));
+}
+
+describe('withBranchGuard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns fn result when no mismatch', async () => {
+    mockBranchMismatchError();
+    vi.doMock('../infrastructure/adapters/sqlite/create-state-stores.js', () => ({
+      createStateStores: vi.fn().mockReturnValue({ projectStore: 'mock' }),
+      createStateStoresUnchecked: vi.fn().mockReturnValue({ projectStore: 'mock' }),
+      createClosableStateStores: vi.fn().mockReturnValue({ projectStore: 'mock', close: vi.fn(), checkpoint: vi.fn() }),
+      createClosableStateStoresUnchecked: vi
+        .fn()
+        .mockReturnValue({ projectStore: 'mock', close: vi.fn(), checkpoint: vi.fn() }),
+    }));
+
+    const { withBranchGuard } = await import('./with-branch-guard.js');
+    const result = await withBranchGuard(async (stores) => {
+      expect(stores.projectStore).toBe('mock');
+      return 'success';
+    });
+    expect(result).toBe('success');
+  });
+
+  it('catches BranchMismatchError and retries after restore', async () => {
+    let callCount = 0;
+    mockBranchMismatchError();
+    vi.doMock('../infrastructure/adapters/sqlite/create-state-stores.js', () => ({
+      createStateStores: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) throw new BranchMismatchError('old', 'new');
+        return { projectStore: 'mock' };
+      }),
+      createStateStoresUnchecked: vi.fn().mockReturnValue({ projectStore: 'mock-unchecked' }),
+      createClosableStateStores: vi.fn(),
+      createClosableStateStoresUnchecked: vi.fn(),
+    }));
+
+    vi.doMock('../infrastructure/adapters/git/git-cli.adapter.js', () => ({
+      GitCliAdapter: class MockGitCliAdapter {},
+    }));
+    vi.doMock('../infrastructure/adapters/git/git-state-branch.adapter.js', () => ({
+      GitStateBranchAdapter: class MockGitStateBranchAdapter {},
+    }));
+    vi.doMock('../application/state-branch/restore-branch.js', () => ({
+      restoreBranchUseCase: vi.fn().mockResolvedValue({ ok: true, data: { filesRestored: 1, schemaVersion: 0 } }),
+    }));
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        existsSync: vi.fn().mockReturnValue(false),
+      };
+    });
+    vi.doMock('../infrastructure/hooks/branch-meta-stamp.js', () => ({
+      writeLocalStamp: vi.fn(),
+      writeSyntheticStamp: vi.fn(),
+    }));
+
+    const { withBranchGuard } = await import('./with-branch-guard.js');
+    const result = await withBranchGuard(async () => 'recovered');
+    expect(result).toBe('recovered');
+  });
+
+  it('writes synthetic stamp when restore returns null', async () => {
+    const mockWriteSyntheticStamp = vi.fn();
+
+    mockBranchMismatchError();
+    vi.doMock('../infrastructure/adapters/sqlite/create-state-stores.js', () => ({
+      createStateStores: vi.fn().mockImplementation(() => {
+        throw new BranchMismatchError('old', 'new');
+      }),
+      createStateStoresUnchecked: vi.fn().mockReturnValue({ projectStore: 'mock-unchecked' }),
+      createClosableStateStores: vi.fn(),
+      createClosableStateStoresUnchecked: vi.fn(),
+    }));
+    vi.doMock('../infrastructure/adapters/git/git-cli.adapter.js', () => ({
+      GitCliAdapter: class MockGitCliAdapter {},
+    }));
+    vi.doMock('../infrastructure/adapters/git/git-state-branch.adapter.js', () => ({
+      GitStateBranchAdapter: class MockGitStateBranchAdapter {},
+    }));
+    vi.doMock('../application/state-branch/restore-branch.js', () => ({
+      restoreBranchUseCase: vi.fn().mockResolvedValue({ ok: true, data: null }),
+    }));
+    vi.doMock('../infrastructure/hooks/branch-meta-stamp.js', () => ({
+      writeLocalStamp: vi.fn(),
+      writeSyntheticStamp: mockWriteSyntheticStamp,
+    }));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { withBranchGuard } = await import('./with-branch-guard.js');
+    const result = await withBranchGuard(async () => 'fallback');
+    expect(result).toBe('fallback');
+    expect(mockWriteSyntheticStamp).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('rethrows non-BranchMismatchError errors', async () => {
+    mockBranchMismatchError();
+    vi.doMock('../infrastructure/adapters/sqlite/create-state-stores.js', () => ({
+      createStateStores: vi.fn().mockImplementation(() => {
+        throw new Error('unrelated failure');
+      }),
+      createStateStoresUnchecked: vi.fn(),
+      createClosableStateStores: vi.fn(),
+      createClosableStateStoresUnchecked: vi.fn(),
+    }));
+
+    const { withBranchGuard } = await import('./with-branch-guard.js');
+    await expect(withBranchGuard(async () => 'never')).rejects.toThrow('unrelated failure');
+  });
+});
+
+describe('withClosableBranchGuard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns fn result when no mismatch', async () => {
+    const mockClose = vi.fn();
+    const mockCheckpoint = vi.fn();
+
+    mockBranchMismatchError();
+    vi.doMock('../infrastructure/adapters/sqlite/create-state-stores.js', () => ({
+      createStateStores: vi.fn(),
+      createStateStoresUnchecked: vi.fn(),
+      createClosableStateStores: vi.fn().mockReturnValue({
+        projectStore: 'mock',
+        close: mockClose,
+        checkpoint: mockCheckpoint,
+      }),
+      createClosableStateStoresUnchecked: vi.fn(),
+    }));
+
+    const { withClosableBranchGuard } = await import('./with-branch-guard.js');
+    const result = await withClosableBranchGuard(async (stores) => {
+      expect(stores.projectStore).toBe('mock');
+      expect(stores.close).toBe(mockClose);
+      expect(stores.checkpoint).toBe(mockCheckpoint);
+      return 'closable-success';
+    });
+    expect(result).toBe('closable-success');
+  });
+
+  it('catches BranchMismatchError and retries with unchecked closable stores', async () => {
+    const mockClose = vi.fn();
+    const mockCheckpoint = vi.fn();
+
+    mockBranchMismatchError();
+    vi.doMock('../infrastructure/adapters/sqlite/create-state-stores.js', () => ({
+      createStateStores: vi.fn(),
+      createStateStoresUnchecked: vi.fn(),
+      createClosableStateStores: vi.fn().mockImplementation(() => {
+        throw new BranchMismatchError('old', 'new');
+      }),
+      createClosableStateStoresUnchecked: vi.fn().mockReturnValue({
+        projectStore: 'mock-unchecked',
+        close: mockClose,
+        checkpoint: mockCheckpoint,
+      }),
+    }));
+    vi.doMock('../infrastructure/adapters/git/git-cli.adapter.js', () => ({
+      GitCliAdapter: class MockGitCliAdapter {},
+    }));
+    vi.doMock('../infrastructure/adapters/git/git-state-branch.adapter.js', () => ({
+      GitStateBranchAdapter: class MockGitStateBranchAdapter {},
+    }));
+    vi.doMock('../application/state-branch/restore-branch.js', () => ({
+      restoreBranchUseCase: vi.fn().mockResolvedValue({ ok: true, data: null }),
+    }));
+    vi.doMock('../infrastructure/hooks/branch-meta-stamp.js', () => ({
+      writeLocalStamp: vi.fn(),
+      writeSyntheticStamp: vi.fn(),
+    }));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { withClosableBranchGuard } = await import('./with-branch-guard.js');
+    const result = await withClosableBranchGuard(async (stores) => {
+      expect(stores.projectStore).toBe('mock-unchecked');
+      return 'closable-recovered';
+    });
+    expect(result).toBe('closable-recovered');
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tools/src/cli/with-branch-guard.ts
+++ b/tools/src/cli/with-branch-guard.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { restoreBranchUseCase } from '../application/state-branch/restore-branch.js';
+import { BranchMismatchError } from '../domain/errors/branch-mismatch.error.js';
+import { isOk } from '../domain/result.js';
+import { BranchMetaSchema } from '../domain/value-objects/branch-meta.js';
+import { GitCliAdapter } from '../infrastructure/adapters/git/git-cli.adapter.js';
+import { GitStateBranchAdapter } from '../infrastructure/adapters/git/git-state-branch.adapter.js';
+import {
+  type ClosableStateStores,
+  createClosableStateStores,
+  createClosableStateStoresUnchecked,
+  createStateStores,
+  createStateStoresUnchecked,
+  type StateStores,
+} from '../infrastructure/adapters/sqlite/create-state-stores.js';
+import { writeLocalStamp, writeSyntheticStamp } from '../infrastructure/hooks/branch-meta-stamp.js';
+
+async function handleMismatch(error: BranchMismatchError): Promise<boolean> {
+  const cwd = process.cwd();
+  const tffDir = path.join(cwd, '.tff');
+  const gitOps = new GitCliAdapter(cwd);
+  const stateBranch = new GitStateBranchAdapter(gitOps, cwd);
+
+  const result = await restoreBranchUseCase({ codeBranch: error.currentBranch, targetDir: cwd }, { stateBranch });
+
+  if (isOk(result) && result.data !== null) {
+    // Read stateId from root-level branch-meta.json (extracted by restore)
+    const rootMetaPath = path.join(cwd, 'branch-meta.json');
+    try {
+      if (existsSync(rootMetaPath)) {
+        const raw = JSON.parse(readFileSync(rootMetaPath, 'utf8'));
+        const meta = BranchMetaSchema.parse(raw);
+        writeLocalStamp(tffDir, {
+          stateId: meta.stateId,
+          codeBranch: error.currentBranch,
+          parentStateBranch: meta.parentStateBranch,
+          createdAt: meta.createdAt,
+        });
+      } else {
+        writeSyntheticStamp(tffDir, error.currentBranch);
+      }
+    } catch {
+      writeSyntheticStamp(tffDir, error.currentBranch);
+    }
+    return true;
+  }
+
+  // Restore failed or no state branch -- write synthetic stamp to prevent loop
+  writeSyntheticStamp(tffDir, error.currentBranch);
+  console.warn(`[tff] restore failed for branch "${error.currentBranch}", using existing state`);
+  return false;
+}
+
+export async function withBranchGuard<T>(
+  fn: (stores: StateStores) => Promise<T>,
+  opts?: { dbPath?: string },
+): Promise<T> {
+  try {
+    const stores = createStateStores(opts?.dbPath);
+    return await fn(stores);
+  } catch (e) {
+    if (!(e instanceof BranchMismatchError)) throw e;
+    await handleMismatch(e);
+    const stores = createStateStoresUnchecked(opts?.dbPath);
+    return await fn(stores);
+  }
+}
+
+export async function withClosableBranchGuard<T>(
+  fn: (stores: ClosableStateStores) => Promise<T>,
+  opts?: { dbPath?: string },
+): Promise<T> {
+  try {
+    const stores = createClosableStateStores(opts?.dbPath);
+    return await fn(stores);
+  } catch (e) {
+    if (!(e instanceof BranchMismatchError)) throw e;
+    await handleMismatch(e);
+    const stores = createClosableStateStoresUnchecked(opts?.dbPath);
+    return await fn(stores);
+  }
+}

--- a/tools/src/domain/errors/branch-mismatch.error.spec.ts
+++ b/tools/src/domain/errors/branch-mismatch.error.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { BranchMismatchError } from './branch-mismatch.error.js';
+
+describe('BranchMismatchError', () => {
+  it('is instanceof Error', () => {
+    const err = new BranchMismatchError('old-branch', 'new-branch');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(BranchMismatchError);
+  });
+
+  it('exposes expectedBranch and currentBranch', () => {
+    const err = new BranchMismatchError('milestone/M01', 'slice/M01-S05');
+    expect(err.expectedBranch).toBe('milestone/M01');
+    expect(err.currentBranch).toBe('slice/M01-S05');
+  });
+
+  it('has descriptive message', () => {
+    const err = new BranchMismatchError('a', 'b');
+    expect(err.message).toContain('a');
+    expect(err.message).toContain('b');
+  });
+});

--- a/tools/src/domain/errors/branch-mismatch.error.ts
+++ b/tools/src/domain/errors/branch-mismatch.error.ts
@@ -1,0 +1,11 @@
+export class BranchMismatchError extends Error {
+  constructor(
+    public readonly expectedBranch: string,
+    public readonly currentBranch: string,
+  ) {
+    super(
+      `Branch mismatch: .tff/ state is for "${expectedBranch}" but current branch is "${currentBranch}"`,
+    );
+    this.name = 'BranchMismatchError';
+  }
+}

--- a/tools/src/domain/errors/branch-mismatch.error.ts
+++ b/tools/src/domain/errors/branch-mismatch.error.ts
@@ -3,9 +3,7 @@ export class BranchMismatchError extends Error {
     public readonly expectedBranch: string,
     public readonly currentBranch: string,
   ) {
-    super(
-      `Branch mismatch: .tff/ state is for "${expectedBranch}" but current branch is "${currentBranch}"`,
-    );
+    super(`Branch mismatch: .tff/ state is for "${expectedBranch}" but current branch is "${currentBranch}"`);
     this.name = 'BranchMismatchError';
   }
 }

--- a/tools/src/domain/value-objects/branch-meta.spec.ts
+++ b/tools/src/domain/value-objects/branch-meta.spec.ts
@@ -30,4 +30,35 @@ describe('BranchMeta', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  describe('restoredAt', () => {
+    const validBase = {
+      stateId: '550e8400-e29b-41d4-a716-446655440000',
+      codeBranch: 'milestone/M01',
+      parentStateBranch: 'tff-state/main',
+      createdAt: '2026-04-01T10:00:00Z',
+    };
+
+    it('parses without restoredAt (backwards compat)', () => {
+      const result = BranchMetaSchema.safeParse(validBase);
+      expect(result.success).toBe(true);
+    });
+
+    it('parses with restoredAt', () => {
+      const result = BranchMetaSchema.safeParse({
+        ...validBase,
+        restoredAt: '2026-04-01T12:00:00Z',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.restoredAt).toBe('2026-04-01T12:00:00Z');
+    });
+
+    it('rejects invalid restoredAt', () => {
+      const result = BranchMetaSchema.safeParse({
+        ...validBase,
+        restoredAt: 'not-a-date',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/tools/src/domain/value-objects/branch-meta.ts
+++ b/tools/src/domain/value-objects/branch-meta.ts
@@ -5,6 +5,7 @@ export const BranchMetaSchema = z.object({
   codeBranch: z.string().min(1),
   parentStateBranch: z.string().min(1).nullable(),
   createdAt: z.string().datetime(),
+  restoredAt: z.string().datetime().optional(),
 });
 
 export type BranchMeta = z.infer<typeof BranchMetaSchema>;

--- a/tools/src/infrastructure/adapters/git/copy-tff-to-worktree.spec.ts
+++ b/tools/src/infrastructure/adapters/git/copy-tff-to-worktree.spec.ts
@@ -1,7 +1,7 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { copyTffToWorktree } from './copy-tff-to-worktree.js';
 
 describe('copyTffToWorktree', () => {

--- a/tools/src/infrastructure/adapters/git/copy-tff-to-worktree.spec.ts
+++ b/tools/src/infrastructure/adapters/git/copy-tff-to-worktree.spec.ts
@@ -1,26 +1,54 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { copyTffToWorktree } from './copy-tff-to-worktree.js';
 
 describe('copyTffToWorktree', () => {
-  it('should copy .tff/ excluding worktrees/', () => {
-    const src = mkdtempSync(path.join(tmpdir(), 'tff-src-'));
-    const dest = mkdtempSync(path.join(tmpdir(), 'tff-dest-'));
-    writeFileSync(path.join(src, 'state.db'), 'db-content');
-    writeFileSync(path.join(src, 'PROJECT.md'), '# P');
-    mkdirSync(path.join(src, 'worktrees'));
-    writeFileSync(path.join(src, 'worktrees', 'M01-S01'), 'should-be-excluded');
-    mkdirSync(path.join(src, 'milestones'), { recursive: true });
-    writeFileSync(path.join(src, 'milestones', 'M01.md'), '# M01');
+  let tmpDir: string;
+  let tffDir: string;
+  let worktreePath: string;
 
-    copyTffToWorktree(src, dest);
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `tff-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    tffDir = path.join(tmpDir, '.tff');
+    worktreePath = path.join(tmpDir, 'worktree');
+    mkdirSync(tffDir, { recursive: true });
+    mkdirSync(worktreePath, { recursive: true });
+  });
 
-    expect(readFileSync(path.join(dest, '.tff', 'state.db'), 'utf-8')).toBe('db-content');
-    expect(readFileSync(path.join(dest, '.tff', 'PROJECT.md'), 'utf-8')).toBe('# P');
-    expect(readFileSync(path.join(dest, '.tff', 'milestones', 'M01.md'), 'utf-8')).toBe('# M01');
-    // worktrees/ should NOT be copied
-    expect(() => readFileSync(path.join(dest, '.tff', 'worktrees', 'M01-S01'))).toThrow();
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copies state.db but excludes branch-meta.json', () => {
+    writeFileSync(path.join(tffDir, 'state.db'), 'data');
+    writeFileSync(path.join(tffDir, 'branch-meta.json'), '{}');
+    copyTffToWorktree(tffDir, worktreePath);
+    expect(existsSync(path.join(worktreePath, '.tff', 'state.db'))).toBe(true);
+    expect(existsSync(path.join(worktreePath, '.tff', 'branch-meta.json'))).toBe(false);
+  });
+
+  it('still excludes worktrees directory', () => {
+    mkdirSync(path.join(tffDir, 'worktrees'), { recursive: true });
+    writeFileSync(path.join(tffDir, 'worktrees', 'dummy'), 'data');
+    writeFileSync(path.join(tffDir, 'state.db'), 'data');
+    copyTffToWorktree(tffDir, worktreePath);
+    expect(existsSync(path.join(worktreePath, '.tff', 'state.db'))).toBe(true);
+    expect(existsSync(path.join(worktreePath, '.tff', 'worktrees'))).toBe(false);
+  });
+
+  it('copies subdirectories recursively', () => {
+    const subDir = path.join(tffDir, 'milestones', 'M01');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(path.join(subDir, 'REQUIREMENTS.md'), '# Req');
+    copyTffToWorktree(tffDir, worktreePath);
+    expect(existsSync(path.join(worktreePath, '.tff', 'milestones', 'M01', 'REQUIREMENTS.md'))).toBe(true);
+  });
+
+  it('no-ops when tff dir does not exist', () => {
+    rmSync(tffDir, { recursive: true, force: true });
+    expect(() => copyTffToWorktree(tffDir, worktreePath)).not.toThrow();
   });
 });

--- a/tools/src/infrastructure/adapters/git/copy-tff-to-worktree.ts
+++ b/tools/src/infrastructure/adapters/git/copy-tff-to-worktree.ts
@@ -11,7 +11,7 @@ export function copyTffToWorktree(tffDir: string, worktreePath: string): void {
   mkdirSync(destTffDir, { recursive: true });
 
   for (const entry of readdirSync(tffDir)) {
-    if (entry === 'worktrees') continue;
+    if (entry === 'worktrees' || entry === 'branch-meta.json') continue;
     const src = path.join(tffDir, entry);
     const dest = path.join(destTffDir, entry);
     if (statSync(src).isDirectory()) {

--- a/tools/src/infrastructure/adapters/sqlite/create-state-stores.guard.spec.ts
+++ b/tools/src/infrastructure/adapters/sqlite/create-state-stores.guard.spec.ts
@@ -16,12 +16,12 @@ describe('createStateStores guard', () => {
     mkdirSync(tffDir, { recursive: true });
     dbPath = join(tffDir, 'state.db');
 
-    // Init git repo so execSync('git branch --show-current') works
-    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', {
-      cwd: tmpDir,
-      stdio: 'ignore',
-    });
+    // Init git repo — strip GIT_* env vars for CI compatibility
+    const env = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')));
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore', env });
+    execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'ignore', env });
+    execSync('git config user.name "Test"', { cwd: tmpDir, stdio: 'ignore', env });
+    execSync('git commit --allow-empty -m "init"', { cwd: tmpDir, stdio: 'ignore', env });
   });
 
   afterEach(() => {

--- a/tools/src/infrastructure/adapters/sqlite/create-state-stores.guard.spec.ts
+++ b/tools/src/infrastructure/adapters/sqlite/create-state-stores.guard.spec.ts
@@ -1,0 +1,78 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('createStateStores guard', () => {
+  let tmpDir: string;
+  let tffDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = join(os.tmpdir(), `tff-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    tffDir = join(tmpDir, '.tff');
+    mkdirSync(tffDir, { recursive: true });
+    dbPath = join(tffDir, 'state.db');
+
+    // Init git repo so execSync('git branch --show-current') works
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', {
+      cwd: tmpDir,
+      stdio: 'ignore',
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('throws BranchMismatchError when stamp codeBranch mismatches', async () => {
+    writeFileSync(
+      join(tffDir, 'branch-meta.json'),
+      JSON.stringify({
+        stateId: '550e8400-e29b-41d4-a716-446655440000',
+        codeBranch: 'some-other-branch',
+        parentStateBranch: null,
+        createdAt: '2026-04-01T10:00:00Z',
+      }),
+    );
+
+    const { createStateStores } = await import('./create-state-stores.js');
+    const { BranchMismatchError } = await import('../../../domain/errors/branch-mismatch.error.js');
+
+    expect(() => createStateStores(dbPath)).toThrow(BranchMismatchError);
+  });
+
+  it('throws BranchMismatchError when stamp is missing but state.db exists', async () => {
+    writeFileSync(dbPath, 'dummy-db');
+
+    const { createStateStores } = await import('./create-state-stores.js');
+    const { BranchMismatchError } = await import('../../../domain/errors/branch-mismatch.error.js');
+
+    expect(() => createStateStores(dbPath)).toThrow(BranchMismatchError);
+  });
+
+  it('createStateStoresUnchecked skips guard', async () => {
+    writeFileSync(
+      join(tffDir, 'branch-meta.json'),
+      JSON.stringify({
+        stateId: '550e8400-e29b-41d4-a716-446655440000',
+        codeBranch: 'wrong-branch',
+        parentStateBranch: null,
+        createdAt: '2026-04-01T10:00:00Z',
+      }),
+    );
+
+    const { createStateStoresUnchecked } = await import('./create-state-stores.js');
+    const { BranchMismatchError } = await import('../../../domain/errors/branch-mismatch.error.js');
+
+    // Should not throw BranchMismatchError even with mismatched stamp
+    try {
+      createStateStoresUnchecked(dbPath);
+    } catch (e) {
+      expect(e).not.toBeInstanceOf(BranchMismatchError);
+    }
+  });
+});

--- a/tools/src/infrastructure/adapters/sqlite/create-state-stores.ts
+++ b/tools/src/infrastructure/adapters/sqlite/create-state-stores.ts
@@ -1,4 +1,7 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { BranchMismatchError } from '../../../domain/errors/branch-mismatch.error.js';
 import type { DatabaseInit } from '../../../domain/ports/database-init.port.js';
 import type { DependencyStore } from '../../../domain/ports/dependency-store.port.js';
 import type { MilestoneStore } from '../../../domain/ports/milestone-store.port.js';
@@ -7,6 +10,7 @@ import type { ReviewStore } from '../../../domain/ports/review-store.port.js';
 import type { SessionStore } from '../../../domain/ports/session-store.port.js';
 import type { SliceStore } from '../../../domain/ports/slice-store.port.js';
 import type { TaskStore } from '../../../domain/ports/task-store.port.js';
+import { BranchMetaSchema } from '../../../domain/value-objects/branch-meta.js';
 import { SQLiteStateAdapter } from './sqlite-state.adapter.js';
 
 export interface StateStores {
@@ -20,7 +24,35 @@ export interface StateStores {
   reviewStore: ReviewStore;
 }
 
-export function createStateStores(dbPath?: string): StateStores {
+function checkBranchAlignment(tffDir: string): void {
+  try {
+    const stampPath = path.join(tffDir, 'branch-meta.json');
+    const dbFilePath = path.join(tffDir, 'state.db');
+
+    if (existsSync(stampPath)) {
+      const raw = JSON.parse(readFileSync(stampPath, 'utf8'));
+      const meta = BranchMetaSchema.parse(raw);
+      const currentBranch = execSync('git branch --show-current', {
+        cwd: path.dirname(tffDir), // run git from parent of .tff/
+        encoding: 'utf8',
+      }).trim();
+      if (meta.codeBranch !== currentBranch) {
+        throw new BranchMismatchError(meta.codeBranch, currentBranch);
+      }
+    } else if (existsSync(dbFilePath)) {
+      const currentBranch = execSync('git branch --show-current', {
+        cwd: path.dirname(tffDir),
+        encoding: 'utf8',
+      }).trim();
+      throw new BranchMismatchError('unknown', currentBranch);
+    }
+  } catch (e) {
+    if (e instanceof BranchMismatchError) throw e;
+    // execSync failed (not git repo) or stamp parse failed — skip guard
+  }
+}
+
+export function createStateStoresUnchecked(dbPath?: string): StateStores {
   const resolvedPath = dbPath ?? path.join(process.cwd(), '.tff', 'state.db');
   const adapter = SQLiteStateAdapter.create(resolvedPath);
   const initResult = adapter.init();
@@ -37,12 +69,18 @@ export function createStateStores(dbPath?: string): StateStores {
   };
 }
 
+export function createStateStores(dbPath?: string): StateStores {
+  const resolvedPath = dbPath ?? path.join(process.cwd(), '.tff', 'state.db');
+  checkBranchAlignment(path.dirname(resolvedPath));
+  return createStateStoresUnchecked(dbPath);
+}
+
 export interface ClosableStateStores extends StateStores {
   close(): void;
   checkpoint(): void;
 }
 
-export function createClosableStateStores(dbPath?: string): ClosableStateStores {
+export function createClosableStateStoresUnchecked(dbPath?: string): ClosableStateStores {
   const resolvedPath = dbPath ?? path.join(process.cwd(), '.tff', 'state.db');
   const adapter = SQLiteStateAdapter.create(resolvedPath);
   const initResult = adapter.init();
@@ -59,4 +97,10 @@ export function createClosableStateStores(dbPath?: string): ClosableStateStores 
     close: () => adapter.close(),
     checkpoint: () => adapter.checkpoint(),
   };
+}
+
+export function createClosableStateStores(dbPath?: string): ClosableStateStores {
+  const resolvedPath = dbPath ?? path.join(process.cwd(), '.tff', 'state.db');
+  checkBranchAlignment(path.dirname(resolvedPath));
+  return createClosableStateStoresUnchecked(dbPath);
 }

--- a/tools/src/infrastructure/hooks/branch-meta-stamp.spec.ts
+++ b/tools/src/infrastructure/hooks/branch-meta-stamp.spec.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readLocalStamp, writeLocalStamp, writeSyntheticStamp } from './branch-meta-stamp.js';
+
+describe('branch-meta-stamp', () => {
+  let tffDir: string;
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = join(os.tmpdir(), `tff-stamp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    tffDir = join(tmpBase, '.tff');
+    mkdirSync(tffDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it('returns null when no stamp exists', () => {
+    expect(readLocalStamp(tffDir)).toBeNull();
+  });
+
+  it('writes and reads stamp with restoredAt', () => {
+    writeLocalStamp(tffDir, {
+      stateId: '550e8400-e29b-41d4-a716-446655440000',
+      codeBranch: 'slice/M01-S05',
+      parentStateBranch: 'tff-state/milestone/M01',
+      createdAt: '2026-04-01T10:00:00Z',
+    });
+    const stamp = readLocalStamp(tffDir);
+    expect(stamp).not.toBeNull();
+    expect(stamp!.codeBranch).toBe('slice/M01-S05');
+    expect(stamp!.restoredAt).toBeDefined();
+    expect(stamp!.stateId).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('writeSyntheticStamp creates valid stamp for unknown state', () => {
+    writeSyntheticStamp(tffDir, 'some-branch');
+    const stamp = readLocalStamp(tffDir);
+    expect(stamp).not.toBeNull();
+    expect(stamp!.codeBranch).toBe('some-branch');
+    expect(stamp!.stateId).toBeDefined();
+    expect(stamp!.parentStateBranch).toBeNull();
+    expect(stamp!.restoredAt).toBeDefined();
+  });
+
+  it('returns null for corrupted stamp file', () => {
+    writeFileSync(join(tffDir, 'branch-meta.json'), 'not json');
+    expect(readLocalStamp(tffDir)).toBeNull();
+  });
+});

--- a/tools/src/infrastructure/hooks/branch-meta-stamp.ts
+++ b/tools/src/infrastructure/hooks/branch-meta-stamp.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { type BranchMeta, BranchMetaSchema } from '../../domain/value-objects/branch-meta.js';
+
+const STAMP_FILE = 'branch-meta.json';
+
+export function readLocalStamp(tffDir: string): BranchMeta | null {
+  const stampPath = path.join(tffDir, STAMP_FILE);
+  if (!existsSync(stampPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(stampPath, 'utf8'));
+    return BranchMetaSchema.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function writeLocalStamp(tffDir: string, meta: Omit<BranchMeta, 'restoredAt'>): void {
+  const stampPath = path.join(tffDir, STAMP_FILE);
+  const stamp = BranchMetaSchema.parse({ ...meta, restoredAt: new Date().toISOString() });
+  writeFileSync(stampPath, JSON.stringify(stamp, null, 2));
+}
+
+export function writeSyntheticStamp(tffDir: string, codeBranch: string): void {
+  const stamp = BranchMetaSchema.parse({
+    stateId: randomUUID(),
+    codeBranch,
+    parentStateBranch: null,
+    createdAt: new Date().toISOString(),
+    restoredAt: new Date().toISOString(),
+  });
+  writeFileSync(path.join(tffDir, STAMP_FILE), JSON.stringify(stamp, null, 2));
+}

--- a/tools/src/infrastructure/hooks/install-post-checkout.spec.ts
+++ b/tools/src/infrastructure/hooks/install-post-checkout.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+import { installPostCheckoutHook } from './install-post-checkout.js';
+import { TFF_HOOK_MARKER } from './post-checkout-template.js';
+
+describe('installPostCheckoutHook', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(os.tmpdir(), `tff-hook-install-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('installs hook with executable permissions', () => {
+    installPostCheckoutHook(tmpDir);
+    const hookPath = join(tmpDir, '.git', 'hooks', 'post-checkout');
+    expect(existsSync(hookPath)).toBe(true);
+    const mode = statSync(hookPath).mode;
+    expect(mode & 0o111).toBeTruthy();
+  });
+
+  it('contains tff marker', () => {
+    installPostCheckoutHook(tmpDir);
+    const hookPath = join(tmpDir, '.git', 'hooks', 'post-checkout');
+    expect(readFileSync(hookPath, 'utf8')).toContain(TFF_HOOK_MARKER);
+  });
+
+  it('renames existing non-tff hook to .pre-tff', () => {
+    const hooksDir = join(tmpDir, '.git', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(join(hooksDir, 'post-checkout'), '#!/bin/sh\necho existing', { mode: 0o755 });
+
+    installPostCheckoutHook(tmpDir);
+
+    expect(existsSync(join(hooksDir, 'post-checkout.pre-tff'))).toBe(true);
+    const preTff = readFileSync(join(hooksDir, 'post-checkout.pre-tff'), 'utf8');
+    expect(preTff).toContain('echo existing');
+    expect(readFileSync(join(hooksDir, 'post-checkout'), 'utf8')).toContain(TFF_HOOK_MARKER);
+  });
+
+  it('overwrites existing tff hook without creating .pre-tff', () => {
+    const hooksDir = join(tmpDir, '.git', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(join(hooksDir, 'post-checkout'), `#!/bin/sh\n${TFF_HOOK_MARKER}\nold version`, { mode: 0o755 });
+
+    installPostCheckoutHook(tmpDir);
+
+    expect(existsSync(join(hooksDir, 'post-checkout.pre-tff'))).toBe(false);
+    expect(readFileSync(join(hooksDir, 'post-checkout'), 'utf8')).toContain(TFF_HOOK_MARKER);
+  });
+});

--- a/tools/src/infrastructure/hooks/install-post-checkout.spec.ts
+++ b/tools/src/infrastructure/hooks/install-post-checkout.spec.ts
@@ -12,7 +12,8 @@ describe('installPostCheckoutHook', () => {
   beforeEach(() => {
     tmpDir = join(os.tmpdir(), `tff-hook-install-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(tmpDir, { recursive: true });
-    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
+    const env = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')));
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore', env });
   });
 
   afterEach(() => {

--- a/tools/src/infrastructure/hooks/install-post-checkout.spec.ts
+++ b/tools/src/infrastructure/hooks/install-post-checkout.spec.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import os from 'node:os';
 import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { installPostCheckoutHook } from './install-post-checkout.js';
 import { TFF_HOOK_MARKER } from './post-checkout-template.js';
 

--- a/tools/src/infrastructure/hooks/install-post-checkout.ts
+++ b/tools/src/infrastructure/hooks/install-post-checkout.ts
@@ -1,0 +1,47 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, chmodSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { postCheckoutHookScript, TFF_HOOK_MARKER } from './post-checkout-template.js';
+
+/**
+ * Install post-checkout hook in the git repository at repoDir.
+ * - If an existing non-tff hook exists, renames it to post-checkout.pre-tff
+ * - If an existing tff hook exists, overwrites it
+ * - Creates .git/hooks/ directory if needed
+ */
+export function installPostCheckoutHook(repoDir: string): void {
+  // Resolve hook directory (handles worktrees via --git-common-dir)
+  let gitCommonDir: string;
+  try {
+    gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: repoDir,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return; // Not a git repo
+  }
+
+  // Resolve to absolute path
+  if (!path.isAbsolute(gitCommonDir)) {
+    gitCommonDir = path.resolve(repoDir, gitCommonDir);
+  }
+
+  const hooksDir = path.join(gitCommonDir, 'hooks');
+  mkdirSync(hooksDir, { recursive: true });
+
+  const hookPath = path.join(hooksDir, 'post-checkout');
+  const preTffPath = path.join(hooksDir, 'post-checkout.pre-tff');
+
+  if (existsSync(hookPath)) {
+    const existing = readFileSync(hookPath, 'utf8');
+    if (existing.includes(TFF_HOOK_MARKER)) {
+      // Our hook — overwrite
+    } else {
+      // Third-party hook — rename to .pre-tff
+      renameSync(hookPath, preTffPath);
+    }
+  }
+
+  writeFileSync(hookPath, postCheckoutHookScript, { mode: 0o755 });
+  chmodSync(hookPath, 0o755);
+}

--- a/tools/src/infrastructure/hooks/install-post-checkout.ts
+++ b/tools/src/infrastructure/hooks/install-post-checkout.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, chmodSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { postCheckoutHookScript, TFF_HOOK_MARKER } from './post-checkout-template.js';
 

--- a/tools/src/infrastructure/hooks/post-checkout-template.spec.ts
+++ b/tools/src/infrastructure/hooks/post-checkout-template.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { postCheckoutHookScript, TFF_HOOK_MARKER } from './post-checkout-template.js';
+
+describe('postCheckoutHookScript', () => {
+  it('starts with shebang', () => {
+    expect(postCheckoutHookScript).toMatch(/^#!\/bin\/sh/);
+  });
+
+  it('contains tff marker comment', () => {
+    expect(postCheckoutHookScript).toContain(TFF_HOOK_MARKER);
+  });
+
+  it('exits 0 for non-branch checkouts', () => {
+    expect(postCheckoutHookScript).toContain('[ "$3" = "1" ] || exit 0');
+  });
+
+  it('skips detached HEAD', () => {
+    expect(postCheckoutHookScript).toContain('[ -z "$BRANCH" ] && exit 0');
+  });
+
+  it('logs to .tff/hook.log', () => {
+    expect(postCheckoutHookScript).toContain('.tff/hook.log');
+  });
+
+  it('chains pre-existing hook without exec', () => {
+    expect(postCheckoutHookScript).toContain('post-checkout.pre-tff');
+    expect(postCheckoutHookScript).not.toMatch(/exec "\$\(dirname/);
+  });
+
+  it('always ends with exit 0', () => {
+    expect(postCheckoutHookScript.trimEnd()).toMatch(/exit 0$/);
+  });
+
+  it('resolves tff-tools via git rev-parse', () => {
+    expect(postCheckoutHookScript).toContain('git rev-parse --show-toplevel');
+  });
+});

--- a/tools/src/infrastructure/hooks/post-checkout-template.ts
+++ b/tools/src/infrastructure/hooks/post-checkout-template.ts
@@ -1,0 +1,27 @@
+export const TFF_HOOK_MARKER = '# tff post-checkout hook';
+
+export const postCheckoutHookScript = `#!/bin/sh
+# tff post-checkout hook — restores .tff/ state on branch switch
+# $1=prev HEAD, $2=new HEAD, $3=1 if branch checkout (0 if file checkout)
+
+[ "$3" = "1" ] || exit 0
+
+BRANCH=$(git branch --show-current)
+[ -z "$BRANCH" ] && exit 0
+
+command -v node >/dev/null 2>&1 || exit 0
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+TFF_TOOLS="$REPO_ROOT/tools/dist/tff-tools.cjs"
+[ -f "$TFF_TOOLS" ] || exit 0
+
+mkdir -p "$REPO_ROOT/.tff"
+
+node "$TFF_TOOLS" hook:post-checkout "$BRANCH" >> "$REPO_ROOT/.tff/hook.log" 2>&1
+
+if [ -x "$(dirname "$0")/post-checkout.pre-tff" ]; then
+  "$(dirname "$0")/post-checkout.pre-tff" "$@" || true
+fi
+
+exit 0
+`;

--- a/tools/src/infrastructure/locking/tff-lock.spec.ts
+++ b/tools/src/infrastructure/locking/tff-lock.spec.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { acquireRestoreLock, isLocked } from './tff-lock.js';
 
 describe('tff-lock', () => {

--- a/tools/src/infrastructure/locking/tff-lock.spec.ts
+++ b/tools/src/infrastructure/locking/tff-lock.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import os from 'node:os';
+import { acquireRestoreLock, isLocked } from './tff-lock.js';
+
+describe('tff-lock', () => {
+  let tmpDir: string;
+  let lockTarget: string;
+
+  beforeEach(() => {
+    tmpDir = join(os.tmpdir(), `tff-lock-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    lockTarget = join(tmpDir, 'state.db');
+    writeFileSync(lockTarget, 'data');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('acquires and releases lock', async () => {
+    const release = await acquireRestoreLock(lockTarget);
+    expect(release).not.toBeNull();
+    expect(await isLocked(lockTarget)).toBe(true);
+    await release!();
+    expect(await isLocked(lockTarget)).toBe(false);
+  });
+
+  it('returns null when lock is held and timeout expires', async () => {
+    const release = await acquireRestoreLock(lockTarget);
+    expect(release).not.toBeNull();
+    const second = await acquireRestoreLock(lockTarget, 200);
+    expect(second).toBeNull();
+    await release!();
+  });
+
+  it('allows lock after previous is released', async () => {
+    const release1 = await acquireRestoreLock(lockTarget);
+    await release1!();
+    const release2 = await acquireRestoreLock(lockTarget);
+    expect(release2).not.toBeNull();
+    await release2!();
+  });
+});

--- a/tools/src/infrastructure/locking/tff-lock.ts
+++ b/tools/src/infrastructure/locking/tff-lock.ts
@@ -1,0 +1,24 @@
+import lockfile from 'proper-lockfile';
+
+/**
+ * Acquire exclusive lock for restore operations.
+ * Returns release function, or null if lock couldn't be acquired within timeout.
+ */
+export async function acquireRestoreLock(
+  targetPath: string,
+  timeoutMs = 5000,
+): Promise<(() => Promise<void>) | null> {
+  try {
+    const release = await lockfile.lock(targetPath, {
+      retries: { retries: Math.ceil(timeoutMs / 200), factor: 1, minTimeout: 200 },
+      stale: 30000,
+    });
+    return release;
+  } catch {
+    return null;
+  }
+}
+
+export async function isLocked(targetPath: string): Promise<boolean> {
+  return lockfile.check(targetPath, { stale: 30000 });
+}

--- a/tools/src/infrastructure/locking/tff-lock.ts
+++ b/tools/src/infrastructure/locking/tff-lock.ts
@@ -4,10 +4,7 @@ import lockfile from 'proper-lockfile';
  * Acquire exclusive lock for restore operations.
  * Returns release function, or null if lock couldn't be acquired within timeout.
  */
-export async function acquireRestoreLock(
-  targetPath: string,
-  timeoutMs = 5000,
-): Promise<(() => Promise<void>) | null> {
+export async function acquireRestoreLock(targetPath: string, timeoutMs = 5000): Promise<(() => Promise<void>) | null> {
   try {
     const release = await lockfile.lock(targetPath, {
       retries: { retries: Math.ceil(timeoutMs / 200), factor: 1, minTimeout: 200 },

--- a/tools/src/integration/post-checkout-restore.integration.spec.ts
+++ b/tools/src/integration/post-checkout-restore.integration.spec.ts
@@ -3,26 +3,19 @@ import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } 
 import os from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { hookPostCheckoutCmd } from '../cli/commands/hook-post-checkout.cmd.js';
 import { BranchMismatchError } from '../domain/errors/branch-mismatch.error.js';
 import { createStateStores } from '../infrastructure/adapters/sqlite/create-state-stores.js';
-import {
-  readLocalStamp,
-  writeLocalStamp,
-  writeSyntheticStamp,
-} from '../infrastructure/hooks/branch-meta-stamp.js';
+import { readLocalStamp, writeLocalStamp, writeSyntheticStamp } from '../infrastructure/hooks/branch-meta-stamp.js';
 import { installPostCheckoutHook } from '../infrastructure/hooks/install-post-checkout.js';
 import { TFF_HOOK_MARKER } from '../infrastructure/hooks/post-checkout-template.js';
-import { hookPostCheckoutCmd } from '../cli/commands/hook-post-checkout.cmd.js';
 
 describe('post-checkout restore integration', () => {
   let tmpDir: string;
   let tffDir: string;
 
   beforeEach(() => {
-    tmpDir = join(
-      os.tmpdir(),
-      `tff-integ-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-    );
+    tmpDir = join(os.tmpdir(), `tff-integ-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(tmpDir, { recursive: true });
     tffDir = join(tmpDir, '.tff');
     mkdirSync(tffDir, { recursive: true });

--- a/tools/src/integration/post-checkout-restore.integration.spec.ts
+++ b/tools/src/integration/post-checkout-restore.integration.spec.ts
@@ -1,0 +1,126 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BranchMismatchError } from '../domain/errors/branch-mismatch.error.js';
+import { createStateStores } from '../infrastructure/adapters/sqlite/create-state-stores.js';
+import {
+  readLocalStamp,
+  writeLocalStamp,
+  writeSyntheticStamp,
+} from '../infrastructure/hooks/branch-meta-stamp.js';
+import { installPostCheckoutHook } from '../infrastructure/hooks/install-post-checkout.js';
+import { TFF_HOOK_MARKER } from '../infrastructure/hooks/post-checkout-template.js';
+import { hookPostCheckoutCmd } from '../cli/commands/hook-post-checkout.cmd.js';
+
+describe('post-checkout restore integration', () => {
+  let tmpDir: string;
+  let tffDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      os.tmpdir(),
+      `tff-integ-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    tffDir = join(tmpDir, '.tff');
+    mkdirSync(tffDir, { recursive: true });
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', {
+      cwd: tmpDir,
+      stdio: 'ignore',
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('factory guard', () => {
+    it('throws BranchMismatchError when stamp codeBranch mismatches', () => {
+      writeFileSync(
+        join(tffDir, 'branch-meta.json'),
+        JSON.stringify({
+          stateId: '550e8400-e29b-41d4-a716-446655440000',
+          codeBranch: 'wrong-branch',
+          parentStateBranch: null,
+          createdAt: '2026-04-01T10:00:00Z',
+        }),
+      );
+      const dbPath = join(tffDir, 'state.db');
+      expect(() => createStateStores(dbPath)).toThrow(BranchMismatchError);
+    });
+
+    it('throws BranchMismatchError when no stamp but state.db exists', () => {
+      const dbPath = join(tffDir, 'state.db');
+      writeFileSync(dbPath, 'dummy');
+      expect(() => createStateStores(dbPath)).toThrow(BranchMismatchError);
+    });
+
+    it('does not throw BranchMismatchError when stamp matches current branch', () => {
+      const currentBranch = execSync('git branch --show-current', {
+        cwd: tmpDir,
+        encoding: 'utf8',
+      }).trim();
+      writeFileSync(
+        join(tffDir, 'branch-meta.json'),
+        JSON.stringify({
+          stateId: '550e8400-e29b-41d4-a716-446655440000',
+          codeBranch: currentBranch,
+          parentStateBranch: null,
+          createdAt: '2026-04-01T10:00:00Z',
+        }),
+      );
+      const dbPath = join(tffDir, 'state.db');
+      // Will throw because no real SQLite DB, but NOT BranchMismatchError
+      try {
+        createStateStores(dbPath);
+      } catch (e) {
+        expect(e).not.toBeInstanceOf(BranchMismatchError);
+      }
+    });
+  });
+
+  describe('stamp helpers', () => {
+    it('roundtrip write and read', () => {
+      writeLocalStamp(tffDir, {
+        stateId: '550e8400-e29b-41d4-a716-446655440000',
+        codeBranch: 'slice/M01-S05',
+        parentStateBranch: 'tff-state/milestone/M01',
+        createdAt: '2026-04-01T10:00:00Z',
+      });
+      const stamp = readLocalStamp(tffDir);
+      expect(stamp).not.toBeNull();
+      expect(stamp!.codeBranch).toBe('slice/M01-S05');
+      expect(stamp!.stateId).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(stamp!.restoredAt).toBeDefined();
+    });
+
+    it('synthetic stamp has valid UUID and correct branch', () => {
+      writeSyntheticStamp(tffDir, 'my-branch');
+      const stamp = readLocalStamp(tffDir);
+      expect(stamp).not.toBeNull();
+      expect(stamp!.codeBranch).toBe('my-branch');
+      expect(stamp!.stateId).toMatch(/^[0-9a-f]{8}-/);
+    });
+  });
+
+  describe('hook installation', () => {
+    it('installs executable hook with tff marker', () => {
+      installPostCheckoutHook(tmpDir);
+      const hookPath = join(tmpDir, '.git', 'hooks', 'post-checkout');
+      expect(existsSync(hookPath)).toBe(true);
+      expect(statSync(hookPath).mode & 0o111).toBeTruthy();
+      expect(readFileSync(hookPath, 'utf8')).toContain(TFF_HOOK_MARKER);
+    });
+  });
+
+  describe('hook command', () => {
+    it('returns INVALID_ARGS without branch', async () => {
+      const result = JSON.parse(await hookPostCheckoutCmd([]));
+      expect(result.ok).toBe(false);
+      expect(result.error.code).toBe('INVALID_ARGS');
+    });
+  });
+});

--- a/tools/src/integration/post-checkout-restore.integration.spec.ts
+++ b/tools/src/integration/post-checkout-restore.integration.spec.ts
@@ -19,11 +19,12 @@ describe('post-checkout restore integration', () => {
     mkdirSync(tmpDir, { recursive: true });
     tffDir = join(tmpDir, '.tff');
     mkdirSync(tffDir, { recursive: true });
-    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', {
-      cwd: tmpDir,
-      stdio: 'ignore',
-    });
+    // Strip GIT_* env vars for CI compatibility
+    const env = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')));
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore', env });
+    execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'ignore', env });
+    execSync('git config user.name "Test"', { cwd: tmpDir, stdio: 'ignore', env });
+    execSync('git commit --allow-empty -m "init"', { cwd: tmpDir, stdio: 'ignore', env });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Post-checkout git hook auto-restores `.tff/` state on `git checkout` (branch switches only)
- Factory guard in `createStateStores()` detects stale branch-meta stamp and throws `BranchMismatchError`
- `withBranchGuard()` wrapper for all CLI commands — catches mismatch, restores, retries
- Advisory locking via `proper-lockfile` prevents DB corruption during concurrent restore
- Hook installed by `project:init` with existing-hook chaining via `.pre-tff` rename
- `.tff/branch-meta.json` excluded from state branch sync to prevent feedback loops

## Changes

- **12 new files**: error class, locking, hook template/installer, stamp helpers, CLI wrapper, hook command, integration tests
- **11 modified files**: 10 CLI commands migrated to `withBranchGuard`, factory guard added to `createStateStores`
- **1264 tests passing**, typecheck clean, biome clean

## Acceptance Criteria

All 15 ACs verified — see `.tff/milestones/M01/slices/M01-S05/VERIFICATION.md`

## Reviews

- Spec review: PASS (15/15 ACs)
- Code review: APPROVE
- Security audit: CLEAR (0 critical/high)

## Test plan

- [x] Full test suite passes (1264 tests)
- [x] TypeScript compiles clean
- [x] Biome lint/format clean
- [x] Integration test covers factory guard, stamp roundtrip, hook installation
- [ ] Manual: `git checkout` between branches with state branches verifies auto-restore