### PR TITLE
fix(M01-S11): native bindings, .tff/ auto-creation, worktree fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,18 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            platform: darwin-arm64
+          - os: macos-13
+            platform: darwin-x64
+          - os: ubuntu-latest
+            platform: linux-x64
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +33,15 @@ jobs:
       - run: npm ci
 
       - name: Lint
+        if: matrix.platform == 'linux-x64'
         run: npm run lint
 
       - name: Type check
+        if: matrix.platform == 'linux-x64'
         run: npm run typecheck
 
       - name: Run tests
+        if: matrix.platform == 'linux-x64'
         run: npm test
 
       - name: Build
@@ -36,6 +49,39 @@ jobs:
 
       - name: Verify CLI
         run: node tools/dist/tff-tools.cjs --help
+
+      - name: Upload native binding
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.platform }}
+          path: tools/dist/better_sqlite3.*.node
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Download all native bindings
+        uses: actions/download-artifact@v4
+        with:
+          path: tools/dist/
+          pattern: native-*
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la tools/dist/
 
       - name: Extract version from tag
         id: version
@@ -48,3 +94,4 @@ jobs:
           generate_release_notes: true
           files: |
             tools/dist/tff-tools.cjs
+            tools/dist/better_sqlite3.*.node

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 .beads/
 .worktrees/
 /branch-meta.json
