### PR TITLE
chore(quality-gates): stage f — hygiene & thin coverage

### DIFF
--- a/src/application/routing/calibrate.ts
+++ b/src/application/routing/calibrate.ts
@@ -14,10 +14,8 @@ import { computeImplicitOutcomesUseCase } from "./compute-outcomes.js";
 
 export interface CalibrateConfig {
 	n_min: number;
-	/** Preferred: explicit per-source weights. */
+	/** Per-source weights. Missing sources fall back to defaults (manual: 1.0, debug-join: 0.5, model-judge: 1.0). */
 	source_weights?: Record<string, number>;
-	/** Deprecated: single-dial debug-join weight. Used only if source_weights is absent. */
-	implicit_weight?: number;
 }
 
 export interface CalibrateDeps {
@@ -40,9 +38,6 @@ const resolveWeights = (config: CalibrateConfig): Record<string, number> => {
 		// Merge over defaults so partial maps don't silently zero out other sources.
 		return { ...DEFAULT_WEIGHTS, ...config.source_weights };
 	}
-	if (config.implicit_weight !== undefined) {
-		return { manual: 1.0, "debug-join": config.implicit_weight, "model-judge": 1.0 };
-	}
 	return DEFAULT_WEIGHTS;
 };
 
@@ -57,7 +52,6 @@ export const calibrateUseCase = async (deps: CalibrateDeps): Promise<Calibration
 	for await (const o of deps.outcomesSource.readOutcomes({})) outcomes.push(o);
 
 	const weights = resolveWeights(deps.config);
