### PR TITLE
fix: prevent state branch artifact leak to code branches

### DIFF
--- a/tools/src/cli/commands/hook-post-checkout.cmd.ts
+++ b/tools/src/cli/commands/hook-post-checkout.cmd.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { restoreBranchUseCase } from '../../application/state-branch/restore-branch.js';
 import { isOk } from '../../domain/result.js';
@@ -70,11 +70,11 @@ export const hookPostCheckoutCmd = async (args: string[]): Promise<string> => {
         });
       }
 
-      // 5. Write stamp — read stateId from root-level branch-meta.json
-      const rootMetaPath = path.join(cwd, 'branch-meta.json');
-      try {
-        if (existsSync(rootMetaPath)) {
-          const raw = JSON.parse(readFileSync(rootMetaPath, 'utf8'));
+      // 5. Write stamp — extract stateId from branch-meta.json in git (not disk, to avoid leaking root-level artifacts)
+      const metaBufR = await gitOps.extractFile(`tff-state/${codeBranch}`, 'branch-meta.json');
+      if (isOk(metaBufR)) {
+        try {
+          const raw = JSON.parse(metaBufR.data.toString('utf8'));
           const meta = BranchMetaSchema.parse(raw);
           writeLocalStamp(tffDir, {
             stateId: meta.stateId,
@@ -82,10 +82,10 @@ export const hookPostCheckoutCmd = async (args: string[]): Promise<string> => {
             parentStateBranch: meta.parentStateBranch,
             createdAt: meta.createdAt,
           });
-        } else {
+        } catch {
           writeSyntheticStamp(tffDir, codeBranch);
         }
-      } catch {
+      } else {
         writeSyntheticStamp(tffDir, codeBranch);
       }
 

--- a/tools/src/cli/with-branch-guard.spec.ts
+++ b/tools/src/cli/with-branch-guard.spec.ts
@@ -56,7 +56,9 @@ describe('withBranchGuard', () => {
     }));
 
     vi.doMock('../infrastructure/adapters/git/git-cli.adapter.js', () => ({
-      GitCliAdapter: class MockGitCliAdapter {},
+      GitCliAdapter: class MockGitCliAdapter {
+        extractFile = vi.fn().mockResolvedValue({ ok: false, error: { code: 'NOT_FOUND', message: 'mock' } });
+      },
     }));
     vi.doMock('../infrastructure/adapters/git/git-state-branch.adapter.js', () => ({
       GitStateBranchAdapter: class MockGitStateBranchAdapter {},
@@ -94,7 +96,9 @@ describe('withBranchGuard', () => {
       createClosableStateStoresUnchecked: vi.fn(),
     }));
     vi.doMock('../infrastructure/adapters/git/git-cli.adapter.js', () => ({
-      GitCliAdapter: class MockGitCliAdapter {},
+      GitCliAdapter: class MockGitCliAdapter {
+        extractFile = vi.fn().mockResolvedValue({ ok: false, error: { code: 'NOT_FOUND', message: 'mock' } });
+      },
     }));
     vi.doMock('../infrastructure/adapters/git/git-state-branch.adapter.js', () => ({
       GitStateBranchAdapter: class MockGitStateBranchAdapter {},
@@ -186,7 +190,9 @@ describe('withClosableBranchGuard', () => {
       }),
     }));
     vi.doMock('../infrastructure/adapters/git/git-cli.adapter.js', () => ({
-      GitCliAdapter: class MockGitCliAdapter {},
+      GitCliAdapter: class MockGitCliAdapter {
+        extractFile = vi.fn().mockResolvedValue({ ok: false, error: { code: 'NOT_FOUND', message: 'mock' } });
+      },
     }));
     vi.doMock('../infrastructure/adapters/git/git-state-branch.adapter.js', () => ({
       GitStateBranchAdapter: class MockGitStateBranchAdapter {},

--- a/tools/src/cli/with-branch-guard.ts
+++ b/tools/src/cli/with-branch-guard.ts
@@ -1,4 +1,3 @@
-import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { restoreBranchUseCase } from '../application/state-branch/restore-branch.js';
 import { BranchMismatchError } from '../domain/errors/branch-mismatch.error.js';
@@ -25,11 +24,11 @@ async function handleMismatch(error: BranchMismatchError): Promise<boolean> {
   const result = await restoreBranchUseCase({ codeBranch: error.currentBranch, targetDir: cwd }, { stateBranch });
 
   if (isOk(result) && result.data !== null) {
-    // Read stateId from root-level branch-meta.json (extracted by restore)
-    const rootMetaPath = path.join(cwd, 'branch-meta.json');
-    try {
-      if (existsSync(rootMetaPath)) {
-        const raw = JSON.parse(readFileSync(rootMetaPath, 'utf8'));
+    // Extract stateId from branch-meta.json in git (not disk, to avoid leaking root-level artifacts)
+    const metaBufR = await gitOps.extractFile(`tff-state/${error.currentBranch}`, 'branch-meta.json');
+    if (isOk(metaBufR)) {
+      try {
+        const raw = JSON.parse(metaBufR.data.toString('utf8'));
         const meta = BranchMetaSchema.parse(raw);
         writeLocalStamp(tffDir, {
           stateId: meta.stateId,
@@ -37,10 +36,10 @@ async function handleMismatch(error: BranchMismatchError): Promise<boolean> {
           parentStateBranch: meta.parentStateBranch,
           createdAt: meta.createdAt,
         });
-      } else {
+      } catch {
         writeSyntheticStamp(tffDir, error.currentBranch);
       }
-    } catch {
+    } else {
       writeSyntheticStamp(tffDir, error.currentBranch);
     }
     return true;

--- a/tools/src/infrastructure/adapters/git/git-state-branch.adapter.ts
+++ b/tools/src/infrastructure/adapters/git/git-state-branch.adapter.ts
@@ -174,6 +174,7 @@ export class GitStateBranchAdapter implements StateBranchPort {
     let filesRestored = 0;
     const resolvedTargetDir = path.resolve(targetDir);
     for (const filePath of filesR.data) {
+      if (!filePath.startsWith('.tff/')) continue; // only restore .tff/ files, not root-level state artifacts
       const destPath = path.join(targetDir, filePath);
       const resolved = path.resolve(destPath);
       if (!resolved.startsWith(resolvedTargetDir + path.sep) && resolved !== resolvedTargetDir) {


### PR DESCRIPTION
## Problem

`branch-meta.json` and `milestones/` directory were appearing as untracked files on code branches (e.g. `milestone/M06`).

These are state-only artifacts that live on `tff-state/*` branches. They exist at the root of the state branch tree (outside `.tff/`), so they aren't covered by the `.tff/` blanket gitignore.

## Root Cause

The `restore()` method in `GitStateBranchAdapter` extracts **all** files from the state branch to the working directory — no prefix filtering. This includes:

- `branch-meta.json` (state branch identity metadata)
- `milestones/` (artifact copies at root, outside `.tff/`)
- `.gitignore` (state branch's own gitignore)

The post-checkout hook and branch guard both called `restore()`, then read `branch-meta.json` from disk to extract `stateId` for the local stamp. Neither cleaned up the root-level file afterward.

## Fix

### 1. `git-state-branch.adapter.ts` — `restore()` method

Added a prefix filter so only `.tff/` files are restored to the working directory:

```typescript
for (const filePath of filesR.data) {
  if (!filePath.startsWith('.tff/')) continue; // only restore .tff/ files
  // ...
}
```

### 2. `hook-post-checkout.cmd.ts` — stamp extraction

Instead of reading `branch-meta.json` from the working directory after restore, now extracts it directly from the state branch via `gitOps.extractFile()`.

Removed unused `existsSync` / `readFileSync` imports.

### 3. `with-branch-guard.ts` — `handleMismatch()`

Same change as #2 — extract `branch-meta.json` from git instead of disk.

Removed unused `existsSync` / `readFileSync` imports.

## Result

- Root-level artifacts (`branch-meta.json`, `milestones/`, `.gitignore`) are no longer leaked to code branches
- Only `.tff/` directory contents are restored to the working directory
- `git status` on code branches will show no untracked state artifacts

## Affected Files

- `tools/src/infrastructure/adapters/git/git-state-branch.adapter.ts`
- `tools/src/cli/commands/hook-post-checkout.cmd.ts`
- `tools/src/cli/with-branch-guard.ts`