### PR TITLE
fix: use tff-tools command instead of node path

### DIFF
--- a/commands/tff/repair-branches.md
+++ b/commands/tff/repair-branches.md
@@ -9,7 +9,7 @@ Scan all milestones and slices, create any missing tff-state/* branches.
 </objective>
 
 <execution_context>
-Run `node tools/dist/tff-tools.cjs state:repair-branches [--dry-run]`
+Run `tff-tools state:repair-branches [--dry-run]`
 </execution_context>
 
 <output>


### PR DESCRIPTION
## Problem

The \"repair-branches\" command was using \"node tools/dist/tff-tools.cjs\" path,
but tff-tools is installed as a Claude Code plugin and available as a global
command, not at a local project path.

## Fix

Changed execution context to use \"tff-tools state:repair-branches\" directly,
matching the pattern used in workflow files.

## Before
{"ok":false,"error":{"code":"INTERNAL_ERROR","message":"TypeError: Cannot open database because the directory does not exist"}}

## After  