+tools/dist/*.node

--- a/tools/src/application/project/init-project.spec.ts
+++ b/tools/src/application/project/init-project.spec.ts
@@ -32,6 +32,31 @@ describe('initProject', () => {
     expect(await artifactStore.exists('.tff/PROJECT.md')).toBe(true);
   });
 
+  it('should add .tff/ to .gitignore', async () => {
+    await initProject({ name: 'my-app', vision: 'A great app' }, { projectStore: adapter, artifactStore });
+    expect(await artifactStore.exists('.gitignore')).toBe(true);
+    const content = await artifactStore.read('.gitignore');
+    expect(isOk(content) && content.data).toContain('.tff/');
+  });
+
+  it('should append .tff/ to existing .gitignore without duplicating', async () => {
+    artifactStore.seed({ '.gitignore': 'node_modules/\nbuild/\n' });
+    await initProject({ name: 'my-app', vision: 'A great app' }, { projectStore: adapter, artifactStore });
+    const content = await artifactStore.read('.gitignore');
+    expect(isOk(content) && content.data).toContain('node_modules/');
+    expect(isOk(content) && content.data).toContain('.tff/');
+  });
+
+  it('should not duplicate .tff/ if already in .gitignore', async () => {
+    artifactStore.seed({ '.gitignore': 'node_modules/\n.tff/\n' });
+    await initProject({ name: 'my-app', vision: 'A great app' }, { projectStore: adapter, artifactStore });
+    const content = await artifactStore.read('.gitignore');
+    if (isOk(content)) {
+      const matches = content.data.split('\n').filter((l) => l.trim() === '.tff/');
+      expect(matches).toHaveLength(1);
+    }
+  });
+
   it('should reject if project already exists', async () => {
     await initProject({ name: 'my-app', vision: 'A great app' }, { projectStore: adapter, artifactStore });
     const result = await initProject({ name: 'another', vision: 'Nope' }, { projectStore: adapter, artifactStore });

--- a/tools/src/application/project/init-project.ts
+++ b/tools/src/application/project/init-project.ts
@@ -37,6 +37,9 @@ export const initProject = async (
   await deps.artifactStore.mkdir('.tff');
   await deps.artifactStore.mkdir('.tff/milestones');
 
+  // Ensure .tff/ is in .gitignore so artifacts never land on code branches
+  await ensureTffGitignored(deps.artifactStore);
+
   const projectMd = `# ${project.name}\n\n## Vision\n\n${project.vision}\n`;
   await deps.artifactStore.write('.tff/PROJECT.md', projectMd);
 
@@ -50,3 +53,22 @@ export const initProject = async (
 
   return Ok({ project: saveResult.data });
 };
+
+async function ensureTffGitignored(artifactStore: ArtifactStore): Promise<void> {
+  const gitignorePath = '.gitignore';
+  const tffEntry = '.tff/';
+
+  if (await artifactStore.exists(gitignorePath)) {
+    const readResult = await artifactStore.read(gitignorePath);
+    if (isOk(readResult)) {
+      const lines = readResult.data.split('\n');
+      if (lines.some((line) => line.trim() === '.tff/' || line.trim() === '.tff')) return;
+      const content = readResult.data.endsWith('\n')
+        ? `${readResult.data}${tffEntry}\n`
+        : `${readResult.data}\n${tffEntry}\n`;
+      await artifactStore.write(gitignorePath, content);
+      return;
+    }
+  }
+  await artifactStore.write(gitignorePath, `${tffEntry}\n`);
+}

--- a/tools/src/application/state-branch/merge-state-dbs.ts
+++ b/tools/src/application/state-branch/merge-state-dbs.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { getNativeBindingPath } from '../../infrastructure/adapters/sqlite/load-native-binding.js';
 import type { DomainError } from '../../domain/errors/domain-error.js';
 import { syncFailedError } from '../../domain/errors/sync-failed.error.js';
 import { Err, Ok, type Result } from '../../domain/result.js';
@@ -16,11 +17,14 @@ export function mergeStateDbs(
   sliceId: string,
 ): Result<MergeResult, DomainError> {
   try {
+    const nativeBinding = getNativeBindingPath();
+    const dbOpts = nativeBinding ? { nativeBinding } : undefined;
+
     // Run migrations on both DBs to ensure schema compatibility
-    const parentDb = new Database(parentDbPath);
+    const parentDb = new Database(parentDbPath, dbOpts);
     runMigrations(parentDb);
 
-    const childDb = new Database(childDbPath);
+    const childDb = new Database(childDbPath, dbOpts);
     runMigrations(childDb);
     childDb.close();
 

--- a/tools/src/application/state-branch/merge-state-dbs.ts
+++ b/tools/src/application/state-branch/merge-state-dbs.ts
@@ -1,9 +1,9 @@
 import Database from 'better-sqlite3';
-import { getNativeBindingPath } from '../../infrastructure/adapters/sqlite/load-native-binding.js';
 import type { DomainError } from '../../domain/errors/domain-error.js';
 import { syncFailedError } from '../../domain/errors/sync-failed.error.js';
 import { Err, Ok, type Result } from '../../domain/result.js';
 import type { MergeResult } from '../../domain/value-objects/merge-result.js';
+import { getNativeBindingPath } from '../../infrastructure/adapters/sqlite/load-native-binding.js';
 import { runMigrations } from '../../infrastructure/adapters/sqlite/schema.js';
 
 /**

--- a/tools/src/application/worktree/create-worktree.ts
+++ b/tools/src/application/worktree/create-worktree.ts
@@ -4,6 +4,7 @@ import { isOk, Ok, type Result } from '../../domain/result.js';
 
 interface CreateWorktreeInput {
   sliceId: string;
+  startPoint?: string;
 }
 interface CreateWorktreeDeps {
   gitOps: GitOps;
@@ -20,7 +21,7 @@ export const createWorktreeUseCase = async (
   const worktreePath = `.tff/worktrees/${input.sliceId}`;
   const branchName = `slice/${input.sliceId}`;
 
-  const result = await deps.gitOps.createWorktree(worktreePath, branchName);
+  const result = await deps.gitOps.createWorktree(worktreePath, branchName, input.startPoint);
   if (!isOk(result)) return result;
 
   return Ok({ worktreePath, branchName });

--- a/tools/src/cli/commands/checkpoint-save.cmd.ts
+++ b/tools/src/cli/commands/checkpoint-save.cmd.ts
@@ -2,21 +2,31 @@ import { saveCheckpoint } from '../../application/checkpoint/save-checkpoint.js'
 import { isOk } from '../../domain/result.js';
 import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js';
 
+const USAGE =
+  'Usage: checkpoint:save \'{"sliceId":"M01-S01","baseCommit":"abc123","currentWave":0,"completedWaves":[],"completedTasks":[],"executorLog":[]}\'';
+
 export const checkpointSaveCmd = async (args: string[]): Promise<string> => {
   const [dataJson] = args;
   if (!dataJson) {
+    return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: USAGE } });
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(dataJson);
+  } catch {
     return JSON.stringify({
       ok: false,
-      error: { code: 'INVALID_ARGS', message: 'Usage: checkpoint:save <checkpoint-data-json>' },
+      error: { code: 'INVALID_ARGS', message: `Invalid JSON. ${USAGE}` },
     });
   }
-  try {
-    const data = JSON.parse(dataJson);
-    const artifactStore = new MarkdownArtifactAdapter(process.cwd());
-    const result = await saveCheckpoint(data, { artifactStore });
-    if (isOk(result)) return JSON.stringify({ ok: true, data: null });
-    return JSON.stringify({ ok: false, error: result.error });
-  } catch {
-    return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Invalid JSON input' } });
+  if (typeof (data as Record<string, unknown>)?.sliceId !== 'string') {
+    return JSON.stringify({
+      ok: false,
+      error: { code: 'INVALID_ARGS', message: `Missing required field "sliceId". ${USAGE}` },
+    });
   }
+  const artifactStore = new MarkdownArtifactAdapter(process.cwd());
+  const result = await saveCheckpoint(data as Parameters<typeof saveCheckpoint>[0], { artifactStore });
+  if (isOk(result)) return JSON.stringify({ ok: true, data: null });
+  return JSON.stringify({ ok: false, error: result.error });
 };

--- a/tools/src/cli/commands/project-init.cmd.spec.ts
+++ b/tools/src/cli/commands/project-init.cmd.spec.ts
@@ -1,0 +1,31 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { projectInitCmd } from './project-init.cmd.js';
+
+describe('project:init — .tff/ auto-creation', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'tff-init-test-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates .tff/ directory before opening database', async () => {
+    expect(existsSync(path.join(tmpDir, '.tff'))).toBe(false);
+
+    const result = JSON.parse(await projectInitCmd(['test-project', 'A test']));
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(path.join(tmpDir, '.tff'))).toBe(true);
+    expect(existsSync(path.join(tmpDir, '.tff', 'state.db'))).toBe(true);
+  });
+});

--- a/tools/src/cli/commands/project-init.cmd.ts
+++ b/tools/src/cli/commands/project-init.cmd.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from 'node:fs';
 import { initProject } from '../../application/project/init-project.js';
 import { isOk } from '../../domain/result.js';
 import { MarkdownArtifactAdapter } from '../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js';
@@ -12,6 +13,7 @@ export const projectInitCmd = async (args: string[]): Promise<string> => {
       ok: false,
       error: { code: 'INVALID_ARGS', message: 'Usage: project:init <name> [vision]' },
     });
+  mkdirSync('.tff', { recursive: true });
   const { projectStore } = createStateStores();
   const artifactStore = new MarkdownArtifactAdapter(process.cwd());
 

--- a/tools/src/cli/commands/waves-detect.cmd.ts
+++ b/tools/src/cli/commands/waves-detect.cmd.ts
@@ -1,16 +1,30 @@
 import { detectWaves } from '../../application/waves/detect-waves.js';
 import { isOk } from '../../domain/result.js';
 
+const USAGE = 'Usage: waves:detect \'[{"id":"T01","dependsOn":[]},{"id":"T02","dependsOn":["T01"]}]\'';
+
 export const wavesDetectCmd = async (args: string[]): Promise<string> => {
   const input = args[0];
-  if (!input)
-    return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Usage: waves:detect <json-tasks>' } });
+  if (!input) return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: USAGE } });
+  let tasks: unknown;
   try {
-    const tasks = JSON.parse(input);
-    const result = detectWaves(tasks);
-    if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
-    return JSON.stringify({ ok: false, error: result.error });
+    tasks = JSON.parse(input);
   } catch {
-    return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Invalid JSON input' } });
+    return JSON.stringify({
+      ok: false,
+      error: { code: 'INVALID_ARGS', message: `Invalid JSON. ${USAGE}` },
+    });
   }
+  if (!Array.isArray(tasks) || !tasks.every((t) => typeof t?.id === 'string' && Array.isArray(t?.dependsOn))) {
+    return JSON.stringify({
+      ok: false,
+      error: {
+        code: 'INVALID_ARGS',
+        message: `Each task must have { id: string, dependsOn: string[] }. ${USAGE}`,
+      },
+    });
+  }
+  const result = detectWaves(tasks);
+  if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
+  return JSON.stringify({ ok: false, error: result.error });
 };

--- a/tools/src/cli/commands/worktree-create.cmd.ts
+++ b/tools/src/cli/commands/worktree-create.cmd.ts
@@ -1,13 +1,21 @@
+import path from 'node:path';
 import { createWorktreeUseCase } from '../../application/worktree/create-worktree.js';
 import { isOk } from '../../domain/result.js';
+import { copyTffToWorktree } from '../../infrastructure/adapters/git/copy-tff-to-worktree.js';
 import { GitCliAdapter } from '../../infrastructure/adapters/git/git-cli.adapter.js';
 
 export const worktreeCreateCmd = async (args: string[]): Promise<string> => {
   const [sliceId] = args;
   if (!sliceId)
     return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Usage: worktree:create <slice-id>' } });
-  const gitOps = new GitCliAdapter(process.cwd());
+  const cwd = process.cwd();
+  const gitOps = new GitCliAdapter(cwd);
   const result = await createWorktreeUseCase({ sliceId }, { gitOps });
-  if (isOk(result)) return JSON.stringify({ ok: true, data: result.data });
+  if (isOk(result)) {
+    const tffDir = path.join(cwd, '.tff');
+    const worktreeAbsPath = path.resolve(cwd, result.data.worktreePath);
+    copyTffToWorktree(tffDir, worktreeAbsPath);
+    return JSON.stringify({ ok: true, data: result.data });
+  }
   return JSON.stringify({ ok: false, error: result.error });
 };

--- a/tools/src/cli/commands/worktree-create.cmd.ts
+++ b/tools/src/cli/commands/worktree-create.cmd.ts
@@ -10,7 +10,10 @@ export const worktreeCreateCmd = async (args: string[]): Promise<string> => {
     return JSON.stringify({ ok: false, error: { code: 'INVALID_ARGS', message: 'Usage: worktree:create <slice-id>' } });
   const cwd = process.cwd();
   const gitOps = new GitCliAdapter(cwd);
-  const result = await createWorktreeUseCase({ sliceId }, { gitOps });
+  // Derive milestone branch from slice ID (e.g., M01-S01 → milestone/M01)
+  const milestoneMatch = sliceId.match(/^(M\d+)/);
+  const startPoint = milestoneMatch ? `milestone/${milestoneMatch[1]}` : undefined;
+  const result = await createWorktreeUseCase({ sliceId, startPoint }, { gitOps });
   if (isOk(result)) {
     const tffDir = path.join(cwd, '.tff');
     const worktreeAbsPath = path.resolve(cwd, result.data.worktreePath);

--- a/tools/src/domain/ports/git-ops.port.ts
+++ b/tools/src/domain/ports/git-ops.port.ts
@@ -4,7 +4,7 @@ import type { CommitRef } from '../value-objects/commit-ref.js';
 
 export interface GitOps {
   createBranch(name: string, from: string): Promise<Result<void, DomainError>>;
-  createWorktree(path: string, branch: string): Promise<Result<void, DomainError>>;
+  createWorktree(path: string, branch: string, startPoint?: string): Promise<Result<void, DomainError>>;
   deleteWorktree(path: string): Promise<Result<void, DomainError>>;
   listWorktrees(): Promise<Result<string[], DomainError>>;
   commit(message: string, files: string[], worktreePath?: string): Promise<Result<CommitRef, DomainError>>;

--- a/tools/src/infrastructure/adapters/git/git-cli.adapter.ts
+++ b/tools/src/infrastructure/adapters/git/git-cli.adapter.ts
@@ -59,8 +59,10 @@ export class GitCliAdapter implements GitOps {
     this.invalidateCache();
     return Ok(undefined);
   }
-  async createWorktree(path: string, branch: string): Promise<Result<void, DomainError>> {
-    const r = await runGit(['worktree', 'add', path, '-b', branch], this.repoRoot);
+  async createWorktree(path: string, branch: string, startPoint?: string): Promise<Result<void, DomainError>> {
+    const args = ['worktree', 'add', path, '-b', branch];
+    if (startPoint) args.push(startPoint);
+    const r = await runGit(args, this.repoRoot);
     if (!r.ok) return r;
     return Ok(undefined);
   }

--- a/tools/src/infrastructure/adapters/sqlite/load-native-binding.spec.ts
+++ b/tools/src/infrastructure/adapters/sqlite/load-native-binding.spec.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getNativeBindingPath } from './load-native-binding.js';
+
+describe('getNativeBindingPath', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'tff-native-binding-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns path when co-located binding exists', () => {
+    const bindingFile = `better_sqlite3.${process.platform}-${process.arch}.node`;
+    writeFileSync(path.join(tmpDir, bindingFile), 'fake-binary');
+
+    const result = getNativeBindingPath(tmpDir);
+    expect(result).toBe(path.join(tmpDir, bindingFile));
+  });
+
+  it('returns undefined when no co-located binding exists', () => {
+    const result = getNativeBindingPath(tmpDir);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for default dirname in dev/test environment', () => {
+    const result = getNativeBindingPath();
+    expect(result).toBeUndefined();
+  });
+});

--- a/tools/src/infrastructure/adapters/sqlite/load-native-binding.ts
+++ b/tools/src/infrastructure/adapters/sqlite/load-native-binding.ts
@@ -1,0 +1,15 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolves the platform-specific better_sqlite3 native binding path.
+ * In the bundled CLI (tools/dist/), the .node file is co-located.
+ * In dev/test, returns undefined so better-sqlite3 uses standard node_modules resolution.
+ */
+export function getNativeBindingPath(dirname?: string): string | undefined {
+  const dir = dirname ?? __dirname;
+  const bindingFile = `better_sqlite3.${process.platform}-${process.arch}.node`;
+  const bindingPath = path.join(dir, bindingFile);
+  if (existsSync(bindingPath)) return bindingPath;
+  return undefined;
+}

