### PR TITLE
fix(ci): remove deprecated macos-13 runner from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
         include:
           - os: macos-latest
             platform: darwin-arm64
-          - os: macos-13
-            platform: darwin-x64
           - os: ubuntu-latest
             platform: linux-x64
 


### PR DESCRIPTION
# Description

## What does this PR change?

Fixes the release workflow by removing the deprecated `macos-13` runner.

The release workflow now builds native bindings for:
- `macos-latest` (darwin-arm64)
- `ubuntu-latest` (linux-x64)

## Context

PR #70 was merged but the release workflow failed because `macos-13` runner configuration is no longer supported.