### PR TITLE
feat(M02-S01): Remove AskUserQuestion, use inline questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Plugin Distribution:** Fully bundled CLI with native bindings for all platforms (darwin-x64/arm64, linux-x64/arm64, win32-x64) — zero npm install required
 - **Compressed Notation:** Applied formal logic symbols (∀∃∈∧∨¬->∅) to 195 markdown files across workflows, skills, agents, and GSD docs
 
+### Changed
+
+- **S01 — AskUserQuestion removal:** Removed AskUserQuestion from AI-facing instruction files (15 commands, 7 workflows, 1 skill, 1 reference); AI now asks questions inline in conversation rather than through a structured tool call; `tff_ask_user` tool remains for TFF's internal use
+
 ### Infrastructure
 
 - Built CLI artifacts committed to `tools/dist/` for out-of-the-box plugin installation

--- a/commands/tff/add-slice.md
+++ b/commands/tff/add-slice.md
@@ -2,7 +2,7 @@
 name: tff:add-slice
 description: Add a slice to the current milestone
 argument-hint: "<slice-name>"
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob
 ---
 
 <objective>

--- a/commands/tff/complete-milestone.md
+++ b/commands/tff/complete-milestone.md
@@ -1,7 +1,7 @@
 ---
 name: tff:complete-milestone
 description: Create milestone PR, review, and merge to main
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 ---
 
 <objective>

--- a/commands/tff/compose.md
+++ b/commands/tff/compose.md
@@ -1,7 +1,7 @@
 ---
 name: tff:compose
 description: Detect skill co-activation clusters and propose bundles or agents
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion, Bash(plannotator:*)
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent, Bash(plannotator:*)
 ---
 
 <objective>

--- a/commands/tff/create-skill.md
+++ b/commands/tff/create-skill.md
@@ -2,7 +2,7 @@
 name: tff:create-skill
 description: Draft a new skill from a detected pattern or description
 argument-hint: "<candidate-number|description>"
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion, Bash(plannotator:*)
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent, Bash(plannotator:*)
 ---
 
 <objective>

--- a/commands/tff/debug.md
+++ b/commands/tff/debug.md
@@ -2,7 +2,7 @@
 name: tff:debug
 description: Diagnose and fix a bug with systematic debugging — diagnosis first, then fix via slice
 argument-hint: "<error description or symptom>"
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
 ---
 
 <objective>

--- a/commands/tff/discuss.md
+++ b/commands/tff/discuss.md
@@ -2,7 +2,7 @@
 name: tff:discuss
 description: Brainstorm and scope a slice
 argument-hint: "[slice-id]"
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 ---
 
 <objective>

--- a/commands/tff/insert-slice.md
+++ b/commands/tff/insert-slice.md
@@ -2,7 +2,7 @@
 name: tff:insert-slice
 description: Insert a slice between existing slices
 argument-hint: "<after-slice-id> <slice-name>"
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob
 ---
 
 <objective>

--- a/commands/tff/learn.md
+++ b/commands/tff/learn.md
@@ -1,7 +1,7 @@
 ---
 name: tff:learn
 description: Detect corrections to existing skills and propose bounded refinements
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion, Bash(plannotator:*)
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent, Bash(plannotator:*)
 ---
 
 <objective>

--- a/commands/tff/new-milestone.md
+++ b/commands/tff/new-milestone.md
@@ -2,7 +2,7 @@
 name: tff:new-milestone
 description: Start a new milestone cycle
 argument-hint: "[milestone-name]"
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 ---
 
 <objective>

--- a/commands/tff/new.md
+++ b/commands/tff/new.md
@@ -2,7 +2,7 @@
 name: tff:new
 description: Initialize a new tff project with vision, requirements, and first milestone
 argument-hint: "[project-name]"
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 ---
 
 <objective>

--- a/commands/tff/plan.md
+++ b/commands/tff/plan.md
@@ -2,7 +2,7 @@
 name: tff:plan
 description: Plan a slice with task decomposition and plannotator review
 argument-hint: "[slice-id] [--tier S|F-lite|F-full]"