--- a/tools/src/infrastructure/adapters/sqlite/sqlite-state.adapter.ts
+++ b/tools/src/infrastructure/adapters/sqlite/sqlite-state.adapter.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { getNativeBindingPath } from './load-native-binding.js';
 import type { Milestone } from '../../../domain/entities/milestone.js';
 import { formatMilestoneNumber } from '../../../domain/entities/milestone.js';
 import type { Project } from '../../../domain/entities/project.js';
@@ -47,12 +48,14 @@ export class SQLiteStateAdapter
   constructor(private db: Database.Database) {}
 
   static create(dbPath: string): SQLiteStateAdapter {
-    const db = new Database(dbPath);
+    const nativeBinding = getNativeBindingPath();
+    const db = new Database(dbPath, nativeBinding ? { nativeBinding } : undefined);
     return new SQLiteStateAdapter(db);
   }
 
   static createInMemory(): SQLiteStateAdapter {
-    const db = new Database(':memory:');
+    const nativeBinding = getNativeBindingPath();
+    const db = new Database(':memory:', nativeBinding ? { nativeBinding } : undefined);
     return new SQLiteStateAdapter(db);
   }
 

--- a/tools/src/infrastructure/adapters/sqlite/sqlite-state.adapter.ts
+++ b/tools/src/infrastructure/adapters/sqlite/sqlite-state.adapter.ts
@@ -1,5 +1,4 @@
 import Database from 'better-sqlite3';
