### PR TITLE
fix: properly check Result from state branch fork/create operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-04-06
+
+### Fixed
+
+- **State branch creation now properly reports errors** — Previously, state branch fork/create operations failed silently because the Result type was not being checked
+  - `create-milestone.ts`: Now checks Result from `stateBranch.fork()` and logs warning on failure
+  - `create-slice.ts`: Now checks Result from `stateBranch.fork()` and logs warning on failure  
+  - `init-project.ts`: Now checks Result from `stateBranch.createRoot()` and logs warning on failure
+
+### Changed
+
+- Bumped version to 0.8.1 across all files:
+  - `package.json`
+  - `plugin/.claude-plugin/plugin.json`
+  - `tools/src/cli/index.ts` (CLI version string)
+
 ## [0.8.0] - 2026-04-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-forge-flow",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Autonomous coding agent orchestrator for Claude Code",
   "type": "module",
   "engines": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "the-forge-flow",
 	"description": "Autonomous coding agent orchestrator with SQLite-backed state, plannotator integration, and wave-based parallel execution",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"author": { "name": "MonsieurBarti" },
 	"repository": "https://github.com/MonsieurBarti/The-Forge-Flow-CC",
 	"keywords": ["orchestration", "sqlite", "plannotator", "agents", "tdd"]

--- a/tools/src/application/milestone/create-milestone.ts
+++ b/tools/src/application/milestone/create-milestone.ts
@@ -50,10 +50,9 @@ export const createMilestoneUseCase = async (
   );
 
   if (deps.stateBranch) {
-    try {
-      await deps.stateBranch.fork(branchName, 'tff-state/main');
-    } catch {
-      // State branch fork is best-effort
+    const forkResult = await deps.stateBranch.fork(branchName, 'tff-state/main');
+    if (!isOk(forkResult)) {
+      console.warn(`[tff] Failed to create milestone state branch: ${forkResult.error.message}`);
     }
   }
 

--- a/tools/src/application/project/init-project.ts
+++ b/tools/src/application/project/init-project.ts
@@ -44,10 +44,9 @@ export const initProject = async (
   await deps.artifactStore.write('.tff/PROJECT.md', projectMd);
 
   if (deps.stateBranch) {
-    try {
-      await deps.stateBranch.createRoot();
-    } catch {
-      // State branch creation is best-effort during init
+    const createResult = await deps.stateBranch.createRoot();
+    if (!isOk(createResult)) {
+      console.warn(`[tff] Failed to create root state branch: ${createResult.error.message}`);
     }
   }
 

--- a/tools/src/application/slice/create-slice.ts
+++ b/tools/src/application/slice/create-slice.ts
@@ -55,10 +55,9 @@ export const createSliceUseCase = async (
   );
 
   if (deps.stateBranch) {
-    try {
-      await deps.stateBranch.fork(`slice/${slice.id}`, `tff-state/milestone/${input.milestoneId}`);
-    } catch {
-      // State branch fork is best-effort
+    const forkResult = await deps.stateBranch.fork(`slice/${slice.id}`, `tff-state/milestone/${input.milestoneId}`);
+    if (!isOk(forkResult)) {
+      console.warn(`[tff] Failed to create slice state branch: ${forkResult.error.message}`);
     }
   }
 

--- a/tools/src/cli/index.ts
+++ b/tools/src/cli/index.ts
@@ -95,7 +95,7 @@ const main = async () => {
     console.log(
       JSON.stringify({
         ok: true,
-        data: { name: 'tff-tools', version: '0.7.0', commands: Object.keys(commands) },
+        data: { name: 'tff-tools', version: '0.8.1', commands: Object.keys(commands) },
       }),
     );
     return;


### PR DESCRIPTION
## Problem

State branches (tff-state/milestone/M01, tff-state/slice/M01-S01) were not being created when milestones and slices were created.

## Root Cause

The \"fork\" and \"createRoot\" methods on GitStateBranchAdapter return \"Result<T, E>\" (not throwing Promises), but the calling code was:

1. Wrapping in try-catch (useless for Result types)
2. Not checking if the Result was Ok or Err
3. Silently ignoring failures



## Fix

Now properly checks the Result:



## Files Changed

- \"create-milestone.ts\" - Fork milestone state branch from root
- \"create-slice.ts\" - Fork slice state branch from milestone
- \"init-project.ts\" - Create root state branch

## Impact

Users will now see warning messages if state branch creation fails, making debugging possible. Previously, failures were completely silent.

## Testing

- Type check passes
- Build succeeds
- 1582 tests pass