### PR TITLE
feat(release): stage c — release pipeline trust (0.10.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,56 @@ jobs:
 
       - name: Verify CLI
         run: node dist/cli/index.js --help
+
+  smoke-matrix:
+    name: CLI smoke (${{ matrix.os }})
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: 1.3.11
+
+      - run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Align native sqlite binding with runner abi (linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          install -D node_modules/better-sqlite3/build/Release/better_sqlite3.node \
+            dist/cli/better_sqlite3.linux-x64.node
+
+      - name: Align native sqlite binding with runner abi (macos only)
+        if: matrix.os == 'macos-14'
+        run: |
+          install -D node_modules/better-sqlite3/build/Release/better_sqlite3.node \
+            dist/cli/better_sqlite3.darwin-arm64.node
+
+      - name: Verify build manifest byte-matches bundle
+        run: bash scripts/verify-build-manifest.sh
+
+      - name: Smoke-test CLI
+        run: |
+          set -e
+          node dist/cli/index.js --help
+          WORK=$(mktemp -d)
+          cd "$WORK"
+          git init --quiet
+          git -c user.email=smoke@tff.invalid -c user.name=smoke-test commit --allow-empty -m "smoke-init" --quiet
+          git checkout -b smoke-branch --quiet
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" schema --command project:init > schema.json
+          test -s schema.json
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" project:init --name pr-smoke
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" milestone:create --name "PR Smoke Milestone"
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:create --title "pr smoke slice"
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:list \
+            | jq -e '.data[] | select(.title == "pr smoke slice")' > /dev/null
+          echo "ok: CLI smoke passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Align native sqlite binding with runner abi (macos only)
         if: matrix.os == 'macos-14'
         run: |
-          install -D node_modules/better-sqlite3/build/Release/better_sqlite3.node \
+          mkdir -p dist/cli
+          cp node_modules/better-sqlite3/build/Release/better_sqlite3.node \
             dist/cli/better_sqlite3.darwin-arm64.node
 
       - name: Verify build manifest byte-matches bundle

--- a/.github/workflows/release-branch-rebuild-diff.yml
+++ b/.github/workflows/release-branch-rebuild-diff.yml
@@ -70,6 +70,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh label create release-pipeline --color B60205 --description "issues from release-pipeline automation" --force
           gh issue create \
             --title "release-branch rebuild-diff mismatch ($(date -u +%Y-%m-%d))" \
             --body "The scheduled rebuild-diff found a bundle sha256 mismatch.

--- a/.github/workflows/release-branch-rebuild-diff.yml
+++ b/.github/workflows/release-branch-rebuild-diff.yml
@@ -1,0 +1,83 @@
+name: Release Branch Rebuild-Diff
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  rebuild-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: release
+          path: release-tree
+
+      - name: Read source sha from manifest
+        id: manifest
+        run: |
+          set -e
+          SOURCE_SHA=$(sed -n 's/.*"sourceSha" *: *"\([0-9a-f]*\)".*/\1/p' release-tree/dist/.build-manifest.json)
+          SHIPPED_SHA=$(sed -n 's/.*"bundleSha256" *: *"\([0-9a-f]*\)".*/\1/p' release-tree/dist/.build-manifest.json)
+          if [ -z "$SOURCE_SHA" ] || [ -z "$SHIPPED_SHA" ]; then
+            echo "manifest missing required fields" >&2
+            exit 2
+          fi
+          echo "source_sha=$SOURCE_SHA"  >> "$GITHUB_OUTPUT"
+          echo "shipped_sha=$SHIPPED_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main@sourceSha
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ steps.manifest.outputs.source_sha }}
+          path: main-tree
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Rebuild from main@sourceSha
+        working-directory: main-tree
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Compare bundle sha256
+        id: diff
+        run: |
+          REBUILT_SHA=$(sha256sum main-tree/dist/cli/index.js | awk '{print $1}')
+          SHIPPED_SHA="${{ steps.manifest.outputs.shipped_sha }}"
+          echo "rebuilt: $REBUILT_SHA"
+          echo "shipped: $SHIPPED_SHA"
+          if [ "$REBUILT_SHA" = "$SHIPPED_SHA" ]; then
+            echo "status=match" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=mismatch" >> "$GITHUB_OUTPUT"
+          fi
+          echo "rebuilt_sha=$REBUILT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Open issue on mismatch
+        if: steps.diff.outputs.status == 'mismatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "release-branch rebuild-diff mismatch ($(date -u +%Y-%m-%d))" \
+            --body "The scheduled rebuild-diff found a bundle sha256 mismatch.
+
+          - source sha: ${{ steps.manifest.outputs.source_sha }}
+          - shipped bundleSha256: ${{ steps.manifest.outputs.shipped_sha }}
+          - rebuilt bundleSha256: ${{ steps.diff.outputs.rebuilt_sha }}
+
+          This may indicate non-reproducible esbuild output across Node minor versions, or tampering with the release branch.
+          If this fires repeatedly for the same source sha with the same runner image, downgrade the schedule to monthly (docs/specs/ROADMAP-0.10.0.md Stage C open question)." \
+            --label "release-pipeline"

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -12,7 +12,11 @@ env:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -36,14 +36,15 @@ jobs:
           cd "$WORK"
           # Branch guards require a git repo on a non-default branch.
           git init --quiet
