### PR TITLE
feat(M02-S03): Clean up documentation and fix inconsistencies

### DIFF
--- a/workflows/compose-skills.md
+++ b/workflows/compose-skills.md
@@ -8,7 +8,7 @@ Detect skill co-activation clusters → propose bundles ∨ agents.
 observation enabled ∧ multiple skills ∈ `skills/`
 
 ## Settings
-Read `.tff/settings.yaml` → `auto-learn.clustering`.
+Read `.tff-cc/settings.yaml` → `auto-learn.clustering`.
 Pass: `tff-tools compose:detect --min-sessions 3 --min-patterns 2 --max-distance 0.3`
 
 ## Steps
@@ -22,8 +22,8 @@ Pass: `tff-tools compose:detect --min-sessions 3 --min-patterns 2 --max-distance
    ```
 3. LOAD @skills/skill-authoring/SKILL.md → SPAWN subagent ("Compose Bundle" mode) for selected cluster:
    - provide cluster skills + co-activation rate → decides bundle vs agent
-   - draft → `.tff/drafts/<name>.md`
-4. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/drafts/<name>.md`
+   - draft → `.tff-cc/drafts/<name>.md`
+4. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff-cc/drafts/<name>.md`
 5. HANDLE:
    - approved bundle → `skills/<name>.md`
    - approved agent → `agents/<name>.md`

--- a/workflows/create-skill.md
+++ b/workflows/create-skill.md
@@ -8,12 +8,12 @@ Draft new skill from pattern candidate ∨ user description.
 1. INPUT: candidate number (load from candidates.jsonl) ∨ free-text description
 2. LOAD @skills/skill-authoring/SKILL.md → SPAWN subagent ("Draft New Skill" mode):
    - provide pattern evidence (∨ description) + existing skills as format examples
-   - draft → `.tff/drafts/<skill-name>.md`
+   - draft → `.tff-cc/drafts/<skill-name>.md`
 3. VALIDATE: `tff-tools skills:validate --skill '<json>'`
    - fail → drafter fixes ∧ re-validates
-4. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/drafts/<skill-name>.md`
+4. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff-cc/drafts/<skill-name>.md`
 5. HANDLE:
-   - approved → move `.tff/drafts/<name>.md` → `skills/<name>.md`
+   - approved → move `.tff-cc/drafts/<name>.md` → `skills/<name>.md`
    - feedback → revise ∧ re-invoke `plannotator-annotate`
    - rejected → delete draft
 6. NEXT: @references/next-steps.md

--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -31,11 +31,11 @@ exploration, spawn Explore subagents ∧ reason about their findings.
 
 6. CREATE slice:
    - Create slice via `tff-tools`
-   - Create worktree: `tff-tools worktree:create --slice-id <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
+   - Create worktree: `tff-tools worktree:create --slice-id <slice-id>` → worktree at `.tff-cc/worktrees/<slice-id>/`
 7. CLASSIFY: ask user → user picks tier (S / F-lite / F-full)
    - Default suggestion based on diagnosis: single-file root cause → S, multi-file → F-lite
 8. PLAN: write fix strategy + implicated files ∈ PLAN.md
-   - Write to `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+   - Write to `.tff-cc/milestones/<milestone>/slices/<id>/PLAN.md`
 9. HAND OFF to standard pipeline:
    - invoke plan-slice workflow from step 8 (Plannotator Review) onward
    - then: execute-slice → verify-slice → ship-slice (standard workflows)

--- a/workflows/detect-patterns.md
+++ b/workflows/detect-patterns.md
@@ -5,17 +5,17 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 Run pattern detection pipeline: extract → aggregate → rank.
 
 ## Prerequisites
-observation enabled ∈ `.tff/settings.yaml` ∧ `.tff/observations/sessions.jsonl` ∃
+observation enabled ∈ `.tff-cc/settings.yaml` ∧ `.tff-cc/observations/sessions.jsonl` ∃
 LOAD @skills/skill-authoring/SKILL.md
 
 ## Settings
