### PR TITLE
fix: recover project id from primary worktree; persist in new worktrees

### DIFF
--- a/src/cli/commands/worktree-create.cmd.ts
+++ b/src/cli/commands/worktree-create.cmd.ts
@@ -2,7 +2,11 @@ import { createWorktreeUseCase } from "../../application/worktree/create-worktre
 import { isOk } from "../../domain/result.js";
 import { GitCliAdapter } from "../../infrastructure/adapters/git/git-cli.adapter.js";
 import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
-import { createTffCcSymlink, getProjectId } from "../../infrastructure/home-directory.js";
+import {
+	createTffCcSymlink,
+	getProjectId,
+	writeProjectIdFile,
+} from "../../infrastructure/home-directory.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { resolveSliceId } from "../utils/resolve-id.js";
 
@@ -74,6 +78,10 @@ export const worktreeCreateCmd = async (args: string[]): Promise<string> => {
 			const projectId = getProjectId(cwd);
 			const worktreePath = result.data.worktreePath;
 			createTffCcSymlink(worktreePath, projectId);
+			// Persist the project id in the new worktree so subsequent tff-tools commands
+			// run inside it don't mint a fresh one (e.g. when the branch's HEAD predates
+			// the commit that added .tff-project-id).
+			writeProjectIdFile(worktreePath, projectId);
 
 			return JSON.stringify({ ok: true, data: result.data });
 		}

--- a/src/infrastructure/home-directory.ts
+++ b/src/infrastructure/home-directory.ts
@@ -5,21 +5,47 @@
  * pattern (~/.tff-cc/{projectId}/) shared across all worktrees.
  */
 
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
 	existsSync,
 	lstatSync,
 	mkdirSync,
 	readFileSync,