-	const implicitWeightDeprecated = deps.config.implicit_weight !== undefined;
 
 	const { byAgent, byTag } = groupOutcomes({
 		decisions: deps.decisions,
@@ -90,9 +84,7 @@ export const calibrateUseCase = async (deps: CalibrateDeps): Promise<Calibration
 	return {
 		generated_at: deps.now(),
 		n_min: deps.config.n_min,
-		implicit_weight: weights["debug-join"] ?? 0.5,
 		source_weights: weights,
-		implicit_weight_deprecated: implicitWeightDeprecated,
 		decisions_scanned: deps.decisions.length,
 		outcomes_scanned: outcomes.length,
 		cells,

--- a/src/cli/commands/routing-calibrate.cmd.ts
+++ b/src/cli/commands/routing-calibrate.cmd.ts
@@ -16,24 +16,14 @@ export const routingCalibrateSchema: CommandSchema = {
 	purpose: "Produce an advisory calibration report from routing decisions + outcomes",
 	mutates: true,
 	requiredFlags: [],
-	optionalFlags: [
-		{ name: "n-min", type: "number", description: "Minimum cell size (default 5)" },
-		{
-			name: "implicit-weight",
-			type: "number",
-			description: "Weight on debug-join outcomes (default 0.5)",
-		},
-	],
-	examples: ["routing:calibrate", "routing:calibrate --n-min 3 --implicit-weight 0.3"],
+	optionalFlags: [{ name: "n-min", type: "number", description: "Minimum cell size (default 5)" }],
+	examples: ["routing:calibrate", "routing:calibrate --n-min 3"],
 };
 
 export const routingCalibrateCmd = async (args: string[]): Promise<string> => {
 	const parsed = parseFlags(args, routingCalibrateSchema);
 	if (!parsed.ok) return JSON.stringify(parsed);
-	const { "n-min": nMinFlag, "implicit-weight": weightFlag } = parsed.data as {
-		"n-min"?: number;
-		"implicit-weight"?: number;
-	};
+	const { "n-min": nMinFlag } = parsed.data as { "n-min"?: number };
 
 	const projectRoot = process.cwd();
 	const configReader = new YamlRoutingConfigReader({ projectRoot });
@@ -53,10 +43,7 @@ export const routingCalibrateCmd = async (args: string[]): Promise<string> => {
 	);
 
 	const n_min = nMinFlag ?? configRes.data.calibration?.n_min ?? 5;
-	const implicitWeightFromSettings = configRes.data.calibration?.implicit_weight;
 	const sourceWeightsFromSettings = configRes.data.calibration?.source_weights;
-	// CLI flag override wins; if no flag, fall through to settings; if neither, leave undefined so calibrateUseCase defaults kick in.
-	const implicit_weight = weightFlag ?? implicitWeightFromSettings;
 
 	const decisionReader = new JsonlRoutingDecisionReader(routingPath);
 	const decisions = await decisionReader.readDecisions();
@@ -72,7 +59,6 @@ export const routingCalibrateCmd = async (args: string[]): Promise<string> => {
 		config: {
 			n_min,
 			...(sourceWeightsFromSettings ? { source_weights: sourceWeightsFromSettings } : {}),
-			...(implicit_weight !== undefined ? { implicit_weight } : {}),
 		},
 		now: () => new Date().toISOString(),
 	});

--- a/src/domain/ports/routing-config-reader.port.ts
+++ b/src/domain/ports/routing-config-reader.port.ts
@@ -13,7 +13,6 @@ export interface ModelJudgeConfig {
 
 export interface CalibrationConfig {
 	n_min: number;
-	implicit_weight?: number;
 	debug_join: { enabled: boolean };
 	source_weights?: Record<string, number>;
 	model_judge?: ModelJudgeConfig;

--- a/src/domain/value-objects/calibration-report.ts
+++ b/src/domain/value-objects/calibration-report.ts
@@ -51,9 +51,7 @@ export type SkippedCell = z.infer<typeof SkippedCellSchema>;
 export const CalibrationReportSchema = z.object({
 	generated_at: z.string().datetime(),
 	n_min: z.number().int().positive(),
-	implicit_weight: z.number().min(0).max(1),
 	source_weights: z.record(z.string(), z.number().min(0).max(2)).optional(),
-	implicit_weight_deprecated: z.boolean().optional(),
 	decisions_scanned: z.number().int().nonnegative(),
 	outcomes_scanned: z.number().int().nonnegative(),
 	cells: z.array(CalibrationCellSchema),

--- a/src/infrastructure/adapters/filesystem/yaml-routing-config-reader.ts
+++ b/src/infrastructure/adapters/filesystem/yaml-routing-config-reader.ts
@@ -26,7 +26,6 @@ const ModelJudgeConfigSchema = z.object({
 
 const CalibrationConfigSchema = z.object({
 	n_min: z.number().int().positive().default(5),
-	implicit_weight: z.number().min(0).max(1).optional(),
 	debug_join: z.object({ enabled: z.boolean().default(true) }).default({ enabled: true }),
 	source_weights: z.record(z.string(), z.number().min(0).max(2)).optional(),
 	model_judge: ModelJudgeConfigSchema.optional(),

--- a/src/infrastructure/adapters/markdown/calibration-report-renderer.ts
+++ b/src/infrastructure/adapters/markdown/calibration-report-renderer.ts
@@ -11,7 +11,6 @@ const header = (r: CalibrationReport) =>
 		"",
 		`Generated at: ${r.generated_at}`,
 		`N_min: ${r.n_min}`,
-		`Implicit weight: ${r.implicit_weight}`,
 		`Decisions scanned: ${r.decisions_scanned}`,
 		`Outcomes scanned: ${r.outcomes_scanned}`,
 		"",
@@ -71,17 +70,6 @@ export const renderCalibrationReport = (report: CalibrationReport): string => {
 		recsSection(report.recommendations),
 		skippedSection(report.skipped_cells),
 	];
-
-	if (report.implicit_weight_deprecated) {
-		sections.push(
-			[
-				"---",
-				"",
-				`> **Deprecation:** \`routing.calibration.implicit_weight\` is deprecated. Migrate to \`routing.calibration.source_weights\`. The current run used weights: ${JSON.stringify(report.source_weights ?? {})}.`,
-				"",
-			].join("\n"),
-		);
-	}
 
 	return sections.join("\n");
 };

--- a/tests/integration/cli/routing-calibrate.three-sources.spec.ts
+++ b/tests/integration/cli/routing-calibrate.three-sources.spec.ts
@@ -79,26 +79,7 @@ describe("routing:calibrate — three sources", () => {
 		// effective_total on the reviewer agent cell:
 		// 1.0 (manual) + 0.5 (debug-join) + 1.0 (model-judge) = 2.5 ≥ n_min=2 → cell passes the gate
 		expect(md).not.toContain("reviewer) — insufficient evidence");
-		// source_weights only — no implicit_weight in settings → no deprecation footer
+		// source_weights only
 		expect(md).not.toContain("Deprecation");
-	});
-
-	it("emits a deprecation footer when only implicit_weight is configured", async () => {
-		mkdirSync(join(root, ".tff-cc", "logs"), { recursive: true });
-		writeFileSync(
-			join(root, ".tff-cc", "settings.yaml"),
-			`routing:
-  enabled: true
-  calibration:
-    n_min: 2
-    implicit_weight: 0.4
-`,
-		);
-		writeFileSync(join(root, ".tff-cc", "logs", "routing.jsonl"), "");
-		const out = await routingCalibrateCmd([]);
-		expect(JSON.parse(out).ok).toBe(true);
-		const md = readFileSync(join(root, ".tff-cc", "logs", "routing-calibration.md"), "utf8");
-		expect(md).toContain("Deprecation");
-		expect(md).toContain("implicit_weight");
 	});
 });

--- a/tests/property/sqlite-salvage.property.spec.ts
+++ b/tests/property/sqlite-salvage.property.spec.ts
@@ -1,0 +1,291 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import Database from "better-sqlite3";
+import * as fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isErr, isOk } from "../../src/domain/result.js";
+import { SQLiteSalvage } from "../../src/infrastructure/adapters/sqlite/sqlite-salvage.js";
+
+const SCHEMA_DDL = `
+	CREATE TABLE project (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		vision TEXT,
+		created_at TEXT NOT NULL
+	);
+	CREATE TABLE milestone (
+		id TEXT PRIMARY KEY,
+		project_id TEXT NOT NULL,
+		number INTEGER NOT NULL,
+		name TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'open',
+		branch TEXT,
+		close_reason TEXT,
+		created_at TEXT NOT NULL
+	);
+	CREATE TABLE slice (
+		id TEXT PRIMARY KEY,
+		milestone_id TEXT NOT NULL,
+		number INTEGER NOT NULL,
+		title TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'discussing',
+		tier TEXT,
+		created_at TEXT NOT NULL
+	);
+	CREATE TABLE task (
+		id TEXT PRIMARY KEY,
+		slice_id TEXT NOT NULL,
+		number INTEGER NOT NULL,
+		title TEXT NOT NULL,
+		description TEXT,
+		status TEXT NOT NULL DEFAULT 'open',
+		wave INTEGER,
+		claimed_at TEXT,
+		claimed_by TEXT,
+		closed_reason TEXT,
+		created_at TEXT NOT NULL
+	);
+	CREATE TABLE dependency (
+		from_id TEXT NOT NULL,
+		to_id TEXT NOT NULL,
+		type TEXT NOT NULL,
+		PRIMARY KEY (from_id, to_id)
+	);
+	CREATE TABLE workflow_session (
+		id INTEGER PRIMARY KEY,
+		state TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	);
+	CREATE TABLE review (
+		id TEXT PRIMARY KEY,
+		slice_id TEXT NOT NULL,
+		kind TEXT NOT NULL,
+		verdict TEXT NOT NULL,
+		reviewer_id TEXT NOT NULL,
+		summary TEXT,
+		created_at TEXT NOT NULL
+	);
+`;
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sqlite-salvage-prop-"));
+});
+
+afterEach(() => {
+	try {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	} catch {
+		// Ignore cleanup errors
+	}
+});
+
+function mkDb(populate: (db: Database.Database) => void): string {
+	const dbPath = path.join(tempDir, `db-${Math.random().toString(36).slice(2)}.db`);
+	const db = new Database(dbPath);
+	db.exec(SCHEMA_DDL);
+	populate(db);
+	db.close();
+	return dbPath;
+}
+
+describe("SQLiteSalvage - property-based", () => {
+	const malformedMilestoneRow = fc.record({
+		id: fc.oneof(fc.string(), fc.constant(""), fc.constant(null)),
+		project_id: fc.oneof(fc.string(), fc.constant(null)),
+		number: fc.oneof(fc.integer(), fc.constant(Number.NaN), fc.string()),
+		name: fc.oneof(fc.string(), fc.constant(""), fc.constant(null)),
+		status: fc.oneof(
+			fc.constantFrom("open", "closed", "abandoned"),
+			fc.string(),
+			fc.constant(null),
+		),
+		branch: fc.oneof(fc.string(), fc.constant(null)),
+		close_reason: fc.oneof(fc.string(), fc.constant(null)),
+		created_at: fc.oneof(fc.string(), fc.constant("not-a-date"), fc.constant(null)),
+	});
+
+	it("P1 — malformed milestone rows never crash salvage", () => {
+		fc.assert(
+			fc.property(fc.array(malformedMilestoneRow, { maxLength: 5 }), (rows) => {
+				const dbPath = mkDb((db) => {
+					const stmt = db.prepare(
+						"INSERT INTO milestone (id, project_id, number, name, status, branch, close_reason, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+					);
+					for (const r of rows) {
+						try {
+							stmt.run(
+								r.id ?? `m-${Math.random()}`,
+								r.project_id ?? "singleton",
+								typeof r.number === "number" && !Number.isNaN(r.number) ? r.number : 0,
+								r.name ?? "n",
+								r.status ?? "open",
+								r.branch,
+								r.close_reason,
+								r.created_at ?? new Date().toISOString(),
+							);
+						} catch {
+							// SQLite rejected the row (NOT NULL violation etc.). That's fine — we're
+							// testing salvage's tolerance to whatever made it into the DB.
+						}
+					}
+				});
+
+				const result = SQLiteSalvage.salvage(dbPath);
+				expect(isOk(result) || isErr(result)).toBe(true);
+				if (isOk(result) && result.data.snapshot) {
+					for (const m of result.data.snapshot.milestones) {
+						expect(typeof m.id).toBe("string");
+						expect(m.id.length).toBeGreaterThan(0);
+						expect(typeof m.name).toBe("string");
+						expect(m.name.length).toBeGreaterThan(0);
+						expect(m.createdAt).toBeInstanceOf(Date);
+						expect(Number.isNaN(m.createdAt.getTime())).toBe(false);
+					}
+				}
+			}),
+			{ numRuns: 200 },
+		);
+	});
+
+	it("P2 — partial datasets never crash salvage", () => {
+		const populationPlan = fc.record({
+			hasProject: fc.boolean(),
+			milestoneCount: fc.integer({ min: 0, max: 5 }),
+			sliceCount: fc.integer({ min: 0, max: 5 }),
+			taskCount: fc.integer({ min: 0, max: 5 }),
+			orphanSlices: fc.boolean(),
+			orphanTasks: fc.boolean(),
+		});
+
+		fc.assert(
+			fc.property(populationPlan, (plan) => {
+				const dbPath = mkDb((db) => {
+					if (plan.hasProject) {
+						db.prepare(
+							"INSERT INTO project (id, name, vision, created_at) VALUES ('singleton', 'P', NULL, ?)",
+						).run(new Date().toISOString());
+					}
+					const msInsert = db.prepare(
+						"INSERT INTO milestone (id, project_id, number, name, status, branch, close_reason, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+					);
+					for (let i = 0; i < plan.milestoneCount; i++) {
+						msInsert.run(
+							`m-${i}`,
+							"singleton",
+							i + 1,
+							`M${i}`,
+							"open",
+							null,
+							null,
+							new Date().toISOString(),
+						);
+					}
+					const slInsert = db.prepare(
+						"INSERT INTO slice (id, milestone_id, number, title, status, tier, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+					);
+					for (let i = 0; i < plan.sliceCount; i++) {
+						const msId = plan.orphanSlices
+							? "missing-milestone"
+							: `m-${i % Math.max(1, plan.milestoneCount)}`;
+						slInsert.run(
+							`s-${i}`,
+							msId,
+							i + 1,
+							`S${i}`,
+							"discussing",
+							null,
+							new Date().toISOString(),
+						);
+					}
+					const tkInsert = db.prepare(
+						"INSERT INTO task (id, slice_id, number, title, description, status, wave, claimed_at, claimed_by, closed_reason, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+					);
+					for (let i = 0; i < plan.taskCount; i++) {
+						const slId = plan.orphanTasks
+							? "missing-slice"
+							: `s-${i % Math.max(1, plan.sliceCount)}`;
+						tkInsert.run(
+							`t-${i}`,
+							slId,
+							i + 1,
+							`T${i}`,
+							null,
+							"open",
+							null,
+							null,
+							null,
+							null,
+							new Date().toISOString(),
+						);
+					}
+				});
+
+				const result = SQLiteSalvage.salvage(dbPath);
+				expect(isOk(result) || isErr(result)).toBe(true);
+				if (isOk(result) && result.data.snapshot) {
+					expect(Array.isArray(result.data.snapshot.milestones)).toBe(true);
+					expect(Array.isArray(result.data.snapshot.slices)).toBe(true);
+					expect(Array.isArray(result.data.snapshot.tasks)).toBe(true);
+					expect(Array.isArray(result.data.snapshot.dependencies)).toBe(true);
+					expect(Array.isArray(result.data.snapshot.reviews)).toBe(true);
+				}
+			}),
+			{ numRuns: 200 },
+		);
+	});
+
+	it("P3 — corrupt JSON in workflow_session.state never crashes salvage", () => {
+		const corruptJson = fc.oneof(
+			fc.constant("{not-json"),
+			fc.constant("null"),
+			fc.constant("[]"),
+			fc.constant('{"incomplete":'),
+			fc.string(),
+			fc.constant(""),
+		);
+
+		fc.assert(
+			fc.property(corruptJson, (bogusState) => {
+				const dbPath = mkDb((db) => {
+					db.prepare("INSERT INTO workflow_session (id, state, updated_at) VALUES (1, ?, ?)").run(
+						bogusState,
+						new Date().toISOString(),
+					);
+				});
+
+				const result = SQLiteSalvage.salvage(dbPath);
+				expect(isOk(result) || isErr(result)).toBe(true);
+				if (isOk(result) && result.data.snapshot) {
+					const s = result.data.snapshot.workflowSession;
+					if (s !== null) {
+						expect(typeof s).toBe("object");
+					}
+				}
+			}),
+			{ numRuns: 200 },
+		);
+	});
+});
+
+describe("SQLiteSalvage - smoke", () => {
+	it("truncated SQLite file produces Result.err or Ok-with-null, never a throw", () => {
+		const dbPath = path.join(tempDir, "truncated.db");
+		// Write a partial SQLite header — too short to be a valid database.
+		fs.writeFileSync(dbPath, Buffer.from("SQLite format 3\0").subarray(0, 16));
+
+		const result = SQLiteSalvage.salvage(dbPath);
+		expect(isOk(result) || isErr(result)).toBe(true);
+		if (isOk(result)) {
+			expect(result.data.snapshot).toBeNull();
+		}
+	});
+
+	it("nonexistent file produces Result.err, not a throw", () => {
+		const dbPath = path.join(tempDir, "nonexistent.db");
+		const result = SQLiteSalvage.salvage(dbPath);
+		expect(isErr(result)).toBe(true);
+	});
+});

--- a/tests/unit/application/routing/calibrate.source-weights.spec.ts
+++ b/tests/unit/application/routing/calibrate.source-weights.spec.ts
@@ -54,22 +54,6 @@ describe("calibrateUseCase — source_weights", () => {
 		expect(agentCell?.effective_total).toBeCloseTo(2.5);
 	});
 
-	it("records implicit_weight_deprecated=true when only implicit_weight is provided", async () => {
-		const report = await calibrateUseCase({
-			decisions: [decision],
-			implicitSource: emptySource,
-			outcomesSource,
-			writer,
-			config: {
-				n_min: 2,
-				implicit_weight: 0.3,
-			},
-			now: () => "2026-04-20T10:00:00.000Z",
-		});
-		expect(report.implicit_weight_deprecated).toBe(true);
-		expect(report.source_weights).toEqual({ manual: 1.0, "debug-join": 0.3, "model-judge": 1.0 });
-	});
-
 	it("merges partial source_weights over defaults instead of zeroing untouched sources", async () => {
 		const manualOutcome: RoutingOutcome = {
 			outcome_id: "00000000-0000-4000-8000-0000000000b1",
@@ -114,23 +98,5 @@ describe("calibrateUseCase — source_weights", () => {
 			"debug-join": 0.5, // from DEFAULT_WEIGHTS
 			"model-judge": 0.5, // overridden by user
 		});
-	});
-
-	it("prefers source_weights when both keys are provided", async () => {
-		const report = await calibrateUseCase({
-			decisions: [decision],
-			implicitSource: emptySource,
-			outcomesSource,
-			writer,
-			config: {
-				n_min: 2,
-				implicit_weight: 0.3,
-				source_weights: { manual: 1.0, "debug-join": 0.9, "model-judge": 1.0 },
-			},
-			now: () => "2026-04-20T10:00:00.000Z",
-		});
-		expect(report.source_weights?.["debug-join"]).toBe(0.9);
-		// implicit_weight_deprecated is still true because the *key* was present in config
-		expect(report.implicit_weight_deprecated).toBe(true);
 	});
 });

--- a/tests/unit/application/routing/calibrate.spec.ts
+++ b/tests/unit/application/routing/calibrate.spec.ts
@@ -40,7 +40,7 @@ describe("calibrateUseCase", () => {
 			implicitSource: arraySource([]),
 			outcomesSource: arraySource([]),
 			writer: emptyWriter,
-			config: { n_min: 5, implicit_weight: 0.5 },
+			config: { n_min: 5 },
 			now: () => "2026-04-19T11:00:00.000Z",
 		});
 		expect(report.cells).toEqual([]);
@@ -53,7 +53,7 @@ describe("calibrateUseCase", () => {
 			implicitSource: arraySource([]),
 			outcomesSource: arraySource([manualTierTooLow]),
 			writer: emptyWriter,
-			config: { n_min: 5, implicit_weight: 0.5 },
+			config: { n_min: 5 },
 			now: () => "2026-04-19T11:00:00.000Z",
 		});
 		expect(report.cells).toHaveLength(0);
@@ -72,7 +72,7 @@ describe("calibrateUseCase", () => {
 			implicitSource: arraySource([]),
 			outcomesSource: arraySource(outcomes),
 			writer: emptyWriter,
-			config: { n_min: 5, implicit_weight: 0.5 },
+			config: { n_min: 5 },
 			now: () => "2026-04-19T11:00:00.000Z",
 		});
 		expect(report.recommendations.some((r) => r.rule_id === "tier-too-low-dominant")).toBe(true);
@@ -97,7 +97,7 @@ describe("calibrateUseCase", () => {
 			implicitSource: arraySource([debugJoin]),
 			outcomesSource: arraySource([]),
 			writer,
-			config: { n_min: 5, implicit_weight: 0.5 },
+			config: { n_min: 5 },
 			now: () => "2026-04-19T11:00:00.000Z",
 		});
 		expect(written).toContainEqual(debugJoin);

--- a/tests/unit/domain/value-objects/calibration-report.spec.ts
+++ b/tests/unit/domain/value-objects/calibration-report.spec.ts
@@ -48,7 +48,6 @@ describe("CalibrationReportSchema", () => {
 		const report = {
 			generated_at: "2026-04-19T10:00:00.000Z",
 			n_min: 5,
-			implicit_weight: 0.5,
 			decisions_scanned: 0,
 			outcomes_scanned: 0,
 			cells: [],

--- a/tests/unit/infrastructure/adapters/filesystem/yaml-routing-config-reader.source-weights.spec.ts
+++ b/tests/unit/infrastructure/adapters/filesystem/yaml-routing-config-reader.source-weights.spec.ts
@@ -60,38 +60,4 @@ describe("YamlRoutingConfigReader — source_weights + model_judge", () => {
 			timeout_ms: 30000,
 		});
 	});
-
-	it("accepts implicit_weight alone (backcompat)", async () => {
-		writeSettings(
-			root,
-			`routing:
-  enabled: true
-  calibration:
-    implicit_weight: 0.3
-`,
-		);
-		const res = await new YamlRoutingConfigReader({ projectRoot: root }).readConfig();
-		if (!isOk(res)) throw new Error("not ok");
-		expect(res.data.calibration?.implicit_weight).toBe(0.3);
-		expect(res.data.calibration?.source_weights).toBeUndefined();
-	});
-
-	it("accepts both (caller handles precedence)", async () => {
-		writeSettings(
-			root,
-			`routing:
-  enabled: true
-  calibration:
-    implicit_weight: 0.3
-    source_weights:
-      manual: 1.0
-      debug-join: 0.5
-      model-judge: 1.0
-`,
-		);
-		const res = await new YamlRoutingConfigReader({ projectRoot: root }).readConfig();
-		if (!isOk(res)) throw new Error("not ok");
-		expect(res.data.calibration?.implicit_weight).toBe(0.3);
-		expect(res.data.calibration?.source_weights).toBeDefined();
-	});
 });

--- a/tests/unit/infrastructure/adapters/filesystem/yaml-routing-config-reader.spec.ts
+++ b/tests/unit/infrastructure/adapters/filesystem/yaml-routing-config-reader.spec.ts
@@ -234,19 +234,18 @@ describe("YamlRoutingConfigReader — calibration block", () => {
 		await rm(dir, { recursive: true, force: true });
 	});
 
-	it("parses routing.calibration.{n_min, implicit_weight, debug_join.enabled}", async () => {
+	it("parses routing.calibration.{n_min, debug_join.enabled}", async () => {
 		await writeFile(
-			join(dir, ".tff-cc", "settings.yaml"),
-			"routing:\n  enabled: true\n  logging:\n    path: .tff-cc/logs/routing.jsonl\n  calibration:\n    n_min: 3\n    implicit_weight: 0.25\n    debug_join:\n      enabled: false\n",
+			join(dir, ".tff-cc/settings.yaml"),
+			"routing:\n  enabled: true\n  logging:\n    path: .tff-cc/logs/routing.jsonl\n  calibration:\n    n_min: 3\n    debug_join:\n      enabled: false\n",
 			"utf8",
 		);
 		const reader = new YamlRoutingConfigReader({ projectRoot: dir });
 		const res = await reader.readConfig();
-		expect(res.ok).toBe(true);
-		if (!res.ok) throw new Error("not ok");
+		expect(isOk(res)).toBe(true);
+		if (!isOk(res)) return;
 		expect(res.data.calibration?.n_min).toBe(3);
-		expect(res.data.calibration?.implicit_weight).toBe(0.25);
-		expect(res.data.calibration?.debug_join?.enabled).toBe(false);
+		expect(res.data.calibration?.debug_join.enabled).toBe(false);
 	});
 
 	it("calibration block is optional — absence produces undefined", async () => {
@@ -259,22 +258,8 @@ describe("YamlRoutingConfigReader — calibration block", () => {
 		const res = await reader.readConfig();
 		expect(res.ok).toBe(true);
 		if (!res.ok) throw new Error("not ok");
-		const cal = res.data.calibration ?? { n_min: 5, implicit_weight: 0.5 };
+		const cal = res.data.calibration ?? { n_min: 5 };
 		expect(cal.n_min).toBe(5);
-		expect(cal.implicit_weight).toBe(0.5);
-	});
-
-	it("rejects calibration.implicit_weight outside [0, 1]", async () => {
-		await writeFile(
-			join(dir, ".tff-cc", "settings.yaml"),
-			"routing:\n  enabled: true\n  logging:\n    path: .tff-cc/logs/routing.jsonl\n  calibration:\n    implicit_weight: 2.0\n",
-			"utf8",
-		);
-		const reader = new YamlRoutingConfigReader({ projectRoot: dir });
-		const res = await reader.readConfig();
-		expect(res.ok).toBe(false);
-		if (res.ok) throw new Error("expected err");
-		expect(res.error.code).toBe("ROUTING_CONFIG");
 	});
 });
 

--- a/tests/unit/infrastructure/adapters/markdown/calibration-report-renderer.spec.ts
+++ b/tests/unit/infrastructure/adapters/markdown/calibration-report-renderer.spec.ts
@@ -5,7 +5,6 @@ import { renderCalibrationReport } from "../../../../../src/infrastructure/adapt
 const base: CalibrationReport = {
 	generated_at: "2026-04-19T10:00:00.000Z",
 	n_min: 5,
-	implicit_weight: 0.5,
 	decisions_scanned: 0,
 	outcomes_scanned: 0,
 	cells: [],
@@ -61,22 +60,5 @@ describe("renderCalibrationReport", () => {
 		const md1 = renderCalibrationReport(base);
 		const md2 = renderCalibrationReport(base);
 		expect(md1).toEqual(md2);
-	});
-
-	it("emits a deprecation footer when implicit_weight_deprecated is true", () => {
-		const md = renderCalibrationReport({
-			...base,
-			implicit_weight_deprecated: true,
-			source_weights: { manual: 1.0, "debug-join": 0.4, "model-judge": 1.0 },
-		});
-		expect(md).toContain("Deprecation");
-		expect(md).toContain("implicit_weight");
-		expect(md).toContain("source_weights");
-		expect(md).toContain("debug-join");
-	});
-
-	it("omits the deprecation footer when implicit_weight_deprecated is false/undefined", () => {
-		const md = renderCalibrationReport(base);
-		expect(md).not.toContain("Deprecation");
 	});
 });


### PR DESCRIPTION
## Summary
- Remove `implicit_weight` from routing config. `source_weights` (added in routing Phase E) is now the sole weight-resolution path; callers must migrate.
- Add `tests/property/sqlite-salvage.property.spec.ts` — 3 `fast-check` properties (~200 runs each) + 2 smoke tests covering the 641-LOC `SQLiteSalvage.salvage()` path: malformed rows, partial datasets, corrupt serialized VOs, truncated/missing files. 600+ fuzz cases, zero crashes.
- Net +132 LOC (cleanup removes 175, property spec adds 291).

Two themes under one PR because both are Stage F hygiene items from `ROADMAP-0.10.0.md`.

## Test plan
- [x] `bun run test` — 1684 pass / 2 skipped
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `rg -i "implicit_weight" src/ tests/` — zero hits
- [ ] CI green