-allowed-tools: Read, Write, Bash, Grep, Glob, Agent, AskUserQuestion, Bash(plannotator:*)
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent, Bash(plannotator:*)
 ---
 
 <objective>

--- a/commands/tff/quick.md
+++ b/commands/tff/quick.md
@@ -2,7 +2,7 @@
 name: tff:quick
 description: Execute a quick fix with S-tier defaults — skip discuss and research
 argument-hint: "<description>"
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion, Bash(plannotator:*)
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, Bash(plannotator:*)
 ---
 
 <objective>

--- a/commands/tff/remove-slice.md
+++ b/commands/tff/remove-slice.md
@@ -2,7 +2,7 @@
 name: tff:remove-slice
 description: Remove a future slice from the milestone
 argument-hint: "<slice-id>"
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob
 ---
 
 <objective>

--- a/commands/tff/rollback.md
+++ b/commands/tff/rollback.md
@@ -2,7 +2,7 @@
 name: tff:rollback
 description: Revert execution commits for a slice
 argument-hint: "<slice-id>"
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob
 ---
 
 <objective>

--- a/commands/tff/settings.md
+++ b/commands/tff/settings.md
@@ -1,7 +1,7 @@
 ---
 name: tff:settings
 description: View and modify all project settings — model profiles, autonomy, auto-learn
-allowed-tools: Read, Write, Bash, Grep, Glob, AskUserQuestion
+allowed-tools: Read, Write, Bash, Grep, Glob
 ---
 
 <objective>

--- a/references/orchestrator-pattern.md
+++ b/references/orchestrator-pattern.md
@@ -38,7 +38,7 @@ tff workflows are orchestrators. They coordinate — they don't do heavy work.
 
 ## Exception: Conversation-Driven Workflows
 
-discuss workflow: orchestrator drives Q&A directly via AskUserQuestion (rule 2 exception).
+discuss workflow: orchestrator drives Q&A directly inline (rule 2 exception).
 Reason: multi-turn user context ¬delegable to subagent.
 Agents spawned for independent tasks only (challenge, validate, review).
 ∀ other workflows: standard pattern applies.

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -15,7 +15,7 @@ Do NOT invoke any implementation skill, write any code, ∨ take any implementat
 
 ## Conversation Rules
 
-1. One question per message via AskUserQuestion
+1. One question per message
 2. Multiple choice preferred (A/B/C/D) — open-ended when needed
 3. Assess scope first: multi-subsystem -> decompose before detailing
 4. ∀ assumption: surface explicitly, ¬proceed on implicit agreement
@@ -23,14 +23,14 @@ Do NOT invoke any implementation skill, write any code, ∨ take any implementat
 
 ## Flow
 
-1. FRAME: Define problem, constraints, scope (2-4 questions via AskUserQuestion)
+1. FRAME: Define problem, constraints, scope (2-4 questions)
 2. APPROACH: Propose 2-3, recommend one, user picks
-3. DESIGN: Section-by-section, user approves each via AskUserQuestion
+3. DESIGN: Section-by-section, user approves each inline
    - standard: problem, approach, acceptance criteria, non-goals (~1 page)
    - complex: + constraints, architecture, error handling, testing strategy (~3 pages)
 4. WRITE: `project spec document (e.g., docs/specs/SPEC.md)`
 5. REVIEW: Dispatch anonymous spec reviewer subagent (max 3 iterations)
-6. USER GATE: Show spec, ask approval via AskUserQuestion
+6. USER GATE: Show spec, ask approval inline
 
 ## Spec Document Reviewer
 

--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -16,7 +16,7 @@ milestone audit passed
 
 **tff NEVER merges — only creates PR.**
 
