### PR TITLE
fix(release): authenticate sync-release-branch push; opt in to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, 'milestone/*']
   pull_request:
 
+env:
+  # Opt into Node.js 24 for JavaScript actions (see Node 20 deprecation notice).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 5 * * *'  # daily 05:00 UTC
 
+env:
+  # Opt into Node.js 24 for JavaScript actions (see Node 20 deprecation notice).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+env:
+  # Opt into Node.js 24 for JavaScript actions (see Node 20 deprecation notice).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -125,10 +125,29 @@ EOF
 
 # --- 7. Init fresh git repo and force-push release branch --------------------
 
+# The tmp git has no inherited credentials. For CI (GH Actions over HTTPS),
+# embed $GITHUB_TOKEN as x-access-token into the push URL. For non-HTTPS
+# origins (e.g. ssh:// or git@...), rely on the runner's existing credentials.
+# $GITHUB_TOKEN is masked by GH Actions in any log output, so incidental
+# echoing of PUSH_URL would not leak the token.
+case "$ORIGIN_URL" in
+  https://*)
+    if [ -n "$GITHUB_TOKEN" ]; then
+      HOST_PATH="${ORIGIN_URL#https://}"
+      PUSH_URL="https://x-access-token:${GITHUB_TOKEN}@${HOST_PATH}"
+    else
+      PUSH_URL="$ORIGIN_URL"
+    fi
+    ;;
+  *)
+    PUSH_URL="$ORIGIN_URL"
+    ;;
+esac
+
 cd "$RELEASE_DIR"
 echo "Initializing release git tree..."
 git init -q
-git remote add origin "$ORIGIN_URL"
+git remote add origin "$PUSH_URL"
 git checkout -q -b release
 git add -A
 git -c user.name="tff-release-bot" -c user.email="release@tff-cc.invalid" \


### PR DESCRIPTION
Follow-up to #93. The release workflow triggered by PR #94's merge (tff-cc 0.9.2) failed at the `Sync release branch` step:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Root cause

`scripts/sync-release-branch.sh` does `git init` in a temp directory and then `git push --force origin release`. The temp git has no credential helper and the HTTPS remote URL has no embedded auth, so the push prompts for a username — which in a non-interactive runner errors out immediately.

## Fix

Prepend `x-access-token:$GITHUB_TOKEN@` to the HTTPS origin URL before adding it as a remote in the temp repo. The token is supplied by the existing `env: GITHUB_TOKEN` on the `Sync release branch` step and is masked by GitHub Actions in logs. SSH remotes and empty-token runs fall back to the original URL unchanged.

## Also in this PR

- Opt in to Node.js 24 for JavaScript actions (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`) across all three workflows. Silences the deprecation warning flagged on the 0.9.2 release run.

## Verification

- `sh -n scripts/sync-release-branch.sh` — syntax OK.
- The CI-only guard in the script still refuses to run in non-`GITHUB_ACTIONS` shells.
- The `--force` push still targets `origin/release` by design (that branch is a build artifact; see `docs/superpowers/specs/release-branch-protection.md`).

Once this merges, re-trigger the release workflow by re-running the failed job on the 0.9.2 release workflow run, or by pushing any commit to `main`.