-Read `.tff/settings.yaml` → `auto-learn.weights`.
+Read `.tff-cc/settings.yaml` → `auto-learn.weights`.
 Pass to: `tff-tools patterns:rank --weights '<json>'`
 
 ## Steps
 1. EXTRACT: `tff-tools patterns:extract`
 2. AGGREGATE: `tff-tools patterns:aggregate`
 3. RANK: `tff-tools patterns:rank`
-4. DISPLAY `.tff/observations/candidates.jsonl`: ranked candidates w/ scores + sequences
+4. DISPLAY `.tff-cc/observations/candidates.jsonl`: ranked candidates w/ scores + sequences
    - ∅ candidates above threshold → inform user, suggest lower threshold ∨ more observations
 5. NEXT: suggest `/tff:suggest-skills` ∨ `/tff:create-skill`

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -2,7 +2,7 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+**Autonomy**: check `.tff-cc/settings.yaml` → `autonomy.mode` before pausing.
 
 ## Prerequisites
 status = discussing
@@ -32,7 +32,7 @@ LOAD @skills/brainstorming/SKILL.md
 - Revise until approved, then next section
 
 ### 3. Write Spec
-WRITE `.tff/milestones/<milestone>/slices/<id>/SPEC.md` w/ validated design
+WRITE `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md` w/ validated design
 
 ### 4. Challenge Spec (F-full only — determined ∈ step 8)
 LOAD @skills/stress-testing-specs/SKILL.md → SPAWN subagent: {spec_content}