-          git commit --allow-empty -m "smoke-init" --quiet
+          git -c user.email=smoke@tff.invalid -c user.name=smoke-test commit --allow-empty -m "smoke-init" --quiet
           git checkout -b smoke-branch --quiet
           node "$GITHUB_WORKSPACE/dist/cli/index.js" schema --command project:init > schema.json
           test -s schema.json
           node "$GITHUB_WORKSPACE/dist/cli/index.js" project:init --name smoke-test
           node "$GITHUB_WORKSPACE/dist/cli/index.js" milestone:create --name "Smoke Milestone"
           node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:create --title "smoke slice"
-          node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:list | grep -q "smoke slice"
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:list \
+            | jq -e '.data[] | select(.title == "smoke slice")' > /dev/null
           echo "ok: CLI smoke passed"
 
       - name: Run observe hook smoke

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -28,8 +28,23 @@ jobs:
       - name: Verify build manifest byte-matches bundle
         run: bash scripts/verify-build-manifest.sh
 
-      - name: Verify CLI runs
-        run: node dist/cli/index.js --help
+      - name: Smoke-test CLI commands against a tmp state dir
+        run: |
+          set -e
+          node dist/cli/index.js --help
+          WORK=$(mktemp -d)
+          cd "$WORK"
+          # Branch guards require a git repo on a non-default branch.
+          git init --quiet
+          git commit --allow-empty -m "smoke-init" --quiet
+          git checkout -b smoke-branch --quiet
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" schema --command project:init > schema.json
+          test -s schema.json
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" project:init --name smoke-test
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" milestone:create --name "Smoke Milestone"
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:create --title "smoke slice"
+          node "$GITHUB_WORKSPACE/dist/cli/index.js" slice:list | grep -q "smoke slice"
+          echo "ok: CLI smoke passed"
 
       - name: Run observe hook smoke
         run: |

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Verify dist/ is present
         run: test -f dist/cli/index.js
 
+      - name: Verify build manifest byte-matches bundle
+        run: bash scripts/verify-build-manifest.sh
+
       - name: Verify CLI runs
         run: node dist/cli/index.js --help
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -67,8 +67,10 @@ let sourceSha = "";
 try {
 	sourceSha = execSync("git rev-parse HEAD", { cwd: rootDir, encoding: "utf8" }).trim();
 } catch {
-	// No git context (e.g. npm tarball install). Leave empty; validation
-	// workflows only check manifest integrity, not source presence.
+	// Rare: running `bun run build` outside a git checkout. Leave empty;
+	// the validation workflow still byte-matches bundleSha256, and the
+	// scheduled rebuild-diff workflow reports "no source sha" rather than
+	// silently skipping the comparison.
 	sourceSha = "";
 }
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
@@ -53,3 +54,33 @@ if (existsSync(localBinding)) {
 }
 
 execSync("node scripts/add-cli-shebang.cjs", { cwd: rootDir, stdio: "inherit" });
