### PR TITLE
fix(ci): match tff release workflow with npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,26 @@ permissions:
   id-token: write
 
 jobs:
-  release-please:
+  release:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
 
       - name: Release Please
         uses: googleapis/release-please-action@v4
@@ -25,68 +38,8 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build-native:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            platform: darwin-arm64
-          - os: ubuntu-latest
-            platform: linux-x64
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
-
-      - run: bun install
-
-      - name: Build
-        run: bun run build
-
-      - name: Upload native binding
-        uses: actions/upload-artifact@v4
-        with:
-          name: native-${{ matrix.platform }}
-          path: dist/infrastructure/adapters/sqlite/better_sqlite3.*.node
-
-  publish-release:
-    needs: [release-please, build-native]
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
-
-      - run: bun install
-
-      - name: Build
-        run: bun run build
-
-      - name: Download all native bindings
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/infrastructure/adapters/sqlite/
-          pattern: native-*
-          merge-multiple: true
-
-      - name: List artifacts
-        run: ls -la dist/infrastructure/adapters/sqlite/
-
-      - name: Upload release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.release-please.outputs.version }}
-          files: |
-            dist/cli/index.js
-            dist/infrastructure/adapters/sqlite/better_sqlite3.*.node
+      - name: Publish to npm
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun publish --access public


### PR DESCRIPTION
# Description

## What does this PR change?

Updates the release workflow to match tff style:

- Single `release` job (not split into multiple jobs)
- Adds `npm publish` step with `NPM_TOKEN` secret
- Removes separate native binding build matrix (better-sqlite3 compiles at install time)
- Uses `bun-version: latest` instead of pinned version

## Context

PR #70 was merged but the workflow structure was different from tff. This aligns both projects.