-5. MERGE GATE: AskUserQuestion → "PR merged" ∨ "PR needs changes"
+5. MERGE GATE: ask the user inline → "PR merged" ∨ "PR needs changes"
    - merged → continue to step 6
    - needs changes → fix → push → go back to step 5
 6. CLOSE MILESTONE + CLEANUP:

--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -15,13 +15,13 @@ Exception to orchestrator rule 4 ("never load large files ∈ orchestrator"):
 like `discuss`, debug drives multi-turn investigation directly. For broad code
 exploration, spawn Explore subagents ∧ reason about their findings.
 
-1. GATHER: ask user for error/symptom + reproduction steps via AskUserQuestion
+1. GATHER: ask user for error/symptom + reproduction steps inline
 2. LOAD: @skills/systematic-debugging/SKILL.md
 3. CLASSIFY: reproducible error (Track A) ∨ symptom-based (Track B)
 4. INVESTIGATE: orchestrator drives systematic diagnosis per skill methodology
    - Track A: parse error → read implicated code → trace call chain → form hypothesis → verify
    - Track B: clarify symptom → reproduce → binary search → instrument → isolate
-5. PRESENT: root cause + evidence to user, ask for confirmation via AskUserQuestion
+5. PRESENT: root cause + evidence to user, ask for confirmation inline
    - If user disagrees → refine hypothesis, loop back to step 4
    - If diagnosis stalls after 3 hypotheses → escalate with findings so far
    - If root cause is external (dependency, system, infra) → exit with diagnostic report,
@@ -32,7 +32,7 @@ exploration, spawn Explore subagents ∧ reason about their findings.
 6. CREATE slice:
    - Create slice via `tff-tools`
    - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
-7. CLASSIFY: AskUserQuestion → user picks tier (S / F-lite / F-full)
+7. CLASSIFY: ask the user → user picks tier (S / F-lite / F-full)
    - Default suggestion based on diagnosis: single-file root cause → S, multi-file → F-lite
 8. PLAN: write fix strategy + implicated files ∈ PLAN.md
    - Write to `.tff/milestones/<milestone>/slices/<id>/PLAN.md`

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -15,7 +15,7 @@ CHECK: read slice state + notes
 ### 2. Interactive Design
 LOAD @skills/brainstorming/SKILL.md
 
-**Phase 1 — Scope** (2-4 questions via AskUserQuestion)
+**Phase 1 — Scope** (2-4 questions)
 - What problem does this solve? Who benefits?
 - What constraints? (time, tech, dependencies)
 - What does success look like?
@@ -24,11 +24,11 @@ LOAD @skills/brainstorming/SKILL.md
 **Phase 2 — Approach** (1 message)
 - Propose 2-3 approaches w/ trade-offs
 - Recommend one, explain why
-- User picks via AskUserQuestion
+- User picks inline
 
 **Phase 3 — Design** (section by section)
 - Present each section per tier template from @skills/brainstorming/SKILL.md
-- ∀ section: ask "does this look right?" via AskUserQuestion
+- ∀ section: ask "does this look right?" inline
 - Revise until approved, then next section
 
 ### 3. Write Spec
@@ -41,14 +41,14 @@ APPROVE → note concerns ∈ spec, proceed
 
 ### 5. Validate AC
 LOAD @skills/acceptance-criteria-validation/SKILL.md → SPAWN subagent: {spec_content, acceptance_criteria}
-∀ criterion: testable ∧ binary — gaps → revise via AskUserQuestion
+∀ criterion: testable ∧ binary — gaps → revise by asking the user inline
 
 ### 6. Spec Review
 DISPATCH anonymous reviewer via Agent tool (prompt: @skills/brainstorming/SKILL.md)
 Issues → fix, re-dispatch (max 3)
 
 ### 7. User Gate
-AskUserQuestion: "Spec at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
+Ask the user: "Spec at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
 
 ### 8. Classify Complexity
 Based on what was learned during discuss, build `ComplexitySignals`:
@@ -58,7 +58,7 @@ Based on what was learned during discuss, build `ComplexitySignals`:
 
 RUN: `tff-tools slice:classify '<signals-json>'`
 
