### PR TITLE
fix(release): bundle cli with esbuild and align plugin.json version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Align native sqlite binding with CI node abi
         run: |
           install -D node_modules/better-sqlite3/build/Release/better_sqlite3.node \
-            dist/infrastructure/adapters/sqlite/better_sqlite3.linux-x64.node
+            dist/cli/better_sqlite3.linux-x64.node
 
       - name: Run tests
         run: bun run test

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "postinstall": "tsc -p tsconfig.build.json && node scripts/add-cli-shebang.cjs",
-    "build": "tsc -p tsconfig.build.json && bun run scripts/add-cli-shebang.ts && cp native/*.node dist/infrastructure/adapters/sqlite/",
+    "build": "node scripts/build.mjs",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -30,21 +29,22 @@
   "license": "MIT",
   "author": "MonsieurBarti",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
-    "better-sqlite3": "^12.8.0",
-    "proper-lockfile": "^4.1.2",
-    "typescript": "^5.9.3",
-    "yaml": "^2.8.3"
+    "better-sqlite3": "^12.8.0"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@biomejs/biome": "^2.4.8",
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.5.0",
     "@types/proper-lockfile": "^4.1.4",
+    "esbuild": "^0.27.4",
     "fast-check": "^4.6.0",
+    "proper-lockfile": "^4.1.2",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0",
+    "yaml": "^2.8.3",
     "zod": "^4.3.6"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,14 @@
 			"bump-minor-pre-major": true,
 			"bump-patch-for-minor-pre-major": true,
 			"draft": false,
-			"prerelease": false
+			"prerelease": false,
+			"extra-files": [
+				{
+					"type": "json",
+					"path": "plugin/.claude-plugin/plugin.json",
+					"jsonpath": "$.version"
+				}
+			]
 		}
 	}
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { copyFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distCliDir = resolve(rootDir, "dist", "cli");
+const pkg = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8"));
+
+mkdirSync(distCliDir, { recursive: true });
+
+await build({
+	entryPoints: [resolve(rootDir, "src/cli/index.ts")],
+	bundle: true,
+	platform: "node",
+	format: "esm",
+	target: "node20",
+	outfile: resolve(distCliDir, "index.js"),
+	external: [],
+	define: {
+		__TFF_VERSION__: JSON.stringify(pkg.version),
+	},
+	banner: {
+		js: 'import{createRequire as _tffCreateRequire}from"module";const require=_tffCreateRequire(import.meta.url);',
+	},
+	logLevel: "info",
+});
+
+const nativeDir = resolve(rootDir, "native");
+for (const file of readdirSync(nativeDir).filter((f) => f.endsWith(".node"))) {
+	copyFileSync(resolve(nativeDir, file), resolve(distCliDir, file));
+}
+
+execSync("node scripts/add-cli-shebang.cjs", { cwd: rootDir, stdio: "inherit" });

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -99,11 +99,11 @@ cp -r dist "$RELEASE_DIR/dist"
 # --- 4. Native SQLite binaries ----------------------------------------------
 
 if [ -d native ]; then
-  echo "Copying native/*.node into dist/infrastructure/adapters/sqlite/..."
-  mkdir -p "$RELEASE_DIR/dist/infrastructure/adapters/sqlite"
+  echo "Copying native/*.node into dist/cli/..."
+  mkdir -p "$RELEASE_DIR/dist/cli"
   # `|| true` so an empty native/ doesn't abort; explicit log below tells us.
-  cp native/*.node "$RELEASE_DIR/dist/infrastructure/adapters/sqlite/" 2>/dev/null || true
-  COPIED=$(ls "$RELEASE_DIR/dist/infrastructure/adapters/sqlite/"*.node 2>/dev/null | wc -l | tr -d ' ')
+  cp native/*.node "$RELEASE_DIR/dist/cli/" 2>/dev/null || true
+  COPIED=$(ls "$RELEASE_DIR/dist/cli/"*.node 2>/dev/null | wc -l | tr -d ' ')
   echo "  copied $COPIED native binaries"
 fi
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -178,7 +178,7 @@ const main = async () => {
 		console.log(
 			JSON.stringify({
 				ok: true,
-				data: { name: "tff-tools", version: "0.9.0", commands: Object.keys(commands) },
+				data: { name: "tff-tools", version: __TFF_VERSION__, commands: Object.keys(commands) },
 			}),
 		);
 		return;

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __TFF_VERSION__: string;


### PR DESCRIPTION
## Summary

Resolves three coupled problems with plugin installs from the `release` branch:

- **Marketplace shows 0.9.0** — `plugin/.claude-plugin/plugin.json` was never bumped because release-please only tracks `package.json`. Added an `extra-files` entry so the plugin manifest version tracks every release PR.
- **`node_modules` missing after install** — snapshot shipped pre-built `dist/` but Claude Code does not run `npm install` on plugin installs, so `yaml` / `zod` / `proper-lockfile` / `better-sqlite3` imports failed at runtime. Replaced the `tsc` build with an esbuild bundle: `dist/cli/index.js` is now a single self-contained ESM file. Native `better_sqlite3.*.node` bindings are co-located in `dist/cli/` and loaded via the existing `getNativeBindingPath` option.
- **Release branch stuck at 0.9.4** — the 0.9.5 release workflow errored during release-please labeling, so the migration fix from #105 never reached consumers. Landing this PR lets release-please PR #107 pick up the new config, bump to 0.9.6, and the subsequent merge will cut the release + sync the `release` branch in one go.

Collateral cleanup:

- Runtime deps collapsed to `better-sqlite3` only (native binding can't be bundled); others moved to devDeps.
- Hardcoded `"0.9.0"` in CLI `--help` output replaced with `__TFF_VERSION__` injected from `package.json` at bundle time.
- `postinstall` removed — consumers get a prebuilt `dist/`; contributors run `bun run build` explicitly (already in README).
- Native-binding path moved from `dist/infrastructure/adapters/sqlite/` to `dist/cli/` in both `ci.yml` and `sync-release-branch.sh`.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 954/954 pass
- [x] `bun run build` — produces single 1.0 MB `dist/cli/index.js` + native bindings
- [x] Smoke: copy only `dist/` into a throwaway dir with no `node_modules`; `node dist/cli/index.js --help` and `project:init --name test` both succeed
- [x] Version output reflects `package.json` (0.9.5 in bundle today)
- [ ] After merge: verify release-please PR #107 bumps `plugin/.claude-plugin/plugin.json` to 0.9.6
- [ ] After #107 merges: verify `release` branch snapshot contains bundled `dist/cli/index.js` + co-located `.node` files; verify marketplace install shows 0.9.6