+
+// --- Build manifest ---------------------------------------------------------
+// Record provenance for the release-branch validation workflow to byte-match
+// the shipped bundle against a known-good build. See
+// docs/specs/ROADMAP-0.10.0.md Stage C.
+const bundlePath = resolve(distCliDir, "index.js");
+const bundleBytes = readFileSync(bundlePath);
+const bundleSha256 = createHash("sha256").update(bundleBytes).digest("hex");
+
+let sourceSha = "";
+try {
+	sourceSha = execSync("git rev-parse HEAD", { cwd: rootDir, encoding: "utf8" }).trim();
+} catch {
+	// No git context (e.g. npm tarball install). Leave empty; validation
+	// workflows only check manifest integrity, not source presence.
+	sourceSha = "";
+}
+
+const manifest = {
+	sourceSha,
+	bundleSha256,
+	builtAt: new Date().toISOString(),
+};
+
+writeFileSync(
+	resolve(rootDir, "dist", ".build-manifest.json"),
+	JSON.stringify(manifest, null, 2) + "\n",
+);
+
+console.log(`wrote dist/.build-manifest.json (bundleSha256: ${bundleSha256.slice(0, 16)}…)`);

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -130,13 +130,15 @@ cp package.json "$RELEASE_DIR/"
 # The release branch needs its own .github/workflows/ for GitHub Actions to
 # trigger validation on push-to-release. Workflows are loaded from the branch
 # being pushed to, so skipping this directory leaves release pushes ungated.
