### PR TITLE
feat: resolve .tff-project-id and .tff-cc at git toplevel

### DIFF
--- a/src/cli/commands/direct-edit-guard.cmd.ts
+++ b/src/cli/commands/direct-edit-guard.cmd.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { detectDirectEdit } from "../../application/guard/detect-direct-edit.js";
 import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
 import { SETTINGS_FILE, TFF_CC_DIR } from "../../shared/paths.js";
 import type { CommandSchema } from "../utils/flag-parser.js";
 
@@ -11,7 +12,8 @@ import type { CommandSchema } from "../utils/flag-parser.js";
  * Returns true if workflow.guards is explicitly false.
  */
 function areGuardsDisabled(): boolean {
-	const settingsPath = path.join(process.cwd(), SETTINGS_FILE);
+	const repoRoot = resolveRepoRoot(process.cwd());
+	const settingsPath = path.join(repoRoot, SETTINGS_FILE);
 	if (!existsSync(settingsPath)) {
 		return false; // Default to enabled if no settings file
 	}
@@ -29,7 +31,7 @@ function areGuardsDisabled(): boolean {
  * Check if the project is initialized (has .tff-cc directory).
  */
 function isProjectInitialized(): boolean {
-	const tffDir = path.join(process.cwd(), TFF_CC_DIR);
+	const tffDir = path.join(resolveRepoRoot(process.cwd()), TFF_CC_DIR);
 	return existsSync(tffDir);
 }
 

--- a/src/cli/commands/direct-edit-guard.cmd.ts
+++ b/src/cli/commands/direct-edit-guard.cmd.ts
@@ -11,8 +11,7 @@ import type { CommandSchema } from "../utils/flag-parser.js";
  * Check if direct-edit guards are disabled in settings.yaml.
  * Returns true if workflow.guards is explicitly false.
  */
-function areGuardsDisabled(): boolean {
-	const repoRoot = resolveRepoRoot(process.cwd());
+function areGuardsDisabled(repoRoot: string): boolean {
 	const settingsPath = path.join(repoRoot, SETTINGS_FILE);
 	if (!existsSync(settingsPath)) {
 		return false; // Default to enabled if no settings file
@@ -30,8 +29,8 @@ function areGuardsDisabled(): boolean {
 /**
  * Check if the project is initialized (has .tff-cc directory).
  */
-function isProjectInitialized(): boolean {
-	const tffDir = path.join(resolveRepoRoot(process.cwd()), TFF_CC_DIR);
+function isProjectInitialized(repoRoot: string): boolean {
+	const tffDir = path.join(repoRoot, TFF_CC_DIR);
 	return existsSync(tffDir);
 }
 
@@ -60,8 +59,10 @@ export const directEditGuardCmd = async (args: string[]): Promise<string> => {
 		});
 	}
 
+	const repoRoot = resolveRepoRoot(process.cwd());
+
 	// Fast path: check if guards are disabled
-	if (areGuardsDisabled()) {
+	if (areGuardsDisabled(repoRoot)) {
 		return JSON.stringify({
 			ok: true,
 			data: { warning: null },
@@ -69,7 +70,7 @@ export const directEditGuardCmd = async (args: string[]): Promise<string> => {
 	}
 
 	// Check if project is initialized
-	if (!isProjectInitialized()) {
+	if (!isProjectInitialized(repoRoot)) {
 		return JSON.stringify({
 			ok: true,
 			data: { warning: null },

--- a/src/cli/commands/pre-op-guard.cmd.ts
+++ b/src/cli/commands/pre-op-guard.cmd.ts
@@ -17,8 +17,7 @@ import { withSyncLock } from "../with-sync-lock.js";
  * Check if pre-operation guards are disabled in settings.yaml.
  * Returns true if workflow.guards is explicitly false.
  */
-function areGuardsDisabled(): boolean {
-	const repoRoot = resolveRepoRoot(process.cwd());
+function areGuardsDisabled(repoRoot: string): boolean {
 	const settingsPath = path.join(repoRoot, SETTINGS_FILE);
 	if (!existsSync(settingsPath)) {
 		return false; // Default to enabled if no settings file
@@ -36,8 +35,8 @@ function areGuardsDisabled(): boolean {
 /**
  * Check if the project is initialized (has .tff-cc directory).
  */
-function isProjectInitialized(): boolean {
-	const tffDir = path.join(resolveRepoRoot(process.cwd()), TFF_CC_DIR);
+function isProjectInitialized(repoRoot: string): boolean {
+	const tffDir = path.join(repoRoot, TFF_CC_DIR);
 	return existsSync(tffDir);
 }
 
@@ -74,8 +73,10 @@ export const preOpGuardCmd = async (args: string[]): Promise<string> => {
 		operation: string;
 	};
 
+	const repoRoot = resolveRepoRoot(process.cwd());
+
 	// Fast path: check if guards are disabled
-	if (areGuardsDisabled()) {
+	if (areGuardsDisabled(repoRoot)) {
 		return JSON.stringify({
 			ok: true,
 			data: { blocked: false },
@@ -83,7 +84,7 @@ export const preOpGuardCmd = async (args: string[]): Promise<string> => {
 	}
 
 	// Check if project is initialized
-	if (!isProjectInitialized()) {
+	if (!isProjectInitialized(repoRoot)) {
 		return JSON.stringify({
 			ok: true,
 			data: { blocked: false },

--- a/src/cli/commands/pre-op-guard.cmd.ts
+++ b/src/cli/commands/pre-op-guard.cmd.ts
@@ -8,6 +8,7 @@ import {
 import { isValidOperation } from "../../application/index.js";
 import { isOk } from "../../domain/result.js";
 import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
 import { SETTINGS_FILE, TFF_CC_DIR } from "../../shared/paths.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { withSyncLock } from "../with-sync-lock.js";
@@ -17,7 +18,8 @@ import { withSyncLock } from "../with-sync-lock.js";
  * Returns true if workflow.guards is explicitly false.
  */
 function areGuardsDisabled(): boolean {
-	const settingsPath = path.join(process.cwd(), SETTINGS_FILE);
+	const repoRoot = resolveRepoRoot(process.cwd());
+	const settingsPath = path.join(repoRoot, SETTINGS_FILE);
 	if (!existsSync(settingsPath)) {
 		return false; // Default to enabled if no settings file
 	}
@@ -35,7 +37,7 @@ function areGuardsDisabled(): boolean {
  * Check if the project is initialized (has .tff-cc directory).
  */
 function isProjectInitialized(): boolean {
-	const tffDir = path.join(process.cwd(), TFF_CC_DIR);
+	const tffDir = path.join(resolveRepoRoot(process.cwd()), TFF_CC_DIR);
 	return existsSync(tffDir);
 }
 

--- a/src/cli/commands/project-init.cmd.ts
+++ b/src/cli/commands/project-init.cmd.ts
@@ -3,6 +3,7 @@ import { isOk } from "../../domain/result.js";
 import { MarkdownArtifactAdapter } from "../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js";
 import { GitCliAdapter } from "../../infrastructure/adapters/git/git-cli.adapter.js";
 import { createStateStores } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
 import { installPostCheckoutHook } from "../../infrastructure/hooks/install-post-checkout.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 
@@ -39,7 +40,7 @@ export const projectInitCmd = async (args: string[]): Promise<string> => {
 	const { name, vision } = parsed.data as { name: string; vision?: string };
 	const finalVision = vision || name;
 
-	const cwd = process.cwd();
+	const cwd = resolveRepoRoot(process.cwd());
 	// Note: .tff-cc/ symlink is created by getProjectId() called from createStateStores()
 	const { projectStore } = createStateStores();
 	const artifactStore = new MarkdownArtifactAdapter(cwd);
@@ -48,7 +49,7 @@ export const projectInitCmd = async (args: string[]): Promise<string> => {
 	const result = await initProject({ name, vision: finalVision }, { projectStore, artifactStore });
 	if (isOk(result)) {
 		try {
-			installPostCheckoutHook(process.cwd());
+			installPostCheckoutHook(cwd);
 		} catch {
 			// Hook installation is best-effort
 		}

--- a/src/cli/commands/session-remind.cmd.ts
+++ b/src/cli/commands/session-remind.cmd.ts
@@ -11,8 +11,7 @@ import type { CommandSchema } from "../utils/flag-parser.js";
  * Check if reminders are disabled in settings.yaml.
  * Returns true if workflow.reminders is explicitly false.
  */
-function areRemindersDisabled(): boolean {
-	const repoRoot = resolveRepoRoot(process.cwd());
+function areRemindersDisabled(repoRoot: string): boolean {
 	const settingsPath = path.join(repoRoot, SETTINGS_FILE);
 	if (!existsSync(settingsPath)) {
 		return false; // Default to enabled if no settings file
@@ -30,8 +29,8 @@ function areRemindersDisabled(): boolean {
 /**
  * Check if the project is initialized (has .tff-cc directory).
  */
-function isProjectInitialized(): boolean {
-	const tffDir = path.join(resolveRepoRoot(process.cwd()), TFF_CC_DIR);
+function isProjectInitialized(repoRoot: string): boolean {
+	const tffDir = path.join(repoRoot, TFF_CC_DIR);
 	return existsSync(tffDir);
 }
 
@@ -60,8 +59,10 @@ export const sessionRemindCmd = async (args: string[]): Promise<string> => {
 		});
 	}
 
+	const repoRoot = resolveRepoRoot(process.cwd());
+
 	// Fast path: check if reminders are disabled
-	if (areRemindersDisabled()) {
+	if (areRemindersDisabled(repoRoot)) {
 		return JSON.stringify({
 			ok: true,
 			data: { reminder: null },
@@ -69,7 +70,7 @@ export const sessionRemindCmd = async (args: string[]): Promise<string> => {
 	}
 
 	// Check if project is initialized
-	if (!isProjectInitialized()) {
+	if (!isProjectInitialized(repoRoot)) {
 		return JSON.stringify({
 			ok: true,
 			data: { reminder: null },

--- a/src/cli/commands/session-remind.cmd.ts
+++ b/src/cli/commands/session-remind.cmd.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { generateReminder } from "../../application/session/generate-reminder.js";
 import { loadProjectSettings } from "../../domain/value-objects/project-settings.js";
 import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
 import { SETTINGS_FILE, TFF_CC_DIR } from "../../shared/paths.js";
 import type { CommandSchema } from "../utils/flag-parser.js";
 
@@ -11,7 +12,8 @@ import type { CommandSchema } from "../utils/flag-parser.js";
  * Returns true if workflow.reminders is explicitly false.
  */
 function areRemindersDisabled(): boolean {
-	const settingsPath = path.join(process.cwd(), SETTINGS_FILE);
+	const repoRoot = resolveRepoRoot(process.cwd());
+	const settingsPath = path.join(repoRoot, SETTINGS_FILE);
 	if (!existsSync(settingsPath)) {
 		return false; // Default to enabled if no settings file
 	}
@@ -29,7 +31,7 @@ function areRemindersDisabled(): boolean {
  * Check if the project is initialized (has .tff-cc directory).
  */
 function isProjectInitialized(): boolean {
-	const tffDir = path.join(process.cwd(), TFF_CC_DIR);
+	const tffDir = path.join(resolveRepoRoot(process.cwd()), TFF_CC_DIR);
 	return existsSync(tffDir);
 }
 

--- a/src/cli/commands/version.cmd.ts
+++ b/src/cli/commands/version.cmd.ts
@@ -2,6 +2,7 @@
 import { join } from "node:path";
 import { readRecoveryMarker } from "../../application/recovery/recovery-marker.js";
 import { openDatabaseWithTrace } from "../../infrastructure/adapters/sqlite/open-database.js";
+import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 
 export const versionSchema: CommandSchema = {
@@ -62,7 +63,7 @@ export const versionCmd = async (args: string[]): Promise<string> => {
 		binding = null;
 	}
 
-	const home = join(process.cwd(), ".tff-cc");
+	const home = join(resolveRepoRoot(process.cwd()), ".tff-cc");
 	const marker = await readRecoveryMarker(home);
 	const lastRecovery: LastRecovery = marker
 		? {

--- a/src/cli/commands/worktree-create.cmd.ts
+++ b/src/cli/commands/worktree-create.cmd.ts
@@ -5,6 +5,7 @@ import { createClosableStateStoresUnchecked } from "../../infrastructure/adapter
 import {
 	createTffCcSymlink,
 	getProjectId,
+	resolveRepoRoot,
 	writeProjectIdFile,
 } from "../../infrastructure/home-directory.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
@@ -40,6 +41,7 @@ export const worktreeCreateCmd = async (args: string[]): Promise<string> => {
 
 	const cwd = process.cwd();
 	const gitOps = new GitCliAdapter(cwd);
+	const repoRoot = resolveRepoRoot(cwd);
 
 	const closableStores = createClosableStateStoresUnchecked();
 	const { sliceStore, milestoneStore } = closableStores;
@@ -76,7 +78,7 @@ export const worktreeCreateCmd = async (args: string[]): Promise<string> => {
 			{ gitOps },
 		);
 		if (isOk(result)) {
-			const projectId = getProjectId(cwd);
+			const projectId = getProjectId(repoRoot);
 			const worktreePath = result.data.worktreePath;
 			createTffCcSymlink(worktreePath, projectId);
 			// Persist the project id in the new worktree so subsequent tff-tools commands

--- a/src/cli/utils/with-mutating-command.ts
+++ b/src/cli/utils/with-mutating-command.ts
@@ -8,6 +8,7 @@ import {
 	type ClosableStateStores,
 	createClosableStateStoresUnchecked,
 } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
 
 export const WITH_MUTATING_COMMAND_TAG = Symbol("with-mutating-command");
 
@@ -77,7 +78,7 @@ export const withMutatingCommand = (handler: Handler, deps?: WrapperDeps): Tagge
 		// Fire on attempt (after guards pass), not on handler success — the sentinel
 		// means "a mutating command reached the handler," which is what the first-
 		// observation probe needs.
-		touchMutatingSentinel(process.cwd());
+		touchMutatingSentinel(resolveRepoRoot(process.cwd()));
 		return handler(args);
 	};
 

--- a/src/infrastructure/adapters/sqlite/create-state-stores.ts
+++ b/src/infrastructure/adapters/sqlite/create-state-stores.ts
@@ -11,7 +11,13 @@ import type { SliceDependencyStore } from "../../../domain/ports/slice-dependenc
 import type { SliceStore } from "../../../domain/ports/slice-store.port.js";
 import type { TaskStore } from "../../../domain/ports/task-store.port.js";
 import type { TransactionRunner } from "../../../domain/ports/transaction-runner.port.js";
-import { createTffCcSymlink, getProjectHome, getProjectId } from "../../home-directory.js";
+import {
+	createTffCcSymlink,
+	getProjectHome,
+	getProjectId,
+	resolveRepoRoot,
+	warnOnStrayTffFiles,
+} from "../../home-directory.js";
 import { JsonlJournalAdapter } from "../journal/jsonl-journal.adapter.js";
 import { SQLiteStateAdapter } from "./sqlite-state.adapter.js";
 
@@ -30,7 +36,9 @@ export interface StateStores {
 }
 
 function getDerivedPaths(): { dbPath: string; journalPath: string; projectId: string } {
-	const repoRoot = process.cwd();
+	const cwd = process.cwd();
+	const repoRoot = resolveRepoRoot(cwd);
+	warnOnStrayTffFiles(cwd, repoRoot);
 	const projectId = getProjectId(repoRoot);
 	const home = getProjectHome(projectId);
 

--- a/src/infrastructure/adapters/sqlite/create-state-stores.ts
+++ b/src/infrastructure/adapters/sqlite/create-state-stores.ts
@@ -60,9 +60,7 @@ export function createStateStoresUnchecked(dbPath?: string): StateStores {
 		? { dbPath, journalPath: path.join(path.dirname(dbPath), "journal") }
 		: getDerivedPaths();
 
-	const adapter = dbPath
-		? SQLiteStateAdapter.createWithPath(resolvedPath)
-		: SQLiteStateAdapter.create();
+	const adapter = SQLiteStateAdapter.createWithPath(resolvedPath);
 	const initResult = adapter.init();
 	if (!initResult.ok) throw new Error(`DB init failed: ${initResult.error.message}`);
 	const journalRepository = new JsonlJournalAdapter(journalPath);
@@ -99,9 +97,7 @@ export function createClosableStateStoresUnchecked(dbPath?: string): ClosableSta
 		? { dbPath, journalPath: path.join(path.dirname(dbPath), "journal") }
 		: getDerivedPaths();
 
-	const adapter = dbPath
-		? SQLiteStateAdapter.createWithPath(resolvedPath)
-		: SQLiteStateAdapter.create();
+	const adapter = SQLiteStateAdapter.createWithPath(resolvedPath);
 	const initResult = adapter.init();
 	if (!initResult.ok) throw new Error(`DB init failed: ${initResult.error.message}`);
 	const journalRepository = new JsonlJournalAdapter(journalPath);

--- a/src/infrastructure/home-directory.ts
+++ b/src/infrastructure/home-directory.ts
@@ -72,6 +72,36 @@ export function resolveRepoRoot(cwd?: string): string {
 	}
 }
 
+let warnedStrayThisProcess = false;
+
+/**
+ * Emit a one-time stderr warning if the launch cwd holds a stray
+ * `.tff-project-id` or `.tff-cc` that isn't at the git toplevel.
+ * No-op when cwd === repoRoot, when no stray files exist, or after the
+ * first call in the current process.
+ */
+export function warnOnStrayTffFiles(cwd: string, repoRoot: string): void {
+	if (warnedStrayThisProcess) return;
+	if (cwd === repoRoot) return;
+	try {
+		const strayId = existsSync(join(cwd, ".tff-project-id"));
+		let straySym = false;
+		try {
+			lstatSync(join(cwd, TFF_CC_DIR));
+			straySym = true;
+		} catch {
+			// Entry does not exist — expected path.
+		}
+		if (!strayId && !straySym) return;
+		warnedStrayThisProcess = true;
+		process.stderr.write(
+			`tff-cc: stray .tff-project-id at ${cwd} — only the one at ${repoRoot} is used. Safe to delete.\n`,
+		);
+	} catch {
+		// Never fail startup on a warning path.
+	}
+}
+
 /** Validate that a string is a valid UUID v4 format. */
 function isValidUuidV4(id: string): boolean {
 	return UUID_V4_REGEX.test(id);

--- a/src/infrastructure/home-directory.ts
+++ b/src/infrastructure/home-directory.ts
@@ -86,6 +86,9 @@ export function warnOnStrayTffFiles(cwd: string, repoRoot: string): void {
 	try {
 		const strayId = existsSync(join(cwd, ".tff-project-id"));
 		let straySym = false;
+		// Use lstatSync rather than existsSync: a dangling .tff-cc symlink
+		// (broken target) is exactly the stray state we want to warn about,
+		// and existsSync follows the link so it would miss that case.
 		try {
 			lstatSync(join(cwd, TFF_CC_DIR));
 			straySym = true;
@@ -94,8 +97,11 @@ export function warnOnStrayTffFiles(cwd: string, repoRoot: string): void {
 		}
 		if (!strayId && !straySym) return;
 		warnedStrayThisProcess = true;
+		const names = [strayId ? ".tff-project-id" : null, straySym ? ".tff-cc" : null]
+			.filter((n): n is string => n !== null)
+			.join(" and ");
 		process.stderr.write(
-			`tff-cc: stray .tff-project-id at ${cwd} — only the one at ${repoRoot} is used. Safe to delete.\n`,
+			`tff-cc: stray ${names} at ${cwd} — only the one(s) at ${repoRoot} are used. Safe to delete.\n`,
 		);
 	} catch {
 		// Never fail startup on a warning path.

--- a/src/infrastructure/home-directory.ts
+++ b/src/infrastructure/home-directory.ts
@@ -47,6 +47,31 @@ function findPrimaryWorktreeRoot(repoRoot: string): string | null {
 	}
 }
 
+/**
+ * Resolve the git working-tree toplevel for `cwd`.
+ * Returns `cwd ?? process.cwd()` when:
+ *  - not inside a git repo
+ *  - `git` isn't installed / on PATH
+ *  - the repo is bare
+ *
+ * This is the single source of truth for where tff-cc state files
+ * (`.tff-project-id`, `.tff-cc` symlink) live relative to the working tree,
+ * so launching tff-cc from any sub-directory of a repo always finds the
+ * same toplevel.
+ */
+export function resolveRepoRoot(cwd?: string): string {
+	const start = cwd ?? process.cwd();
+	try {
+		const top = execFileSync("git", ["-C", start, "rev-parse", "--show-toplevel"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+		return top || start;
+	} catch {
+		return start;
+	}
+}
+
 /** Validate that a string is a valid UUID v4 format. */
 function isValidUuidV4(id: string): boolean {
 	return UUID_V4_REGEX.test(id);

--- a/tests/integration/cli/project-init-subdir.integration.spec.ts
+++ b/tests/integration/cli/project-init-subdir.integration.spec.ts
@@ -45,15 +45,11 @@ describe("project:init from a sub-directory", () => {
 
 	it("writes .tff-project-id at the repo toplevel when launched from a sub-directory", () => {
 		const cliEntry = join(process.cwd(), "dist", "cli", "index.js");
-		execFileSync(
-			process.execPath,
-			[cliEntry, "project:init", "--name", "subdir-test"],
-			{
-				cwd: subDir,
-				env: { ...process.env, TFF_CC_HOME: join(tempDir, "tff-home") },
-				encoding: "utf-8",
-			},
-		);
+		execFileSync(process.execPath, [cliEntry, "project:init", "--name", "subdir-test"], {
+			cwd: subDir,
+			env: { ...process.env, TFF_CC_HOME: join(tempDir, "tff-home") },
+			encoding: "utf-8",
+		});
 
 		// .tff-project-id must be at the repo root, not in the sub-directory
 		expect(existsSync(join(repoRoot, ".tff-project-id"))).toBe(true);

--- a/tests/integration/cli/project-init-subdir.integration.spec.ts
+++ b/tests/integration/cli/project-init-subdir.integration.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration test: project:init from a sub-directory
+ *
+ * Verifies that running `tff-cc project:init` from a sub-directory of a git
+ * repo writes `.tff-project-id` and creates the `.tff-cc` symlink at the repo
+ * TOPLEVEL — not in the sub-directory where the CLI was invoked.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("project:init from a sub-directory", () => {
+	let tempDir: string;
+	let repoRoot: string;
+	let subDir: string;
+
+	beforeEach(() => {
+		const created = join(
+			tmpdir(),
+			`tff-subdir-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+		);
+		mkdirSync(created, { recursive: true });
+		// Resolve realpath for macOS /private/var normalization
+		tempDir = realpathSync(created);
+		repoRoot = join(tempDir, "repo");
+		subDir = join(repoRoot, "apps", "api");
+		mkdirSync(subDir, { recursive: true });
+
+		execFileSync("git", ["init", repoRoot]);
+		execFileSync("git", ["-C", repoRoot, "config", "user.email", "test@test.com"]);
+		execFileSync("git", ["-C", repoRoot, "config", "user.name", "Test"]);
+		// Create an initial commit so git rev-parse --show-toplevel is reliable
+		execFileSync("git", ["-C", repoRoot, "commit", "--allow-empty", "-m", "init"]);
+		// project:init is wrapped with withMutatingCommand which refuses to run on the default
+		// branch. Check out a feature branch so the guard passes.
+		execFileSync("git", ["-C", repoRoot, "checkout", "-b", "feat/subdir-test"]);
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("writes .tff-project-id at the repo toplevel when launched from a sub-directory", () => {
+		const cliEntry = join(process.cwd(), "dist", "cli", "index.js");
+		execFileSync(
+			process.execPath,
+			[cliEntry, "project:init", "--name", "subdir-test"],
+			{
+				cwd: subDir,
+				env: { ...process.env, TFF_CC_HOME: join(tempDir, "tff-home") },
+				encoding: "utf-8",
+			},
+		);
+
+		// .tff-project-id must be at the repo root, not in the sub-directory
+		expect(existsSync(join(repoRoot, ".tff-project-id"))).toBe(true);
+		expect(existsSync(join(subDir, ".tff-project-id"))).toBe(false);
+
+		// .tff-cc symlink must be at the repo root, not in the sub-directory
+		expect(existsSync(join(repoRoot, ".tff-cc"))).toBe(true);
+		expect(existsSync(join(subDir, ".tff-cc"))).toBe(false);
+	});
+});

--- a/tests/unit/infrastructure/home-directory.spec.ts
+++ b/tests/unit/infrastructure/home-directory.spec.ts
@@ -13,7 +13,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("T14: Home directory resolver module", () => {
 	let tempDir: string;
@@ -161,6 +161,80 @@ describe("T14: Home directory resolver module", () => {
 
 			const { resolveRepoRoot } = await import("../../../src/infrastructure/home-directory.js");
 			expect(resolveRepoRoot(plainDir)).toBe(plainDir);
+		});
+	});
+
+	describe("warnOnStrayTffFiles", () => {
+		let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+		beforeEach(() => {
+			stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+			// Reset the module-level guard so each test starts fresh
+			vi.resetModules();
+		});
+
+		afterEach(() => {
+			stderrSpy.mockRestore();
+		});
+
+		it("is a no-op when cwd === repoRoot", async () => {
+			const dir = join(tempDir, "stray-noop-same");
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(join(dir, ".tff-project-id"), "a1b2c3d4-e5f6-4000-8000-111111111111\n");
+
+			const { warnOnStrayTffFiles } = await import(
+				"../../../src/infrastructure/home-directory.js"
+			);
+			warnOnStrayTffFiles(dir, dir);
+
+			expect(stderrSpy).not.toHaveBeenCalled();
+		});
+
+		it("is a no-op when no stray files exist", async () => {
+			const repoRoot = join(tempDir, "stray-noop-repo");
+			const subDir = join(repoRoot, "apps", "api");
+			mkdirSync(subDir, { recursive: true });
+
+			const { warnOnStrayTffFiles } = await import(
+				"../../../src/infrastructure/home-directory.js"
+			);
+			warnOnStrayTffFiles(subDir, repoRoot);
+
+			expect(stderrSpy).not.toHaveBeenCalled();
+		});
+
+		it("emits exactly one stderr line when a stray .tff-project-id exists below the root", async () => {
+			const repoRoot = join(tempDir, "stray-hit-repo");
+			const subDir = join(repoRoot, "apps", "api");
+			mkdirSync(subDir, { recursive: true });
+			writeFileSync(join(subDir, ".tff-project-id"), "a1b2c3d4-e5f6-4000-8000-222222222222\n");
+
+			const { warnOnStrayTffFiles } = await import(
+				"../../../src/infrastructure/home-directory.js"
+			);
+			warnOnStrayTffFiles(subDir, repoRoot);
+			warnOnStrayTffFiles(subDir, repoRoot); // second call must stay silent
+
+			expect(stderrSpy).toHaveBeenCalledTimes(1);
+			const line = stderrSpy.mock.calls[0][0] as string;
+			expect(line).toContain("stray");
+			expect(line).toContain(subDir);
+			expect(line).toContain(repoRoot);
+		});
+
+		it("also warns when only .tff-cc exists (no .tff-project-id)", async () => {
+			const repoRoot = join(tempDir, "stray-symlink-repo");
+			const subDir = join(repoRoot, "apps", "web");
+			mkdirSync(subDir, { recursive: true });
+			const { symlinkSync } = await import("node:fs");
+			symlinkSync(join(tempDir, "some-target"), join(subDir, ".tff-cc"));
+
+			const { warnOnStrayTffFiles } = await import(
+				"../../../src/infrastructure/home-directory.js"
+			);
+			warnOnStrayTffFiles(subDir, repoRoot);
+
+			expect(stderrSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/tests/unit/infrastructure/home-directory.spec.ts
+++ b/tests/unit/infrastructure/home-directory.spec.ts
@@ -182,9 +182,7 @@ describe("T14: Home directory resolver module", () => {
 			mkdirSync(dir, { recursive: true });
 			writeFileSync(join(dir, ".tff-project-id"), "a1b2c3d4-e5f6-4000-8000-111111111111\n");
 
-			const { warnOnStrayTffFiles } = await import(
-				"../../../src/infrastructure/home-directory.js"
-			);
+			const { warnOnStrayTffFiles } = await import("../../../src/infrastructure/home-directory.js");
 			warnOnStrayTffFiles(dir, dir);
 
 			expect(stderrSpy).not.toHaveBeenCalled();
@@ -195,9 +193,7 @@ describe("T14: Home directory resolver module", () => {
 			const subDir = join(repoRoot, "apps", "api");
 			mkdirSync(subDir, { recursive: true });
 
-			const { warnOnStrayTffFiles } = await import(
-				"../../../src/infrastructure/home-directory.js"
-			);
+			const { warnOnStrayTffFiles } = await import("../../../src/infrastructure/home-directory.js");
 			warnOnStrayTffFiles(subDir, repoRoot);
 
 			expect(stderrSpy).not.toHaveBeenCalled();
@@ -209,9 +205,7 @@ describe("T14: Home directory resolver module", () => {
 			mkdirSync(subDir, { recursive: true });
 			writeFileSync(join(subDir, ".tff-project-id"), "a1b2c3d4-e5f6-4000-8000-222222222222\n");
 
-			const { warnOnStrayTffFiles } = await import(
-				"../../../src/infrastructure/home-directory.js"
-			);
+			const { warnOnStrayTffFiles } = await import("../../../src/infrastructure/home-directory.js");
 			warnOnStrayTffFiles(subDir, repoRoot);
 			warnOnStrayTffFiles(subDir, repoRoot); // second call must stay silent
 
@@ -229,12 +223,12 @@ describe("T14: Home directory resolver module", () => {
 			const { symlinkSync } = await import("node:fs");
 			symlinkSync(join(tempDir, "some-target"), join(subDir, ".tff-cc"));
 
-			const { warnOnStrayTffFiles } = await import(
-				"../../../src/infrastructure/home-directory.js"
-			);
+			const { warnOnStrayTffFiles } = await import("../../../src/infrastructure/home-directory.js");
 			warnOnStrayTffFiles(subDir, repoRoot);
 
 			expect(stderrSpy).toHaveBeenCalledTimes(1);
+			const line = stderrSpy.mock.calls[0][0] as string;
+			expect(line).toContain(".tff-cc");
 		});
 	});
 

--- a/tests/unit/infrastructure/home-directory.spec.ts
+++ b/tests/unit/infrastructure/home-directory.spec.ts
@@ -133,6 +133,37 @@ describe("T14: Home directory resolver module", () => {
 		});
 	});
 
+	describe("resolveRepoRoot", () => {
+		it("returns the git toplevel when called from the repo root", async () => {
+			const repoDir = join(tempDir, "repo-root");
+			mkdirSync(repoDir, { recursive: true });
+			execFileSync("git", ["init", repoDir]);
+
+			const { resolveRepoRoot } = await import("../../../src/infrastructure/home-directory.js");
+			const expected = (await import("node:fs")).realpathSync(repoDir);
+			expect(resolveRepoRoot(repoDir)).toBe(expected);
+		});
+
+		it("returns the git toplevel when called from a sub-directory", async () => {
+			const repoDir = join(tempDir, "repo-subdir");
+			const subDir = join(repoDir, "apps", "api");
+			mkdirSync(subDir, { recursive: true });
+			execFileSync("git", ["init", repoDir]);
+
+			const { resolveRepoRoot } = await import("../../../src/infrastructure/home-directory.js");
+			const expected = (await import("node:fs")).realpathSync(repoDir);
+			expect(resolveRepoRoot(subDir)).toBe(expected);
+		});
+
+		it("falls back to the input cwd when not in a git repo", async () => {
+			const plainDir = join(tempDir, "not-a-git-repo-resolve");
+			mkdirSync(plainDir, { recursive: true });
+
+			const { resolveRepoRoot } = await import("../../../src/infrastructure/home-directory.js");
+			expect(resolveRepoRoot(plainDir)).toBe(plainDir);
+		});
+	});
+
 	describe("ensureProjectHomeDir", () => {
 		it("should create directory structure under TFF_CC_HOME", async () => {
 			process.env.TFF_CC_HOME = tempDir;


### PR DESCRIPTION
## Summary

- Launching `tff-cc` from any sub-directory of a git repo now reuses the root-level `.tff-project-id` / `.tff-cc` instead of creating duplicates.
- New `resolveRepoRoot(cwd?)` helper wraps `git rev-parse --show-toplevel` with a safe cwd fallback (not-a-repo, git missing, bare repo).
- New one-per-process stderr warning when stray `.tff-project-id` or `.tff-cc` files are detected below the git root — advisory only, never auto-deletes.
- Routed every tff-cc-state call site through the resolver: state-store derivation, `project:init`, `worktree:create`, `version`, three guard commands (pre-op, direct-edit, session-remind), and the mutating-command sentinel.
- Plugged a latent bug in `SQLiteStateAdapter.create()` which was re-deriving the project id from raw `process.cwd()`; state-store factories now always route through the resolved path.
- Worktree identity logic is untouched — each worktree keeps its own toplevel identity.

## Test plan

- [x] New unit tests for `resolveRepoRoot` (in-repo, subdir, not-a-repo) and `warnOnStrayTffFiles` (no-op branches, one-per-process, dangling `.tff-cc` symlink)
- [x] New integration test spawning the real CLI from a two-level-deep sub-directory and asserting toplevel-only placement
- [x] Full suite: 1692/1694 pass, 0 fail (2 pre-existing pending)
- [x] `tsc --noEmit` clean
- [x] Manual monorepo smoke: `.tff-project-id` + `.tff-cc` land only at the repo toplevel; stray warning fires with "… stray .tff-project-id at <subdir> — only the one(s) at <root> are used. Safe to delete."

## Design / plan

- Spec: `docs/superpowers/specs/2026-04-23-tff-project-id-at-git-root-design.md` (gitignored, local)
- Plan: `docs/superpowers/plans/2026-04-23-tff-project-id-at-git-root.md` (gitignored, local)