### PR TITLE
fix(docs): use plannotator-annotate for install verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ claude /plugin marketplace add backnotprop/plannotator
 claude /plugin install plannotator@plannotator
 ```
 
-Verify: Run `/plannotator-review` in Claude Code -- it should open a browser window.
+Verify: Run `/plannotator-annotate README.md` in Claude Code -- it should open a browser window.
 
 ### Step 2: Install The Forge Flow
 


### PR DESCRIPTION
## Summary
- README told users to verify plannotator install via `/plannotator-review`, but the tff-cc workflow standardizes on `/plannotator-annotate` as the single entry point. Aligns the onboarding step so users never see a non-annotate subcommand.

## Test plan
- [x] `bun run test` — 997/997 passing in clean worktree from `origin/main`
- [x] `bun run build` — succeeds
- [x] `bun run typecheck` — succeeds (pre-push)