+	readlinkSync,
 	symlinkSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { TFF_CC_DIR } from "../shared/paths.js";
 
 /** UUID v4 format validation regex */
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Attempt to locate the primary (main) git worktree root for a repo.
+ * Returns null when:
+ *  - `repoRoot` isn't inside a git repo (e.g., first-init before `git init`)
+ *  - git isn't installed / on PATH
+ *  - the repo is bare (no working tree)
+ */
+function findPrimaryWorktreeRoot(repoRoot: string): string | null {
+	try {
+		const commonDir = execFileSync(
+			"git",
+			["-C", repoRoot, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+			{ encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+		).trim();
+		if (!commonDir) return null;
+		// For a non-bare repo, the primary worktree is the parent of the common-dir.
+		// (e.g. common-dir=/path/to/repo/.git → primary=/path/to/repo)
+		return dirname(commonDir);
+	} catch {
+		return null;
+	}
+}
 
 /** Validate that a string is a valid UUID v4 format. */
 function isValidUuidV4(id: string): boolean {
@@ -74,23 +100,34 @@ export function writeProjectIdFile(repoRoot: string, projectId: string): void {
 
 /**
  * Get or generate the project ID.
- * If .tff-project-id exists, reads it. Otherwise generates a new UUID v4 and writes it.
- * Also ensures home directory exists.
+ * 1. Prefer the current repo's own .tff-project-id file.
+ * 2. If missing and we are in a secondary git worktree, recover from the primary worktree.
+ * 3. Only mint a fresh UUID on true first-init (no git repo or no ID in primary either).
  * @param repoRoot - The repository root directory
  */
 export function getProjectId(repoRoot: string): string {
+	// Step 1: prefer the current repo's own file.
 	const existing = readProjectIdFile(repoRoot);
 	if (existing) {
 		return existing;
 	}
 
-	// Generate new UUID v4
+	// Step 2: if we're in a secondary git worktree, recover from the primary.
+	const primaryRoot = findPrimaryWorktreeRoot(repoRoot);
+	if (primaryRoot && primaryRoot !== repoRoot) {
+		const recovered = readProjectIdFile(primaryRoot);
+		if (recovered) {
+			// Persist in this worktree so subsequent reads are O(1) and don't re-exec git.
+			writeProjectIdFile(repoRoot, recovered);
+			ensureProjectHomeDir(recovered);
+			return recovered;
+		}
+	}
+
+	// Step 3: true first-init — mint fresh.
 	const projectId = randomUUID();
 	writeProjectIdFile(repoRoot, projectId);
-
-	// Ensure home directory exists for new projects
 	ensureProjectHomeDir(projectId);
-
 	return projectId;
 }
 
@@ -130,27 +167,32 @@ export function ensureProjectHomeDir(projectId: string): string {
 
 /**
  * Create symlink from .tff-cc in repo root to project home directory.
+ * If a symlink already exists but points to the wrong target, repairs it.
  * Throws if .tff-cc/ exists as a real directory.
  */
 export function createTffCcSymlink(repoRoot: string, projectId: string): void {
 	const symlinkPath = join(repoRoot, TFF_CC_DIR);
 	const targetPath = getProjectHome(projectId);
 
-	// Check if .tff-cc exists
 	if (existsSync(symlinkPath)) {
-		// Check if it's a symlink
 		const stats = lstatSync(symlinkPath);
 		if (stats.isSymbolicLink()) {
-			// Symlink already exists, verify it points to correct target
-			// For now, just return - symlink is already there
-			return;
-		} else {
-			throw new Error(
-				`${TFF_CC_DIR}/ exists as a real directory. Remove or rename it before proceeding.`,
+			const currentTarget = readlinkSync(symlinkPath);
+			// Compare absolute targets — we always write absolute targets below.
+			if (currentTarget === targetPath) {
+				return;
+			}
+			process.stderr.write(
+				`tff-cc: repairing .tff-cc symlink in ${repoRoot} — was ${currentTarget}, now ${targetPath}\n`,
 			);
+			unlinkSync(symlinkPath);
+			symlinkSync(targetPath, symlinkPath);
+			return;
 		}
+		throw new Error(
+			`${TFF_CC_DIR}/ exists as a real directory. Remove or rename it before proceeding.`,
+		);
 	}
 
-	// Create symlink
 	symlinkSync(targetPath, symlinkPath);
 }

--- a/tests/integration/cli/worktree-create.roundtrip.spec.ts
+++ b/tests/integration/cli/worktree-create.roundtrip.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * worktree:create roundtrip test
+ *
+ * Verifies that after creating a git worktree, `.tff-project-id` is written
+ * into the new worktree directory so subsequent `tff-tools` invocations
+ * inside it never mint a divergent UUID.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- module mocks (must be hoisted before dynamic imports) ---
+vi.mock("../../../src/application/worktree/create-worktree.js");
+vi.mock("../../../src/infrastructure/adapters/sqlite/create-state-stores.js");
+
+import { createWorktreeUseCase } from "../../../src/application/worktree/create-worktree.js";
+import { createClosableStateStoresUnchecked } from "../../../src/infrastructure/adapters/sqlite/create-state-stores.js";
+
+const mockedCreateWorktreeUseCase = vi.mocked(createWorktreeUseCase);
+const mockedCreateClosableStateStoresUnchecked = vi.mocked(createClosableStateStoresUnchecked);
+
+describe("worktree:create — project id persistence", () => {
+	let tmpDir: string;
+	let homeDir: string;
+	let worktreeDir: string;
+	let originalCwd: string;
+	let originalTffCcHome: string | undefined;
+
+	const PROJECT_UUID = "a1b2c3d4-e5f6-4000-8000-aabbccddeeff";
+	const SLICE_UUID = "11111111-1111-4000-8000-000000000001";
+	const MILESTONE_UUID = "22222222-2222-4000-8000-000000000002";
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "tff-worktree-roundtrip-"));
+		homeDir = mkdtempSync(join(tmpdir(), "tff-home-roundtrip-"));
+		worktreeDir = join(tmpDir, ".tff-cc", "worktrees", "M01-S01");
+
+		originalCwd = process.cwd();
+		originalTffCcHome = process.env.TFF_CC_HOME;
+		process.env.TFF_CC_HOME = homeDir;
+		process.chdir(tmpDir);
+
+		// Write .tff-project-id in primary repo root
+		writeFileSync(join(tmpDir, ".tff-project-id"), `${PROJECT_UUID}\n`);
+
+		// Ensure the home dir structure exists so createTffCcSymlink can resolve target
+		mkdirSync(join(homeDir, PROJECT_UUID), { recursive: true });
+
+		// Pre-create the worktree directory (git normally does this)
+		mkdirSync(worktreeDir, { recursive: true });
+
+		// Mock: createWorktreeUseCase returns the expected worktree path
+		mockedCreateWorktreeUseCase.mockResolvedValue({
+			ok: true,
+			data: { worktreePath: worktreeDir, branchName: "slice/11111111" },
+		});
+
+		// Mock: state stores return a valid slice + milestone
+		const mockSlice = {
+			id: SLICE_UUID,
+			milestoneId: MILESTONE_UUID,
+			number: 1,
+			title: "Test slice",
+			status: "future" as const,
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+		const mockMilestone = {
+			id: MILESTONE_UUID,
+			number: 1,
+			name: "Test Milestone",
+			branch: "main",
+			status: "active" as const,
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+
+		mockedCreateClosableStateStoresUnchecked.mockReturnValue({
+			sliceStore: {
+				getSlice: vi.fn().mockReturnValue({ ok: true, data: mockSlice }),
+				// resolveSliceId calls getSliceByNumbers when given a label like M01-S01
+				getSliceByNumbers: vi.fn().mockReturnValue({ ok: true, data: mockSlice }),
+				listSlices: vi.fn(),
+				createSlice: vi.fn(),
+				updateSlice: vi.fn(),
+			},
+			milestoneStore: {
+				getMilestone: vi.fn().mockReturnValue({ ok: true, data: mockMilestone }),
+				getMilestoneByNumber: vi.fn(),
+				listMilestones: vi.fn(),
+				createMilestone: vi.fn(),
+				updateMilestone: vi.fn(),
+			},
+			close: vi.fn(),
+		} as unknown as ReturnType<typeof createClosableStateStoresUnchecked>);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		if (originalTffCcHome === undefined) {
+			delete process.env.TFF_CC_HOME;
+		} else {
+			process.env.TFF_CC_HOME = originalTffCcHome;
+		}
+		vi.clearAllMocks();
+		rmSync(tmpDir, { recursive: true, force: true });
+		rmSync(homeDir, { recursive: true, force: true });
+	});
+
+	it("writes .tff-project-id into the new worktree directory", async () => {
+		const { worktreeCreateCmd } = await import("../../../src/cli/commands/worktree-create.cmd.js");
+
+		const result = JSON.parse(await worktreeCreateCmd(["--slice-id", "M01-S01"]));
+		expect(result.ok).toBe(true);
+
+		// .tff-project-id must exist in the worktree
+		const idFilePath = join(worktreeDir, ".tff-project-id");
+		expect(existsSync(idFilePath)).toBe(true);
+		const written = readFileSync(idFilePath, "utf-8").trim();
+		expect(written).toBe(PROJECT_UUID);
+	});
+
+	it("written worktree .tff-project-id matches the primary repo's id", async () => {
+		const { worktreeCreateCmd } = await import("../../../src/cli/commands/worktree-create.cmd.js");
+
+		await worktreeCreateCmd(["--slice-id", "M01-S01"]);
+
+		const primaryId = readFileSync(join(tmpDir, ".tff-project-id"), "utf-8").trim();
+		const worktreeId = readFileSync(join(worktreeDir, ".tff-project-id"), "utf-8").trim();
+		expect(worktreeId).toBe(primaryId);
+	});
+
+	it(".tff-cc symlink in worktree points to the same project home as the primary", async () => {
+		const { worktreeCreateCmd } = await import("../../../src/cli/commands/worktree-create.cmd.js");
+
+		await worktreeCreateCmd(["--slice-id", "M01-S01"]);
+
+		const { readlinkSync } = await import("node:fs");
+		const symlinkPath = join(worktreeDir, ".tff-cc");
+		expect(existsSync(symlinkPath)).toBe(true);
+		const target = readlinkSync(symlinkPath);
+		expect(target).toBe(join(homeDir, PROJECT_UUID));
+	});
+});

--- a/tests/unit/infrastructure/home-directory.spec.ts
+++ b/tests/unit/infrastructure/home-directory.spec.ts
@@ -9,7 +9,8 @@
  * 3. Commit
  */
 
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -83,6 +84,53 @@ describe("T14: Home directory resolver module", () => {
 			// Should have written the file
 			expect(existsSync(join(projectDir, ".tff-project-id"))).toBe(true);
 		});
+
+		it("recovers project id from primary worktree when secondary is missing the file", async () => {
+			process.env.TFF_CC_HOME = join(tempDir, "tff-home");
+			mkdirSync(process.env.TFF_CC_HOME, { recursive: true });
+
+			// Set up a real git primary worktree with a committed .tff-project-id
+			const primaryDir = join(tempDir, "primary-repo");
+			mkdirSync(primaryDir, { recursive: true });
+			execFileSync("git", ["init", primaryDir]);
+			execFileSync("git", ["-C", primaryDir, "config", "user.email", "test@test.com"]);
+			execFileSync("git", ["-C", primaryDir, "config", "user.name", "Test"]);
+
+			const primaryUuid = "a1b2c3d4-e5f6-4000-8000-111111111111";
+			writeFileSync(join(primaryDir, ".tff-project-id"), `${primaryUuid}\n`);
+			execFileSync("git", ["-C", primaryDir, "add", ".tff-project-id"]);
+			execFileSync("git", ["-C", primaryDir, "commit", "-m", "add project id"]);
+
+			// Create a secondary worktree (no .tff-project-id file in it)
+			const secondaryDir = join(tempDir, "secondary-worktree");
+			mkdirSync(secondaryDir, { recursive: true });
+			execFileSync("git", ["-C", primaryDir, "worktree", "add", "--detach", secondaryDir]);
+
+			const { getProjectId } = await import("../../../src/infrastructure/home-directory.js");
+			const recovered = getProjectId(secondaryDir);
+
+			// Should return the primary's UUID
+			expect(recovered).toBe(primaryUuid);
+			// Should have written the file into the secondary worktree
+			expect(existsSync(join(secondaryDir, ".tff-project-id"))).toBe(true);
+		});
+
+		it("mints fresh when not in a git repo", async () => {
+			process.env.TFF_CC_HOME = join(tempDir, "tff-home-fresh");
+			mkdirSync(process.env.TFF_CC_HOME, { recursive: true });
+
+			// A plain temp directory — not git-initialized
+			const plainDir = join(tempDir, "not-a-git-repo");
+			mkdirSync(plainDir, { recursive: true });
+
+			const { getProjectId } = await import("../../../src/infrastructure/home-directory.js");
+			const minted = getProjectId(plainDir);
+
+			expect(minted).toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+			);
+			expect(existsSync(join(plainDir, ".tff-project-id"))).toBe(true);
+		});
 	});
 
 	describe("ensureProjectHomeDir", () => {
@@ -125,6 +173,62 @@ describe("T14: Home directory resolver module", () => {
 			const { createTffCcSymlink } = await import("../../../src/infrastructure/home-directory.js");
 
 			expect(() => createTffCcSymlink(projectDir, "migration-test")).toThrow();
+		});
+
+		it("repairs a drifted symlink target", async () => {
+			process.env.TFF_CC_HOME = tempDir;
+			const projectDir = join(tempDir, "project-drift");
+			mkdirSync(projectDir, { recursive: true });
+
+			const { createTffCcSymlink, ensureProjectHomeDir, getProjectHome } = await import(
+				"../../../src/infrastructure/home-directory.js"
+			);
+
+			const oldProjectId = "old00000-0000-4000-8000-000000000000";
+			const newProjectId = "new00000-0000-4000-8000-111111111111";
+
+			// Pre-create a symlink pointing to the old target
+			const oldTarget = join(tempDir, oldProjectId);
+			mkdirSync(oldTarget, { recursive: true });
+			const symlinkPath = join(projectDir, ".tff-cc");
+			const { symlinkSync } = await import("node:fs");
+			symlinkSync(oldTarget, symlinkPath);
+
+			// Ensure new project home exists so the symlink target is valid
+			ensureProjectHomeDir(newProjectId);
+
+			// Repair
+			createTffCcSymlink(projectDir, newProjectId);
+
+			// Symlink should now point to the new target
+			const actualTarget = readlinkSync(symlinkPath);
+			expect(actualTarget).toBe(getProjectHome(newProjectId));
+		});
+
+		it("leaves a correct symlink alone", async () => {
+			process.env.TFF_CC_HOME = tempDir;
+			const projectDir = join(tempDir, "project-correct-symlink");
+			mkdirSync(projectDir, { recursive: true });
+
+			const { createTffCcSymlink, ensureProjectHomeDir, getProjectHome } = await import(
+				"../../../src/infrastructure/home-directory.js"
+			);
+
+			const projectId = "correct0-0000-4000-8000-000000000000";
+			ensureProjectHomeDir(projectId);
+
+			// Create the correct symlink first
+			createTffCcSymlink(projectDir, projectId);
+
+			const symlinkPath = join(projectDir, ".tff-cc");
+			const targetBefore = readlinkSync(symlinkPath);
+
+			// Call again — should not throw and target should be unchanged
+			createTffCcSymlink(projectDir, projectId);
+			const targetAfter = readlinkSync(symlinkPath);
+
+			expect(targetAfter).toBe(targetBefore);
+			expect(targetAfter).toBe(getProjectHome(projectId));
 		});
 	});
 


### PR DESCRIPTION
## Summary

- `getProjectId` no longer silently mints a fresh UUID when `.tff-project-id` is missing inside a git secondary worktree. It now recovers from the primary worktree's committed identity via `git rev-parse --git-common-dir`.
- `createTffCcSymlink` verifies the target of any existing `.tff-cc` symlink and repairs drift (with a stderr notice) instead of silently leaving a wrong target in place.
- `worktree:create` now explicitly writes `.tff-project-id` into the new worktree after creating the symlink, so subsequent commands in that worktree never fall into the minting path.

## Bug reproduction (before fix)

Two paths produced the same symptom — a worktree's `.tff-project-id` not matching its `.tff-cc` symlink target:

1. **Invoker mint:** running `tff-tools worktree:create` (or any state-store command) from a directory where `.tff-project-id` is missing caused `getProjectId` to write a fresh UUID into the invoker's working tree. The new worktree's symlink inherited that fresh UUID while its checked-out `.tff-project-id` came from git HEAD — mismatch.
2. **Post-create mint:** if the branch being worktreed predated commit `708ec5d` (which added `.tff-project-id`), the new worktree materialized without the file. The next `tff-tools X` run inside it minted a fresh UUID, diverging from the symlink target that the original `worktree:create` established.

Both paths also left the invoker's or new worktree's working tree "modified" vs git HEAD.

## Root cause

`src/infrastructure/home-directory.ts`'s `getProjectId` conflated "read-or-return" with "first-init-mint." The auto-mint fallback fired in any context where the file was missing, with no awareness that a git worktree should inherit an existing identity from the primary. `createTffCcSymlink` compounded the issue by silently early-returning when an existing symlink was found, without verifying the target.

## Fix

### `getProjectId(repoRoot)` — three-step recovery

1. Read `repoRoot/.tff-project-id` → return if valid.
2. If missing and we're in a git worktree (verified via `git -C <repoRoot> rev-parse --path-format=absolute --git-common-dir`), locate the primary worktree (parent of the common-dir) and read its `.tff-project-id`. If valid, persist to the current worktree and return.
3. Only mint a fresh UUID on true first-init (no git repo, or primary also has no ID).

### `createTffCcSymlink(repoRoot, projectId)` — self-heal

When an existing symlink is found, resolve its target and compare to `getProjectHome(projectId)`. On drift, unlink + recreate the symlink to the correct target, logging to stderr:

> `tff-cc: repairing .tff-cc symlink in <repoRoot> — was <old>, now <new>`

Matching targets remain no-op. Real directories still throw as before.

### `worktree:create` — persist project id in the new worktree

After `createTffCcSymlink(worktreePath, projectId)`, `worktree-create.cmd.ts` now calls `writeProjectIdFile(worktreePath, projectId)` unconditionally. This ensures the new worktree always has the canonical file, making subsequent command paths idempotent.

## Test plan

- [x] New unit: `getProjectId` recovers from primary worktree when secondary is missing the file (uses real `git init` + `git worktree add`).
- [x] New unit: `getProjectId` mints fresh when not in a git repo (unchanged first-init behavior).
- [x] New unit: `createTffCcSymlink` repairs a drifted symlink target.
- [x] New unit: `createTffCcSymlink` leaves a correct symlink untouched.
- [x] New integration: `worktree:create` writes `.tff-project-id` into the new worktree matching the symlink target.
- [x] Full sweep: 1361 passing, 1 pre-existing skip, 0 failed. Typecheck clean. Lint clean.
- [x] Existing "mints when file missing in a non-git dir" test still passes without modification — behavior preserved for the first-init case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)