-# Keep this copy step — removing it re-introduces the 0.9.x bug where
-# release-branch-validation.yml never ran on release pushes.
-if [ -d .github/workflows ]; then
-  echo "Copying .github/workflows/ into release tree..."
-  mkdir -p "$RELEASE_DIR/.github/workflows"
-  cp .github/workflows/*.yml "$RELEASE_DIR/.github/workflows/"
+# Keep this copy step — GitHub Actions loads workflows from the target branch,
+# so dropping this re-breaks release-branch validation.
+if [ ! -d .github/workflows ]; then
+  echo "error: .github/workflows missing — release gating cannot work without it" >&2
+  exit 1
 fi
+echo "Copying .github/workflows/ into release tree..."
+mkdir -p "$RELEASE_DIR/.github/workflows"
+cp -r .github/workflows/. "$RELEASE_DIR/.github/workflows/"
 
 # --- 6. Minimal .gitignore (does NOT ignore dist/) ---------------------------
 

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -145,6 +145,15 @@ case "$ORIGIN_URL" in
 esac
 
 cd "$RELEASE_DIR"
+echo "release tree assembled at $RELEASE_DIR"
+
+if [ "$TFF_RELEASE_SYNC_DRY_RUN" = "yes" ]; then
+  echo "DRY RUN: skipping force-push. Inspect the tree above."
+  # Disable the EXIT trap so the tmp dir survives for inspection.
+  trap - EXIT
+  exit 0
+fi
+
 echo "Initializing release git tree..."
 git init -q
 git remote add origin "$PUSH_URL"

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -126,6 +126,18 @@ cp package.json "$RELEASE_DIR/"
 [ -f CHANGELOG.md ] && cp CHANGELOG.md "$RELEASE_DIR/"
 [ -f LICENSE ]      && cp LICENSE      "$RELEASE_DIR/"
 
+# --- 5b. GitHub Actions workflows -------------------------------------------
+# The release branch needs its own .github/workflows/ for GitHub Actions to
+# trigger validation on push-to-release. Workflows are loaded from the branch
+# being pushed to, so skipping this directory leaves release pushes ungated.
+# Keep this copy step — removing it re-introduces the 0.9.x bug where
+# release-branch-validation.yml never ran on release pushes.
+if [ -d .github/workflows ]; then
+  echo "Copying .github/workflows/ into release tree..."
+  mkdir -p "$RELEASE_DIR/.github/workflows"
+  cp .github/workflows/*.yml "$RELEASE_DIR/.github/workflows/"
+fi
+
 # --- 6. Minimal .gitignore (does NOT ignore dist/) ---------------------------
 
 cat > "$RELEASE_DIR/.gitignore" <<'EOF'

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -17,6 +17,14 @@
 #      `claude /plugin install tff-cc@the-forge-flow`; verify commands load.
 #   6. Once verified, revert the script edit before merging.
 #
+# DRY-RUN INSPECTION (no push, no test fork required):
+#   bun run build
+#   TFF_RELEASE_SYNC_CONFIRM=yes TFF_RELEASE_SYNC_DRY_RUN=yes \
+#     bash scripts/sync-release-branch.sh
+#   # prints the assembled release-tree path; exits before any git ops.
+#   # the EXIT trap is disabled in dry-run so the tmp tree survives for
+#   # inspection — clean it up yourself when done.
+#
 # This script is invoked from .github/workflows/release.yml AFTER
 # release-please cuts a release and npm publish succeeds, so a force-push
 # here always reflects a tagged, published version.
@@ -27,10 +35,13 @@ set -e
 # This script force-pushes to origin/release. Refuse to run outside GitHub
 # Actions unless the caller opts in with TFF_RELEASE_SYNC_CONFIRM=yes
 # (used for the SAFE LOCAL TEST flow documented above).
-if [ -z "$GITHUB_ACTIONS" ] && [ "$TFF_RELEASE_SYNC_CONFIRM" != "yes" ]; then
-  echo "error: refusing force-push from non-CI context." >&2
-  echo "  set TFF_RELEASE_SYNC_CONFIRM=yes to opt in (see SAFE LOCAL TEST block)." >&2
-  exit 1
+if [ -z "$GITHUB_ACTIONS" ]; then
+  if [ "$TFF_RELEASE_SYNC_CONFIRM" != "yes" ] || [ "$TFF_RELEASE_SYNC_DRY_RUN" != "yes" ]; then
+    echo "error: refusing force-push from non-CI context." >&2
+    echo "  for local inspection, set BOTH TFF_RELEASE_SYNC_CONFIRM=yes and TFF_RELEASE_SYNC_DRY_RUN=yes." >&2
+    echo "  the dry-run branch exits before any git mutation; see SAFE LOCAL TEST block." >&2
+    exit 1
+  fi
 fi
 
 # --- Preconditions -----------------------------------------------------------

--- a/scripts/verify-build-manifest.sh
+++ b/scripts/verify-build-manifest.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# verify-build-manifest.sh
+#
+# Asserts that dist/cli/index.js matches the bundleSha256 recorded in
+# dist/.build-manifest.json. Exit 0 on match, non-zero on mismatch or
+# missing files. Used by release-branch-validation.yml.
+
+set -e
+
+MANIFEST="dist/.build-manifest.json"
+BUNDLE="dist/cli/index.js"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "error: $MANIFEST missing" >&2
+  exit 2
+fi
+
+if [ ! -f "$BUNDLE" ]; then
+  echo "error: $BUNDLE missing" >&2
+  exit 2
+fi
+
+EXPECTED=$(sed -n 's/.*"bundleSha256" *: *"\([0-9a-f]*\)".*/\1/p' "$MANIFEST")
+if [ -z "$EXPECTED" ]; then
+  echo "error: could not parse bundleSha256 from $MANIFEST" >&2
+  exit 3
+fi
+
+# macOS uses `shasum -a 256`; linux has `sha256sum`. Prefer sha256sum.
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL=$(sha256sum "$BUNDLE" | awk '{print $1}')
+else
+  ACTUAL=$(shasum -a 256 "$BUNDLE" | awk '{print $1}')
+fi
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "error: bundle sha256 mismatch" >&2
+  echo "  manifest: $EXPECTED" >&2
+  echo "  actual:   $ACTUAL"   >&2
+  exit 1
+fi
+
+echo "ok: bundle sha256 matches manifest ($EXPECTED)"

