### PR TITLE
chore: add tff-dev plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,6 +6,11 @@
       "name": "the-forge-flow",
       "source": "./plugin",
       "description": "Autonomous coding agent orchestrator with dual markdown+beads state, plannotator integration, and wave-based parallel execution"
+    },
+    {
+      "name": "tff-dev",
+      "source": "./plugin",
+      "description": "Dev build — test breaking changes without impacting stable tff"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `tff-dev` as a second plugin entry in marketplace.json
- Same source (`./plugin`), different name — CI patches the name on milestone/* releases
- Enables: `claude /plugin install tff-dev@the-forge-flow`

One-line change to unblock dev plugin testing ahead of the full M01 milestone merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)