### PR TITLE
ci(release): pin bun to 1.3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4


### PR DESCRIPTION
## Summary

The Release workflow uses setup-bun with \`bun-version: latest\`, which pulled 1.3.12 and produced a lockfile drift vs the 1.3.11 \`packageManager\` pin — failing \`bun install --frozen-lockfile\` on the #108 merge commit (run 24609342987) before release-please could run.

Pinning release.yml to 1.3.11 matches CI's matrix and the \`packageManager\` field in package.json, so lockfile resolution is deterministic across all workflows.

## Test plan

- [ ] Merge, watch the Release workflow succeed on the resulting main commit
- [ ] Confirm release-please PR #107 picks up the new extra-files config and bumps \`plugin/.claude-plugin/plugin.json\` to 0.9.6