@@ -48,7 +48,7 @@ DISPATCH anonymous reviewer via Agent tool (prompt: @skills/brainstorming/SKILL.
 Issues → fix, re-dispatch (max 3)
 
 ### 7. User Gate
-Ask user: "Spec at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
+Ask user: "Spec at `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
 
 ### 8. Classify Complexity
 Based on what was learned during discuss, build `ComplexitySignals`:
@@ -74,7 +74,7 @@ CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry ∨ ab
 
 ## Auto-Transition
 After completing all steps above:
-1. READ `.tff/settings.yaml` → check `autonomy.mode`
+1. READ `.tff-cc/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask user
    - Human gates (plan approval, spec approval, completion): pause ∧ ask

--- a/workflows/execute-slice.md
+++ b/workflows/execute-slice.md
@@ -4,10 +4,10 @@ LOAD @skills/verification-before-completion/SKILL.md
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+**Autonomy**: check `.tff-cc/settings.yaml` → `autonomy.mode` before pausing.
 
 ## Prerequisites
-status = executing ∧ worktree ∃ at `.tff/worktrees/<slice-id>/`
+status = executing ∧ worktree ∃ at `.tff-cc/worktrees/<slice-id>/`
 
 ## Pre-Execute Validation
 1. READ slice classification from SPEC.md → tier ∈ {S-tier, F-lite, F-full}
@@ -37,7 +37,7 @@ status = executing ∧ worktree ∃ at `.tff/worktrees/<slice-id>/`
     
     ## Model Selection (Difficulty-Based)
     READ task.difficulty → IF undefined SET difficulty = "medium" (default)
-    RESOLVE difficulty → profile → model via .tff/settings.yaml "model-profiles"
+    RESOLVE difficulty → profile → model via .tff-cc/settings.yaml "model-profiles"
     - low → budget
     - medium → balanced
     - high → quality
@@ -65,7 +65,7 @@ Read task file paths from PLAN.md to decide which domain skills to load:
 
 ## Auto-Transition
 After completing all steps above:
-1. READ `.tff/settings.yaml` → check `autonomy.mode`
+1. READ `.tff-cc/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask user
    - Human gates (plan approval, spec approval, completion): pause ∧ ask

--- a/workflows/learn-skills.md
+++ b/workflows/learn-skills.md
@@ -8,8 +8,8 @@ Detect corrections to existing skills → propose refinements.
 observation enabled ∧ skills exist ∈ `skills/` ∧ ≥3 corrections observed
 
 ## Settings
-Read `.tff/settings.yaml` → `auto-learn.guardrails`.
-Check cooldown: read `.tff/drafts/metadata.jsonl`, verify canRefine().
+Read `.tff-cc/settings.yaml` → `auto-learn.guardrails`.
+Check cooldown: read `.tff-cc/drafts/metadata.jsonl`, verify canRefine().
 Pass maxDrift: `tff-tools skills:drift --max-drift 0.2`
 
 ## Steps
@@ -17,11 +17,11 @@ Pass maxDrift: `tff-tools skills:drift --max-drift 0.2`
 2. COMPARE actual sequences (sessions.jsonl) vs skill's documented steps → flag consistent deviations (≥3 occurrences)
 3. divergences found → LOAD @skills/skill-authoring/SKILL.md → SPAWN subagent ("Refine Existing Skill" mode):
    - provide original + divergence evidence → bounded diff (max 20% change)
-   - draft → `.tff/drafts/<skill-name>.md`
+   - draft → `.tff-cc/drafts/<skill-name>.md`
 4. CONSTRAINTS: max 20% per refinement, max 60% cumulative drift, 7-day cooldown
    - violated → warn user, suggest new skill instead
-5. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff/drafts/<skill-name>.md`
+5. REVIEW: invoke Skill `plannotator-annotate` with arg `.tff-cc/drafts/<skill-name>.md`
 6. HANDLE:
-   - approved → archive to `.tff/observations/skill-history/<name>.v<N>.md`, update `skills/<name>.md`
+   - approved → archive to `.tff-cc/observations/skill-history/<name>.v<N>.md`, update `skills/<name>.md`
    - rejected → record as intentional divergence (suppress future suggestions)
 7. NEXT: @references/next-steps.md

--- a/workflows/map-codebase.md
+++ b/workflows/map-codebase.md
@@ -5,16 +5,16 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 Analyze codebase → structured docs via parallel doc-writer agents.
 
 ## Prerequisites
-`.tff/docs/` output dir ∃ (created by caller)
+`.tff-cc/docs/` output dir ∃ (created by caller)
 
 ## Steps
-1. `mkdir -p .tff/docs`
+1. `mkdir -p .tff-cc/docs`
 2. LOAD @skills/codebase-documentation/SKILL.md → SPAWN 3 subagents ∈ parallel:
-   - **tech**: write STACK.md → `.tff/docs/STACK.md` (load @skills/hexagonal-architecture/SKILL.md)
-   - **arch**: write ARCHITECTURE.md → `.tff/docs/ARCHITECTURE.md` (load @skills/hexagonal-architecture/SKILL.md)
-   - **concerns**: write CONCERNS.md → `.tff/docs/CONCERNS.md`
+   - **tech**: write STACK.md → `.tff-cc/docs/STACK.md` (load @skills/hexagonal-architecture/SKILL.md)
+   - **arch**: write ARCHITECTURE.md → `.tff-cc/docs/ARCHITECTURE.md` (load @skills/hexagonal-architecture/SKILL.md)
+   - **concerns**: write CONCERNS.md → `.tff-cc/docs/CONCERNS.md`
 3. LOAD @skills/codebase-documentation/SKILL.md → SPAWN subagent: read ARCHITECTURE.md + STACK.md → write CONVENTIONS.md
    - document: naming, imports, error handling, test structure, function design
-4. COMMIT: `git add .tff/docs/ && git commit -m "docs: map codebase"`
+4. COMMIT: `git add .tff-cc/docs/ && git commit -m "docs: map codebase"`
 5. SUMMARY: list generated files (STACK, ARCHITECTURE, CONCERNS, CONVENTIONS)
 6. NEXT: @references/next-steps.md

--- a/workflows/new-milestone.md
+++ b/workflows/new-milestone.md
@@ -5,8 +5,8 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 ## Steps
 1. ASK user: milestone name (e.g. "MVP", "Auth System"), goal
 2. CREATE: `tff-tools milestone:create --name "<name>"`
-   - creates milestone entry + `milestone/M0X` branch (from main)
-3. REQUIREMENTS: ask user for requirements scoped to this milestone → write `.tff/milestones/<M0X>/REQUIREMENTS.md`
+   - creates milestone entry + `milestone/<8hex>` branch (from main)
+3. REQUIREMENTS: ask user for requirements scoped to this milestone → write `.tff-cc/milestones/<M0X>/REQUIREMENTS.md`
 4. DEFINE SLICES: ask user to break milestone into slices (name, desc, deps)
 5. CREATE slices:
    - ∀ slice: `tff-tools slice:create --title "<name>"`

--- a/workflows/new-project.md
+++ b/workflows/new-project.md
@@ -3,7 +3,7 @@
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
 ## Prerequisites
-∄ `.tff/PROJECT.md` — if ∃ → "Use `/tff:new-milestone`" ∧ stop
+∄ `.tff-cc/PROJECT.md` — if ∃ → "Use `/tff:new-milestone`" ∧ stop
 
 ## Steps
 1. DETECT existing codebase: scan for files matching common source extensions
@@ -15,8 +15,8 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 2. ONBOARD existing codebase:
    a. ASK: "This repo has existing code. I'd like to analyze it first to understand your project. Proceed?"
       - If ¬ → skip to step 3 (user provides everything manually)
-   b. INIT minimal: `mkdir -p .tff/docs` (map-codebase needs output dir, ¬ a full project)
-   c. RUN: execute map-codebase workflow (3 parallel doc-writer agents → .tff/docs/)
+   b. INIT minimal: `mkdir -p .tff-cc/docs` (map-codebase needs output dir, ¬ a full project)
+   c. RUN: execute map-codebase workflow (3 parallel doc-writer agents → .tff-cc/docs/)
       - If map-codebase fails → warn user, fall back to step 3 (manual input)
    d. SYNTHESIZE: read STACK.md, ARCHITECTURE.md, CONCERNS.md, CONVENTIONS.md
       - Propose: project name, vision statement, initial requirements
@@ -27,7 +27,7 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 3. ASK user: project name (required), vision statement
    - Pre-filled from step 2 if onboarding occurred
 4. INIT: `tff-tools project:init --name "<name>" --vision "<vision>"`
-5. SETTINGS: generate `.tff/settings.yaml` from @references/settings-template.md
+5. SETTINGS: generate `.tff-cc/settings.yaml` from @references/settings-template.md
 6. SUMMARY: show created files (PROJECT.md, settings.yaml)
    - suggest `/tff:new-milestone` to create first milestone
 

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -2,17 +2,17 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+**Autonomy**: check `.tff-cc/settings.yaml` → `autonomy.mode` before pausing.
 
 ## Prerequisites
 status = planning
-SPEC.md ∃ at `.tff/milestones/<milestone>/slices/<id>/SPEC.md`
+SPEC.md ∃ at `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md`
 
 ## Steps
 
 ### 1. Load Spec
-READ `.tff/milestones/<milestone>/slices/<id>/SPEC.md`
-READ `.tff/milestones/<milestone>/slices/<id>/RESEARCH.md` (if ∃)
+READ `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md`
+READ `.tff-cc/milestones/<milestone>/slices/<id>/RESEARCH.md` (if ∃)
 LOAD @skills/writing-plans/SKILL.md
 
 ### 2. File Structure
@@ -34,7 +34,7 @@ DECOMPOSE spec → tasks:
 - Code snippets, ¬ "implement validation"
 
 ### 4. Write PLAN.md
-WRITE `.tff/milestones/<milestone>/slices/<id>/PLAN.md`:
+WRITE `.tff-cc/milestones/<milestone>/slices/<id>/PLAN.md`:
 
 ```
 # [Slice] Implementation Plan
@@ -74,7 +74,7 @@ DISPATCH anonymous reviewer via Agent tool (prompt: @skills/brainstorming/SKILL.
 Issues → fix, re-dispatch (max 3)
 
 ### 8. Plannotator Review
-invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+invoke Skill `plannotator-annotate` with arg `.tff-cc/milestones/<milestone>/slices/<id>/PLAN.md`
 feedback → revise ∨ approved → continue
 
 ### 9. Worktree + Transition
@@ -87,7 +87,7 @@ CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry ∨ ab
 
 ## Auto-Transition
 After completing all steps above:
-1. READ `.tff/settings.yaml` → check `autonomy.mode`
+1. READ `.tff-cc/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask user
    - Human gates (plan approval, spec approval, completion): pause ∧ ask

--- a/workflows/progress.md
+++ b/workflows/progress.md
@@ -4,7 +4,7 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
 ## Steps
 1. SYNC: `tff-tools sync:state --milestone-id <milestone-id>`
-2. DISPLAY `.tff/STATE.md`: milestone progress (slices done/total), per-slice status + tasks, blocked items
+2. DISPLAY `.tff-cc/STATE.md`: milestone progress (slices done/total), per-slice status + tasks, blocked items
 3. ROUTE by current state:
    - discussing → `/tff:discuss` | planning → `/tff:plan`
    - executing → `/tff:execute` | verifying → `/tff:verify`

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -10,11 +10,11 @@ active milestone ∃
 ## Steps
 1. CREATE slice:
    - Create slice via `tff-tools`
-   - Create worktree: `tff-tools worktree:create --slice-id <slice-id>` → worktree at `.tff/worktrees/<slice-id>/`
+   - Create worktree: `tff-tools worktree:create --slice-id <slice-id>` → worktree at `.tff-cc/worktrees/<slice-id>/`
 2. CLASSIFY: ask user → user picks tier (S / F-lite / F-full)
    - Default suggestion: S (if user described a single-file fix) ∨ F-lite
 3. PLAN (lightweight): ask user for 1-2 sentence desc → single task ∈ PLAN.md
-   - Write to `.tff/milestones/<milestone>/slices/<id>/PLAN.md`
+   - Write to `.tff-cc/milestones/<milestone>/slices/<id>/PLAN.md`
 4. HAND OFF to standard pipeline:
    - invoke plan-slice workflow from step 8 (Plannotator Review) onward
    - then: execute-slice → verify-slice → ship-slice (standard workflows)

--- a/workflows/research-slice.md
+++ b/workflows/research-slice.md
@@ -2,7 +2,7 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+**Autonomy**: check `.tff-cc/settings.yaml` → `autonomy.mode` before pausing.
 
 ## Prerequisites
 status = researching
@@ -13,7 +13,7 @@ LOAD @skills/architecture-review/SKILL.md
 2. RESEARCH (if needed):
    - Read relevant codebase areas
    - Check dependencies + integration points
-   - Output → `.tff/milestones/<milestone>/slices/<slice-id>/RESEARCH.md`
+   - Output → `.tff-cc/milestones/<milestone>/slices/<slice-id>/RESEARCH.md`
 3. TRANSITION: `tff-tools slice:transition --slice-id <id> --status planning`
    CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry ∨ abort
   IF `ok` = true ∧ `warnings.length > 0`:
@@ -22,7 +22,7 @@ LOAD @skills/architecture-review/SKILL.md
 
 ## Auto-Transition
 After completing all steps above:
-1. READ `.tff/settings.yaml` → check `autonomy.mode`
+1. READ `.tff-cc/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask user
    - Human gates (plan approval, spec approval, completion): pause ∧ ask

--- a/workflows/settings.md
+++ b/workflows/settings.md
@@ -8,7 +8,7 @@ View ∧ modify all project settings.
 tff project ∃
 
 ## Steps
-1. READ `.tff/settings.yaml` (if ∃)
+1. READ `.tff-cc/settings.yaml` (if ∃)
    - If missing → offer to create from @references/settings-template.md
 2. DETECT missing fields: compare against template, list any absent sections
    - If missing fields found → offer to add them with defaults (preserve existing values + comments)
@@ -22,5 +22,5 @@ tff project ∃
    - Model profiles: quality/balanced/budget model selection
    - Autonomy: mode selection with explanation of guided vs plan-to-pr
    - Auto-learn: weights, guardrails, clustering values
-6. WRITE updated `.tff/settings.yaml` (preserve comments where possible)
+6. WRITE updated `.tff-cc/settings.yaml` (preserve comments where possible)
 7. NEXT: @references/next-steps.md

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -2,7 +2,7 @@
 
 Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
 
-**Autonomy**: check `.tff/settings.yaml` → `autonomy.mode` before pausing.
+**Autonomy**: check `.tff-cc/settings.yaml` → `autonomy.mode` before pausing.
 
 ## Prerequisites
 status = reviewing
@@ -37,7 +37,7 @@ LOAD @skills/finishing-work/SKILL.md
 
 ## Auto-Transition
 After completing all steps above:
-1. READ `.tff/settings.yaml` → check `autonomy.mode`
+1. READ `.tff-cc/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask user
    - Human gates (plan approval, spec approval, merge gate): pause ∧ ask

--- a/workflows/suggest-skills.md
+++ b/workflows/suggest-skills.md
@@ -8,7 +8,7 @@ Show ranked pattern candidates with human-readable summaries.
 `/tff:detect-patterns` run (candidates.jsonl ∃) — if ∄ → suggest detect first
 
 ## Steps
-1. LOAD `.tff/observations/candidates.jsonl`
+1. LOAD `.tff-cc/observations/candidates.jsonl`
 2. SUMMARIZE: ∀ candidate, LOAD @skills/skill-authoring/SKILL.md → SPAWN subagent (summarize mode) → one-line summary
 3. DISPLAY numbered list:
    ```

--- a/workflows/verify-slice.md
+++ b/workflows/verify-slice.md
@@ -9,7 +9,7 @@ LOAD @skills/verification-before-completion/SKILL.md
 ## Steps
 1. LOAD @skills/acceptance-criteria-validation/SKILL.md → SPAWN subagent: {acceptance_criteria from PLAN.md}
    - Verify each criterion against implementation
-2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff/milestones/<milestone>/slices/<slice-id>/VERIFICATION.md`
+2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff-cc/milestones/<milestone>/slices/<slice-id>/VERIFICATION.md`
 3. VERDICT:
    - PASS → `tff-tools slice:transition --slice-id <id> --status reviewing`
      CHECK: `ok` = true → suggest `/tff:ship` | `ok` = false → warn user, offer retry ∨ abort
@@ -17,7 +17,7 @@ LOAD @skills/verification-before-completion/SKILL.md
 4. NEXT: @references/next-steps.md
 
 ## Auto-Transition
-Read `.tff/settings.yaml` → `autonomy.mode`.
+Read `.tff-cc/settings.yaml` → `autonomy.mode`.
 `plan-to-pr` ∧ ¬HUMAN_GATE → auto-invoke next workflow via `tff-tools workflow:next --status <status>`.
 `guided` → suggest next step, wait for user.
 Progress: `[tff] <slice-id>: verifying → reviewing`


### PR DESCRIPTION
# Description

## What does this PR change or add?

Updates workflow documentation to reflect the `.tff/` → `.tff-cc/` state directory migration completed in M02-S01 and M02-S02. Replaces all path references in workflow markdown files and updates the branch naming description from label-based (`milestone/M0X`) to UUID-based (`milestone/<8hex>`).

## How can it be tested?

Steps to test:

1. Review the diff to confirm all `.tff/` → `.tff-cc/` replacements are correct
2. Verify `workflows/new-milestone.md` line 6 shows UUID-based branch naming
3. Run `grep -r '\.tff/' workflows/ --include='*.md' | grep -v '\.original\.md'` — should return empty
4. Confirm `.original.md` files are untouched: `git diff milestone/f73ccfec -- workflows/*.original.md`

## Any tricky parts _(edge cases, trade-offs, impl details, etc.)_?

_(none)_

## Deployment steps _(migrations, config changes, etc.)_

_(none)_

## New environment variables

_(none)_

---

## PR Checklist :white_check_mark:

- [ ] Tests added or updated
- [ ] Docs updated if needed
- [ ] No new warnings or errors in logs / console
- [ ] Security review if sensitive paths changed