--- a/tests/integration/build-manifest.integration.spec.ts
+++ b/tests/integration/build-manifest.integration.spec.ts
@@ -1,14 +1,18 @@
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 describe("build manifest", () => {
 	it("writes dist/.build-manifest.json with sourceSha, bundleSha256, builtAt", () => {
 		// Ensure a clean build so timestamps and hashes are fresh.
-		execSync("bun run build", { stdio: "inherit" });
+		execSync("bun run build", { stdio: "inherit", cwd: repoRoot });
 
-		const manifestPath = "dist/.build-manifest.json";
+		const manifestPath = resolve(repoRoot, "dist/.build-manifest.json");
 		expect(existsSync(manifestPath)).toBe(true);
 
 		const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
@@ -18,11 +22,14 @@ describe("build manifest", () => {
 		};
 
 		// sourceSha: matches `git rev-parse HEAD`
-		const expectedSha = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+		const expectedSha = execSync("git rev-parse HEAD", {
+			encoding: "utf8",
+			cwd: repoRoot,
+		}).trim();
 		expect(manifest.sourceSha).toBe(expectedSha);
 
 		// bundleSha256: matches sha256 of dist/cli/index.js
-		const bundle = readFileSync("dist/cli/index.js");
+		const bundle = readFileSync(resolve(repoRoot, "dist/cli/index.js"));
 		const expectedBundleSha = createHash("sha256").update(bundle).digest("hex");
 		expect(manifest.bundleSha256).toBe(expectedBundleSha);
 

--- a/tests/integration/build-manifest.integration.spec.ts
+++ b/tests/integration/build-manifest.integration.spec.ts
@@ -1,0 +1,33 @@
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("build manifest", () => {
+	it("writes dist/.build-manifest.json with sourceSha, bundleSha256, builtAt", () => {
+		// Ensure a clean build so timestamps and hashes are fresh.
+		execSync("bun run build", { stdio: "inherit" });
+
+		const manifestPath = "dist/.build-manifest.json";
+		expect(existsSync(manifestPath)).toBe(true);
+
+		const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+			sourceSha: string;
+			bundleSha256: string;
+			builtAt: string;
+		};
+
+		// sourceSha: matches `git rev-parse HEAD`
+		const expectedSha = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+		expect(manifest.sourceSha).toBe(expectedSha);
+
+		// bundleSha256: matches sha256 of dist/cli/index.js
+		const bundle = readFileSync("dist/cli/index.js");
+		const expectedBundleSha = createHash("sha256").update(bundle).digest("hex");
+		expect(manifest.bundleSha256).toBe(expectedBundleSha);
+
+		// builtAt: ISO-8601 timestamp parseable as a Date
+		expect(() => new Date(manifest.builtAt).toISOString()).not.toThrow();
+		expect(manifest.builtAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+});

--- a/tests/integration/sync-release-branch-dry-run.integration.spec.ts
+++ b/tests/integration/sync-release-branch-dry-run.integration.spec.ts
@@ -1,0 +1,26 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("sync-release-branch.sh DRY_RUN mode", () => {
+	it("exits 0 without pushing when TFF_RELEASE_SYNC_DRY_RUN=yes", () => {
+		// The caller must have already built dist/ and have plugin/.claude-plugin/plugin.json present.
+		expect(existsSync("dist/cli/index.js")).toBe(true);
+		expect(existsSync("plugin/.claude-plugin/plugin.json")).toBe(true);
+
+		const output = execSync(
+			"bash scripts/sync-release-branch.sh",
+			{
+				env: {
+					...process.env,
+					TFF_RELEASE_SYNC_CONFIRM: "yes",
+					TFF_RELEASE_SYNC_DRY_RUN: "yes",
+				},
+				encoding: "utf8",
+			},
+		);
+
+		expect(output).toContain("DRY RUN: skipping force-push");
+		expect(output).toContain("release tree assembled at");
+	});
+});

--- a/tests/integration/sync-release-branch-dry-run.integration.spec.ts
+++ b/tests/integration/sync-release-branch-dry-run.integration.spec.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("sync-release-branch.sh DRY_RUN mode", () => {
@@ -22,5 +22,10 @@ describe("sync-release-branch.sh DRY_RUN mode", () => {
 
 		expect(output).toContain("DRY RUN: skipping force-push");
 		expect(output).toContain("release tree assembled at");
+
+		const match = output.match(/release tree assembled at (\S+)/);
+		expect(match).not.toBeNull();
+		expect(existsSync(match![1])).toBe(true);
+		rmSync(match![1], { recursive: true, force: true });
 	});
 });

--- a/tests/integration/sync-release-branch-dry-run.integration.spec.ts
+++ b/tests/integration/sync-release-branch-dry-run.integration.spec.ts
@@ -28,4 +28,28 @@ describe("sync-release-branch.sh DRY_RUN mode", () => {
 		expect(existsSync(match![1])).toBe(true);
 		rmSync(match![1], { recursive: true, force: true });
 	});
+
+	it("copies .github/workflows/ into the release tree", () => {
+		const output = execSync(
+			"bash scripts/sync-release-branch.sh",
+			{
+				env: {
+					...process.env,
+					TFF_RELEASE_SYNC_CONFIRM: "yes",
+					TFF_RELEASE_SYNC_DRY_RUN: "yes",
+				},
+				encoding: "utf8",
+			},
+		);
+
+		const match = output.match(/release tree assembled at (\S+)/);
+		expect(match).not.toBeNull();
+		const treeDir = match![1];
+
+		try {
+			expect(existsSync(`${treeDir}/.github/workflows/release-branch-validation.yml`)).toBe(true);
+		} finally {
+			rmSync(treeDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/tests/integration/sync-release-branch-dry-run.integration.spec.ts
+++ b/tests/integration/sync-release-branch-dry-run.integration.spec.ts
@@ -8,17 +8,14 @@ describe("sync-release-branch.sh DRY_RUN mode", () => {
 		expect(existsSync("dist/cli/index.js")).toBe(true);
 		expect(existsSync("plugin/.claude-plugin/plugin.json")).toBe(true);
 
-		const output = execSync(
-			"bash scripts/sync-release-branch.sh",
-			{
-				env: {
-					...process.env,
-					TFF_RELEASE_SYNC_CONFIRM: "yes",
-					TFF_RELEASE_SYNC_DRY_RUN: "yes",
-				},
-				encoding: "utf8",
+		const output = execSync("bash scripts/sync-release-branch.sh", {
+			env: {
+				...process.env,
+				TFF_RELEASE_SYNC_CONFIRM: "yes",
+				TFF_RELEASE_SYNC_DRY_RUN: "yes",
 			},
-		);
+			encoding: "utf8",
+		});
 
 		expect(output).toContain("DRY RUN: skipping force-push");
 		expect(output).toContain("release tree assembled at");
@@ -30,17 +27,14 @@ describe("sync-release-branch.sh DRY_RUN mode", () => {
 	});
 
 	it("copies .github/workflows/ into the release tree", () => {
-		const output = execSync(
-			"bash scripts/sync-release-branch.sh",
-			{
-				env: {
-					...process.env,
-					TFF_RELEASE_SYNC_CONFIRM: "yes",
-					TFF_RELEASE_SYNC_DRY_RUN: "yes",
-				},
-				encoding: "utf8",
+		const output = execSync("bash scripts/sync-release-branch.sh", {
+			env: {
+				...process.env,
+				TFF_RELEASE_SYNC_CONFIRM: "yes",
+				TFF_RELEASE_SYNC_DRY_RUN: "yes",
 			},
-		);
+			encoding: "utf8",
+		});
 
 		const match = output.match(/release tree assembled at (\S+)/);
 		expect(match).not.toBeNull();

--- a/tests/integration/verify-build-manifest.integration.spec.ts
+++ b/tests/integration/verify-build-manifest.integration.spec.ts
@@ -1,0 +1,56 @@
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const verifyScript = resolve(repoRoot, "scripts/verify-build-manifest.sh");
+
+function setup(bundleBytes: string, manifestSha: string): string {
+	const root = mkdtempSync(join(tmpdir(), "verify-manifest-"));
+	mkdirSync(join(root, "dist", "cli"), { recursive: true });
+	writeFileSync(join(root, "dist", "cli", "index.js"), bundleBytes);
+	writeFileSync(
+		join(root, "dist", ".build-manifest.json"),
+		JSON.stringify({
+			sourceSha: "deadbeef",
+			bundleSha256: manifestSha,
+			builtAt: "2026-04-20T00:00:00.000Z",
+		}),
+	);
+	return root;
+}
+
+describe("verify-build-manifest.sh", () => {
+	it("exits 0 when bundle sha256 matches manifest", () => {
+		const bundle = "console.log('hello');\n";
+		const realSha = createHash("sha256").update(bundle).digest("hex");
+		const root = setup(bundle, realSha);
+
+		expect(() =>
+			execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" }),
+		).not.toThrow();
+	});
+
+	it("exits non-zero when bundle sha256 does not match manifest", () => {
+		const root = setup(
+			"real content\n",
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		);
+		expect(() =>
+			execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" }),
+		).toThrow();
+	});
+
+	it("exits non-zero when manifest is missing", () => {
+		const root = mkdtempSync(join(tmpdir(), "verify-manifest-missing-"));
+		mkdirSync(join(root, "dist", "cli"), { recursive: true });
+		writeFileSync(join(root, "dist", "cli", "index.js"), "x");
+		expect(() =>
+			execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" }),
+		).toThrow();
+	});
+});

--- a/tests/integration/verify-build-manifest.integration.spec.ts
+++ b/tests/integration/verify-build-manifest.integration.spec.ts
@@ -30,9 +30,7 @@ describe("verify-build-manifest.sh", () => {
 		const realSha = createHash("sha256").update(bundle).digest("hex");
 		const root = setup(bundle, realSha);
 
-		expect(() =>
-			execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" }),
-		).not.toThrow();
+		expect(() => execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" })).not.toThrow();
 	});
 
 	it("exits non-zero when bundle sha256 does not match manifest", () => {
@@ -40,17 +38,13 @@ describe("verify-build-manifest.sh", () => {
 			"real content\n",
 			"0000000000000000000000000000000000000000000000000000000000000000",
 		);
-		expect(() =>
-			execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" }),
-		).toThrow();
+		expect(() => execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" })).toThrow();
 	});
 
 	it("exits non-zero when manifest is missing", () => {
 		const root = mkdtempSync(join(tmpdir(), "verify-manifest-missing-"));
 		mkdirSync(join(root, "dist", "cli"), { recursive: true });
 		writeFileSync(join(root, "dist", "cli", "index.js"), "x");
-		expect(() =>
-			execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" }),
-		).toThrow();
+		expect(() => execSync(`bash ${verifyScript}`, { cwd: root, stdio: "pipe" })).toThrow();
 	});
 });


### PR DESCRIPTION
## Summary

Stage C of the 0.10.0 hardening roadmap (`docs/specs/ROADMAP-0.10.0.md`). Makes the `release` branch distribution trustworthy:

- `release-branch-validation.yml` actually runs on release-branch pushes now (sync script whitelists `.github/workflows/` and hard-requires it); matrix-exec on linux-x64 + darwin-arm64 with real CLI smoke (schema / project:init / milestone:create / slice:create / slice:list with `jq -e` assertion).
- `scripts/build.mjs` emits `dist/.build-manifest.json` with `{sourceSha, bundleSha256, builtAt}`; `scripts/verify-build-manifest.sh` byte-matches the shipped bundle against the manifest as a gate.
- New scheduled workflow `release-branch-rebuild-diff.yml` re-checks out `main@<sourceSha>` weekly (Mon 06:00 UTC), rebuilds, diffs; opens a labeled issue on mismatch.
- `ci.yml` gains a `smoke-matrix` job so PRs hit the same CLI smoke on both OSes pre-merge.
- Safety: `sync-release-branch.sh` now refuses to force-push outside GH Actions unless BOTH `TFF_RELEASE_SYNC_CONFIRM=yes` AND `TFF_RELEASE_SYNC_DRY_RUN=yes` are set (closing an incident vector surfaced during TDD).

## Test Plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (biome auto-applied in `0e047b6`)
- [x] `bun run test` — 214 files / 1367 passed / 1 skipped (baseline 211/1361, +3 integration specs)
- [x] Local dry-run sync: `TFF_RELEASE_SYNC_CONFIRM=yes TFF_RELEASE_SYNC_DRY_RUN=yes bash scripts/sync-release-branch.sh` assembles tree with all 4 workflows, valid manifest, bundle SHA matches
- [x] Manifest verifier runs green against the assembled tree
- [ ] CI workflows on this PR (including new `smoke-matrix`) pass on ubuntu-latest + macos-14
- [ ] After merge: next release cut from `main` triggers `release-branch-validation.yml` on the release-branch push (verify in Actions tab)
- [ ] Next Monday: `release-branch-rebuild-diff.yml` fires on schedule (weekly cron)

## Notes

- Spec lives at `docs/specs/ROADMAP-0.10.0.md` (Stage C section).
- Plan at `docs/superpowers/plans/2026-04-20-stage-c-release-pipeline-trust.md`.
- Stages A, B, D, E, F from the roadmap remain to ship; each gets its own PR.