-PRESENT result to user via AskUserQuestion:
+PRESENT result to user, asking inline:
 - "Based on scope: **<tier>** (S / F-lite / F-full). Confirm ∨ override?"
 - Options: S (single-file fix), F-lite (standard), F-full (complex)
 

--- a/workflows/health.md
+++ b/workflows/health.md
@@ -27,7 +27,7 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
    | Stale claims | OK/X stale |
    | Worktrees | OK/X orphans |
    ```
-6. stale slices found → AskUserQuestion: "Close stale slices?" → yes → `tff-tools slice:close <id> --reason "PR already merged"`
+6. stale slices found → ask the user: "Close stale slices?" → yes → `tff-tools slice:close <id> --reason "PR already merged"`
 7. other issues found → offer `/tff:sync` to reconcile
 
 8. NEXT: @references/next-steps.md

--- a/workflows/new-project.md
+++ b/workflows/new-project.md
@@ -21,7 +21,7 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
    d. SYNTHESIZE: read STACK.md, ARCHITECTURE.md, CONCERNS.md, CONVENTIONS.md
       - Propose: project name, vision statement, initial requirements
    e. PRESENT: "Here's what I understood about your project:" + proposed values
-   f. REFINE: user corrects/approves via AskUserQuestion
+   f. REFINE: user corrects/approves by asking inline
    g. Continue to step 3 with pre-filled values
 
 3. ASK user: project name (required), vision statement

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -11,7 +11,7 @@ active milestone ∃
 1. CREATE slice:
    - Create slice via `tff-tools`
    - Create worktree: `tff-tools worktree:create <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
-2. CLASSIFY: AskUserQuestion → user picks tier (S / F-lite / F-full)
+2. CLASSIFY: ask the user → user picks tier (S / F-lite / F-full)
    - Default suggestion: S (if user described a single-file fix) ∨ F-lite
 3. PLAN (lightweight): ask user for 1-2 sentence desc → single task ∈ PLAN.md
    - Write to `.tff/milestones/<milestone>/slices/<id>/PLAN.md`

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -23,7 +23,7 @@ LOAD @skills/finishing-work/SKILL.md
 
 **tff NEVER merges — only creates PR.**
 
-6. MERGE GATE: AskUserQuestion with options:
+6. MERGE GATE: ask the user with options:
    - **"PR merged"** → continue to step 7
    - **"PR needs changes"** → SPAWN tff-fixer with requested changes → push fixes → go back to step 6
 7. CLOSE + CLEANUP:


### PR DESCRIPTION
# Description

## What does this PR change or add?

Removed `AskUserQuestion` from AI-facing instruction files across the codebase. The AI now asks questions directly in conversation rather than through a structured tool call. This affects 15 commands, 7 workflows, 1 skill, and 1 reference file. The `tff_ask_user` tool remains available for TFF's internal system use.

## How can it be tested?

Steps to test:

1. Run `grep -rn "AskUserQuestion" commands/tff/*.md` — expect 0 matches
2. Run `grep -rn "AskUserQuestion" workflows/*.md` — expect 0 matches
3. Run `grep -rn "AskUserQuestion\|tff_ask_user" skills/*/SKILL.md` — expect 0 matches
4. Verify CHANGELOG.md has entry under "### Changed"
5. Run `bun run typecheck` — should pass (no code changes)

## Any tricky parts _(edge cases, trade-offs, impl details, etc.)_?

The inline question patterns vary slightly by context:
- "ask the user inline" used in workflow gate steps
- "inline" standalone in flow descriptions
- "asking inline" in multi-step flows

This is intentional to maintain natural language flow in each file.

## Deployment steps _(migrations, config changes, etc.)_

_(none)_

## New environment variables

_(none)_

---

## PR Checklist :white_check_mark:

- [ ] Tests added or updated
- [ ] Docs updated if needed
- [ ] No new warnings or errors in logs / console
- [ ] Security review if sensitive paths changed