-import { getNativeBindingPath } from './load-native-binding.js';
 import type { Milestone } from '../../../domain/entities/milestone.js';
 import { formatMilestoneNumber } from '../../../domain/entities/milestone.js';
 import type { Project } from '../../../domain/entities/project.js';
@@ -32,6 +31,7 @@ import type { SliceUpdateProps } from '../../../domain/value-objects/slice-updat
 import type { TaskProps } from '../../../domain/value-objects/task-props.js';
 import type { TaskUpdateProps } from '../../../domain/value-objects/task-update-props.js';
 import type { WorkflowSession } from '../../../domain/value-objects/workflow-session.js';
+import { getNativeBindingPath } from './load-native-binding.js';
 import { runMigrations } from './schema.js';
 
 export class SQLiteStateAdapter

--- a/tools/src/infrastructure/hooks/post-checkout-template.ts
+++ b/tools/src/infrastructure/hooks/post-checkout-template.ts
@@ -11,13 +11,23 @@ BRANCH=$(git branch --show-current)
 
 command -v node >/dev/null 2>&1 || exit 0
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+# Resolve main repo root (works in both main repo and worktrees)
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+if [ -z "$GIT_COMMON_DIR" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+else
+  # git-common-dir is the .git directory (or .git/worktrees/<name>/..)
+  # For main repo: /path/to/repo/.git -> parent is repo root
+  # For worktrees: /path/to/repo/.git -> same
+  REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
+fi
 TFF_TOOLS="$REPO_ROOT/tools/dist/tff-tools.cjs"
 [ -f "$TFF_TOOLS" ] || exit 0
 
-mkdir -p "$REPO_ROOT/.tff"
+CWD_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+mkdir -p "$CWD_ROOT/.tff"
 
-node "$TFF_TOOLS" hook:post-checkout "$BRANCH" >> "$REPO_ROOT/.tff/hook.log" 2>&1
+node "$TFF_TOOLS" hook:post-checkout "$BRANCH" >> "$CWD_ROOT/.tff/hook.log" 2>&1
 
 if [ -x "$(dirname "$0")/post-checkout.pre-tff" ]; then
   "$(dirname "$0")/post-checkout.pre-tff" "$@" || true

--- a/tools/src/infrastructure/testing/in-memory-git-ops.ts
+++ b/tools/src/infrastructure/testing/in-memory-git-ops.ts
@@ -17,7 +17,7 @@ export class InMemoryGitOps implements GitOps {
     return Ok(undefined);
   }
 
-  async createWorktree(path: string, branch: string): Promise<Result<void, DomainError>> {
+  async createWorktree(path: string, branch: string, _startPoint?: string): Promise<Result<void, DomainError>> {
     this.worktrees.set(path, branch);
     this.branches.add(branch);
     return Ok(undefined);

--- a/tools/tsup.config.ts
+++ b/tools/tsup.config.ts
@@ -1,3 +1,5 @@
+import { copyFileSync } from 'node:fs';
+import path from 'node:path';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -9,4 +11,16 @@ export default defineConfig({
   noExternal: [/(.*)/],
   external: ['better-sqlite3'],
   banner: { js: '#!/usr/bin/env node' },
+  onSuccess: async () => {
+    const platform = process.platform;
+    const arch = process.arch;
+    const src = path.resolve('node_modules/better-sqlite3/build/Release/better_sqlite3.node');
+    const dest = path.resolve(`tools/dist/better_sqlite3.${platform}-${arch}.node`);
+    try {
+      copyFileSync(src, dest);
+      console.log(`Copied native binding: better_sqlite3.${platform}-${arch}.node`);
+    } catch (e) {
+      console.warn(`Warning: Could not copy native binding: ${e}`);
+    }
+  },
 });

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -63,7 +63,7 @@ WRITE `.tff/milestones/<milestone>/slices/<id>/PLAN.md`:
 
 ### 5. Create Tasks + Detect Waves
 CREATE tasks: `tff-tools` ∀ task w/ deps
-DETECT: `tff-tools waves:detect '<tasks-json>'` → show user
+DETECT: `tff-tools waves:detect '[{"id":"T01","dependsOn":[]},{"id":"T02","dependsOn":["T01"]}]'` → show user
 
 ### 6. Architecture Review (F-lite ∧ F-full)
 LOAD @skills/architecture-review/SKILL.md + @skills/writing-plans/SKILL.md → SPAWN subagent: {plan_content, spec_content}


### PR DESCRIPTION
## Summary

- **Native binding resolution**: Ship platform-specific `better_sqlite3.node` alongside `tff-tools.cjs`. Runtime resolver (`getNativeBindingPath`) passes co-located binding to `better-sqlite3` constructor. Build copies binary via tsup `onSuccess` hook.
- **`.tff/` auto-creation**: `project:init` now calls `mkdirSync('.tff')` before opening the database, and adds `.tff/` to `.gitignore` automatically.
- **CI matrix builds**: `release.yml` now builds on darwin-arm64, darwin-x64, linux-x64 and bundles all native binaries in the release.
- **Worktree fixes**: `worktree:create` now forks from milestone branch (not HEAD), copies `.tff/` to new worktrees, and post-checkout hook resolves main repo root correctly in worktrees.
- **CLI error messages**: `waves:detect` and `checkpoint:save` now show schema examples on invalid input.

## Acceptance Criteria

- [x] AC1: Native binding loads from `tools/dist/` without `node_modules/`
- [x] AC2: `npm run build` copies `.node` binary with platform suffix
- [x] AC3: CI release workflow builds for 3 platforms (release-dev.yml intentionally excluded per plannotator — dev releases use separate repo)
- [x] AC4: `project:init` creates `.tff/` before opening database
- [x] AC5: All 1106 tests pass
- [x] AC6: Built binary runs `project:init` in clean temp dir without `npm install`

## Additional fixes (user-requested during execution)

- `worktree:create` copies `.tff/` to new worktrees (prevents empty DB cascade)
- `worktree:create` forks slice branch from milestone branch (prevents "no common history" PR errors)
- Post-checkout hook uses `git-common-dir` to find main repo root in worktrees
- `project:init` adds `.tff/` to `.gitignore` (prevents artifacts leaking to code branches)
- `waves:detect` and `checkpoint:save` show schema examples in error messages

## Review Results

| Stage | Verdict |
|-------|---------|
| Spec compliance | PASS (AC3 gap is intentional per plannotator) |
| Code quality | APPROVE |
| Security audit | PASS (0 critical/high) |

## Test plan

- [x] Full test suite: 1106/1106 passing
- [x] Typecheck: clean
- [x] Lint: clean (2 pre-existing warnings only)
- [x] AC6 smoke test: `mktemp -d && git init && tff-tools.cjs project:init` succeeds
- [ ] CI matrix build verification (requires tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)