### PR TITLE
fix(recovery): bound the startup walker to stop OOM on cyclic .tff-cc symlinks

### DIFF
--- a/src/application/recovery/recover-orphans.ts
+++ b/src/application/recovery/recover-orphans.ts
@@ -62,7 +62,7 @@ function sweepStaleTmps(root: string, nowMs: number, thresholdMs: number): numbe
 	const stack: string[] = [root];
 
 	while (stack.length > 0) {
-		if (visited.size > MAX_DIRS_VISITED) break;
+		if (visited.size >= MAX_DIRS_VISITED) break;
 		const current = stack.pop();
 		if (current === undefined) break;
 

--- a/src/application/recovery/recover-orphans.ts
+++ b/src/application/recovery/recover-orphans.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 export interface RecoverInput {
@@ -14,6 +14,10 @@ export interface RecoverResult {
 }
 
 const DEFAULT_THRESHOLD_MS = 5 * 60 * 1000;
+// Defensive ceiling — even without cycles, a runaway tree shouldn't consume
+// unbounded memory during startup recovery. 100k dirs is far beyond any real
+// project home and well below Node's default heap.
+const MAX_DIRS_VISITED = 100_000;
 
 export const recoverOrphans = async (input: RecoverInput): Promise<RecoverResult> => {
 	const nowMs = (input.now ?? Date.now)();
@@ -23,25 +27,7 @@ export const recoverOrphans = async (input: RecoverInput): Promise<RecoverResult
 
 	for (const dir of input.stagingDirs) {
 		if (!existsSync(dir)) continue;
-		// `{ recursive: true }` was backported to Node 18.17 and is stable on 20.x.
-		// Our engines.node floor (>=20) covers it; keep the floor intentional.
-		for (const entry of readdirSync(dir, { recursive: true }) as string[]) {
-			if (!entry.endsWith(".tmp")) continue;
-			const p = join(dir, entry);
-			try {
-				// Use lstat so we never follow symlinks out of the staging tree.
-				// Skip anything that isn't a plain file — symlinks, dirs, sockets,
-				// etc. are never considered orphan tmps for sweeping.
-				const st = lstatSync(p);
-				if (!st.isFile()) continue;
-				if (nowMs - st.mtimeMs > threshold) {
-					rmSync(p, { force: true });
-					cleanedTmps++;
-				}
-			} catch {
-				// skip unreadable entries
-			}
-		}
+		cleanedTmps += sweepStaleTmps(dir, nowMs, threshold);
 	}
 
 	for (const p of input.lockPaths) {
@@ -63,3 +49,66 @@ export const recoverOrphans = async (input: RecoverInput): Promise<RecoverResult
 
 	return { cleanedTmps, cleanedLocks };
 };
+
+function sweepStaleTmps(root: string, nowMs: number, thresholdMs: number): number {
+	let cleaned = 0;
+	const visited = new Set<string>();
+	try {
+		visited.add(realpathSync(root));
+	} catch {
+		return 0;
+	}
+
+	const stack: string[] = [root];
+
+	while (stack.length > 0) {
+		if (visited.size > MAX_DIRS_VISITED) break;
+		const current = stack.pop();
+		if (current === undefined) break;
+
+		let entries: import("node:fs").Dirent[];
+		try {
+			entries = readdirSync(current, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			const p = join(current, entry.name);
+
+			if (entry.isSymbolicLink()) {
+				// Never descend into symlinked entries. This is the cycle break.
+				continue;
+			}
+
+			if (entry.isDirectory()) {
+				let real: string;
+				try {
+					real = realpathSync(p);
+				} catch {
+					continue;
+				}
+				if (visited.has(real)) continue;
+				visited.add(real);
+				stack.push(p);
+				continue;
+			}
+
+			if (!entry.isFile()) continue;
+			if (!entry.name.endsWith(".tmp")) continue;
+
+			try {
+				const st = lstatSync(p);
+				if (!st.isFile()) continue;
+				if (nowMs - st.mtimeMs > thresholdMs) {
+					rmSync(p, { force: true });
+					cleaned++;
+				}
+			} catch {
+				// skip unreadable entries
+			}
+		}
+	}
+
+	return cleaned;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -410,7 +410,10 @@ function resolveStartupHomeDir(): string {
 		const repoRoot = resolveRepoRoot(cwd);
 		const projectId = getProjectId(repoRoot);
 		return getProjectHome(projectId);
-	} catch {
+	} catch (err) {
+		process.stderr.write(
+			`tff-cc: could not resolve project home, falling back to cwd/.tff-cc — ${String(err)}\n`,
+		);
 		return join(cwd, ".tff-cc");
 	}
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { handleStartupRecovery } from "../application/recovery/handle-startup-recovery.js";
 import { NativeBindingError } from "../infrastructure/adapters/sqlite/native-binding-error.js";
+import { getProjectHome, getProjectId, resolveRepoRoot } from "../infrastructure/home-directory.js";
 import { branchGuardCheckCmd, branchGuardCheckSchema } from "./commands/branch-guard-check.cmd.js";
 import { checkpointLoadCmd, checkpointLoadSchema } from "./commands/checkpoint-load.cmd.js";
 import { checkpointSaveCmd, checkpointSaveSchema } from "./commands/checkpoint-save.cmd.js";
@@ -391,10 +392,33 @@ function flagToJsonSchema(flag: {
 	return schema;
 }
 
+/**
+ * Resolve the directory that startup recovery should sweep.
+ *
+ * Preferred: the real project home (`~/.tff-cc/<projectId>/`), resolved via
+ * the project id persisted at the git toplevel. This avoids walking through
+ * the `cwd/.tff-cc` symlink, which — in multi-worktree setups — lives inside
+ * the same home directory and can create cyclic descents.
+ *
+ * Fallback: `cwd/.tff-cc` for repos that haven't run `project:init` yet.
+ * These are legitimately non-cyclic (they're either missing or a plain dir),
+ * so the legacy path remains safe.
+ */
+function resolveStartupHomeDir(): string {
+	const cwd = process.cwd();
+	try {
+		const repoRoot = resolveRepoRoot(cwd);
+		const projectId = getProjectId(repoRoot);
+		return getProjectHome(projectId);
+	} catch {
+		return join(cwd, ".tff-cc");
+	}
+}
+
 const main = async () => {
 	const [command, ...args] = process.argv.slice(2);
 
-	await handleStartupRecovery({ homeDir: join(process.cwd(), ".tff-cc") });
+	await handleStartupRecovery({ homeDir: resolveStartupHomeDir() });
 
 	if (!command || command === "--help" || command === "-h") {
 		console.log(

--- a/tests/integration/cli-recovery-marker-replay.integration.spec.ts
+++ b/tests/integration/cli-recovery-marker-replay.integration.spec.ts
@@ -6,17 +6,27 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 let repo: string;
+let home: string;
 const CLI = join(process.cwd(), "dist/cli/index.js");
+
+const projectId = "b2c3d4e5-f6a7-4890-bcde-f01234567890";
 
 beforeEach(() => {
 	repo = mkdtempSync(join(tmpdir(), "tff-replay-"));
+	home = mkdtempSync(join(tmpdir(), "tff-replay-home-"));
+
 	execFileSync("git", ["init", "-b", "feature/x"], { cwd: repo });
 	execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo });
 	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
 	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
-	mkdirSync(join(repo, ".tff-cc"), { recursive: true });
+
+	writeFileSync(join(repo, ".tff-project-id"), `${projectId}\n`);
+	mkdirSync(join(home, projectId), { recursive: true });
 });
-afterEach(() => rmSync(repo, { recursive: true, force: true }));
+afterEach(() => {
+	rmSync(repo, { recursive: true, force: true });
+	rmSync(home, { recursive: true, force: true });
+});
 
 describe("CLI replays warning when recovery marker is present", () => {
 	it("prints warning to stderr on any subsequent invocation", () => {
@@ -28,10 +38,11 @@ describe("CLI replays warning when recovery marker is present", () => {
 			platform: process.platform,
 			arch: process.arch,
 		};
-		writeFileSync(join(repo, ".tff-cc", ".recovery-marker"), JSON.stringify(marker));
+		writeFileSync(join(home, projectId, ".recovery-marker"), JSON.stringify(marker));
 
 		const result = spawnSync("node", [CLI, "schema", "--command", "slice:list"], {
 			cwd: repo,
+			env: { ...process.env, TFF_CC_HOME: home },
 			timeout: 30_000,
 			encoding: "utf-8",
 		});

--- a/tests/integration/cli-startup-orphan-recovery.integration.spec.ts
+++ b/tests/integration/cli-startup-orphan-recovery.integration.spec.ts
@@ -5,21 +5,32 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 let repo: string;
+let home: string;
 const CLI = join(process.cwd(), "dist/cli/index.js");
+
+const projectId = "a1b2c3d4-e5f6-4890-abcd-ef1234567890";
 
 beforeEach(() => {
 	repo = mkdtempSync(join(tmpdir(), "tff-orphan-"));
+	home = mkdtempSync(join(tmpdir(), "tff-orphan-home-"));
+
 	execFileSync("git", ["init", "-b", "feature/x"], { cwd: repo });
 	execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo });
 	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
 	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
-	mkdirSync(join(repo, ".tff-cc"), { recursive: true });
+
+	writeFileSync(join(repo, ".tff-project-id"), `${projectId}\n`);
+
+	mkdirSync(join(home, projectId, "milestones"), { recursive: true });
 });
-afterEach(() => rmSync(repo, { recursive: true, force: true }));
+afterEach(() => {
+	rmSync(repo, { recursive: true, force: true });
+	rmSync(home, { recursive: true, force: true });
+});
 
 describe("CLI startup runs orphan recovery", () => {
 	it("cleans up stale *.tmp files in .tff-cc before dispatching", () => {
-		const stale = join(repo, ".tff-cc", "STATE.md.tmp");
+		const stale = join(home, projectId, "STATE.md.tmp");
 		writeFileSync(stale, "stale");
 		const old = Math.floor(Date.now() / 1000) - 600;
 		utimesSync(stale, old, old);
@@ -27,6 +38,7 @@ describe("CLI startup runs orphan recovery", () => {
 		// Run a read-only CLI command; recovery should still sweep first.
 		execFileSync("node", [CLI, "schema", "--command", "slice:list"], {
 			cwd: repo,
+			env: { ...process.env, TFF_CC_HOME: home },
 			timeout: 30_000,
 			stdio: ["pipe", "pipe", "pipe"],
 		});
@@ -35,7 +47,7 @@ describe("CLI startup runs orphan recovery", () => {
 	});
 
 	it("cleans up stale *.tmp files in .tff-cc subdirectories before dispatching", () => {
-		const subDir = join(repo, ".tff-cc", "milestones", "M01", "slices", "M01-S01");
+		const subDir = join(home, projectId, "milestones", "M01", "slices", "M01-S01");
 		mkdirSync(subDir, { recursive: true });
 		const stale = join(subDir, "PLAN.md.tmp");
 		writeFileSync(stale, "stale");
@@ -44,6 +56,7 @@ describe("CLI startup runs orphan recovery", () => {
 
 		execFileSync("node", [CLI, "schema", "--command", "slice:list"], {
 			cwd: repo,
+			env: { ...process.env, TFF_CC_HOME: home },
 			timeout: 30_000,
 			stdio: ["pipe", "pipe", "pipe"],
 		});
@@ -52,10 +65,11 @@ describe("CLI startup runs orphan recovery", () => {
 	});
 
 	it("preserves fresh *.tmp files", () => {
-		const fresh = join(repo, ".tff-cc", "STATE.md.tmp");
+		const fresh = join(home, projectId, "STATE.md.tmp");
 		writeFileSync(fresh, "fresh");
 		execFileSync("node", [CLI, "schema", "--command", "slice:list"], {
 			cwd: repo,
+			env: { ...process.env, TFF_CC_HOME: home },
 			timeout: 30_000,
 			stdio: ["pipe", "pipe", "pipe"],
 		});

--- a/tests/integration/cli-startup-recovery-cycle.integration.spec.ts
+++ b/tests/integration/cli-startup-recovery-cycle.integration.spec.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let repo: string;
+let home: string;
+const CLI = join(process.cwd(), "dist/cli/index.js");
+
+beforeEach(() => {
+	repo = mkdtempSync(join(tmpdir(), "tff-cycle-repo-"));
+	home = mkdtempSync(join(tmpdir(), "tff-cycle-home-"));
+
+	execFileSync("git", ["init", "-b", "main"], { cwd: repo });
+	execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo });
+	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
+	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
+
+	const projectId = "5580e1f9-2c81-423c-a041-5e8d4089e1fb";
+	writeFileSync(join(repo, ".tff-project-id"), `${projectId}\n`);
+
+	const projectHome = join(home, projectId);
+	mkdirSync(join(projectHome, "milestones"), { recursive: true });
+	mkdirSync(join(projectHome, "worktrees", "M01-S01"), { recursive: true });
+	symlinkSync(projectHome, join(projectHome, "worktrees", "M01-S01", ".tff-cc"));
+	symlinkSync(projectHome, join(repo, ".tff-cc"));
+
+	const stale = join(projectHome, "milestones", "STATE.md.tmp");
+	writeFileSync(stale, "stale");
+	const old = Math.floor(Date.now() / 1000) - 600;
+	utimesSync(stale, old, old);
+});
+afterEach(() => {
+	rmSync(repo, { recursive: true, force: true });
+	rmSync(home, { recursive: true, force: true });
+});
+
+describe("CLI startup against a cyclic project home", () => {
+	it("completes recovery in bounded time and sweeps the stale tmp", () => {
+		const start = Date.now();
+		execFileSync("node", [CLI, "schema", "--command", "slice:list"], {
+			cwd: repo,
+			env: { ...process.env, TFF_CC_HOME: home },
+			timeout: 10_000,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		const elapsed = Date.now() - start;
+		expect(elapsed).toBeLessThan(10_000);
+
+		const stale = join(home, "5580e1f9-2c81-423c-a041-5e8d4089e1fb", "milestones", "STATE.md.tmp");
+		expect(existsSync(stale)).toBe(false);
+	});
+});

--- a/tests/integration/cli-startup-recovery-cycle.integration.spec.ts
+++ b/tests/integration/cli-startup-recovery-cycle.integration.spec.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 let repo: string;
 let home: string;
 const CLI = join(process.cwd(), "dist/cli/index.js");
+const PROJECT_ID = "5580e1f9-2c81-423c-a041-5e8d4089e1fb";
 
 beforeEach(() => {
 	repo = mkdtempSync(join(tmpdir(), "tff-cycle-repo-"));
@@ -25,10 +26,9 @@ beforeEach(() => {
 	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
 	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
 
-	const projectId = "5580e1f9-2c81-423c-a041-5e8d4089e1fb";
-	writeFileSync(join(repo, ".tff-project-id"), `${projectId}\n`);
+	writeFileSync(join(repo, ".tff-project-id"), `${PROJECT_ID}\n`);
 
-	const projectHome = join(home, projectId);
+	const projectHome = join(home, PROJECT_ID);
 	mkdirSync(join(projectHome, "milestones"), { recursive: true });
 	mkdirSync(join(projectHome, "worktrees", "M01-S01"), { recursive: true });
 	symlinkSync(projectHome, join(projectHome, "worktrees", "M01-S01", ".tff-cc"));
@@ -56,7 +56,7 @@ describe("CLI startup against a cyclic project home", () => {
 		const elapsed = Date.now() - start;
 		expect(elapsed).toBeLessThan(10_000);
 
-		const stale = join(home, "5580e1f9-2c81-423c-a041-5e8d4089e1fb", "milestones", "STATE.md.tmp");
+		const stale = join(home, PROJECT_ID, "milestones", "STATE.md.tmp");
 		expect(existsSync(stale)).toBe(false);
 	});
 });

--- a/tests/unit/recovery/recover-orphans.walker.spec.ts
+++ b/tests/unit/recovery/recover-orphans.walker.spec.ts
@@ -1,0 +1,63 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { recoverOrphans } from "../../../src/application/recovery/recover-orphans.js";
+
+let home: string;
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpdir(), "tff-cycle-"));
+});
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+describe("recoverOrphans against a cyclic symlink tree", () => {
+	it("terminates and sweeps stale .tmp files when worktrees/<slice>/.tff-cc cycles back to home", async () => {
+		const worktree = join(home, "worktrees", "M01-S01");
+		mkdirSync(worktree, { recursive: true });
+		symlinkSync(home, join(worktree, ".tff-cc"));
+
+		const staleTmp = join(home, "milestones", "M01", "STATE.md.tmp");
+		mkdirSync(join(home, "milestones", "M01"), { recursive: true });
+		writeFileSync(staleTmp, "stale");
+		const old = Math.floor(Date.now() / 1000) - 600;
+		utimesSync(staleTmp, old, old);
+
+		const start = Date.now();
+		const result = await recoverOrphans({
+			stagingDirs: [home],
+			lockPaths: [],
+			now: () => Date.now(),
+		});
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeLessThan(2000);
+		expect(result.cleanedTmps).toBe(1);
+	});
+
+	it("does not descend through symlinked directories at all", async () => {
+		const staleTmp = join(home, "milestones", "STATE.md.tmp");
+		mkdirSync(join(home, "milestones"), { recursive: true });
+		writeFileSync(staleTmp, "stale");
+		const old = Math.floor(Date.now() / 1000) - 600;
+		utimesSync(staleTmp, old, old);
+
+		const worktree = join(home, "worktrees", "M01-S01");
+		mkdirSync(worktree, { recursive: true });
+		symlinkSync(home, join(worktree, ".tff-cc"));
+
+		const result = await recoverOrphans({
+			stagingDirs: [home],
+			lockPaths: [],
+			now: () => Date.now(),
+		});
+		expect(result.cleanedTmps).toBe(1);
+	});
+});

--- a/tests/unit/recovery/recover-orphans.walker.spec.ts
+++ b/tests/unit/recovery/recover-orphans.walker.spec.ts
@@ -1,11 +1,4 @@
-import {
-	mkdirSync,
-	mkdtempSync,
-	rmSync,
-	symlinkSync,
-	utimesSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";


### PR DESCRIPTION
## Summary

- Rewrites `recoverOrphans` with a stack-based DFS that never descends into symlinked entries and tracks visited realpaths (plus a `MAX_DIRS_VISITED=100_000` ceiling) — cycle cannot loop regardless of Node version or filesystem.
- Reroutes CLI startup recovery to walk the real project home (`getProjectHome(getProjectId(resolveRepoRoot(cwd)))`) instead of `cwd/.tff-cc`, so we don't rely on the symlink as the traversal root.
- Adds a unit test (cyclic walker) and an integration test (CLI end-to-end against a cyclic topology). Migrates two existing integration tests (`cli-startup-orphan-recovery`, `cli-recovery-marker-replay`) to the new resolver — fixed project id + `TFF_CC_HOME` sandbox.

## Root cause

`tff-tools` startup calls `handleStartupRecovery({ homeDir: join(cwd, ".tff-cc") })` → `readdirSync(dir, { recursive: true })`. When the project home contains `worktrees/<slice>/.tff-cc → <home>` (created by `worktree-create.cmd.ts`), the recursive readdir follows the symlink, producing duplicate paths up to the OS symlink-depth ceiling. On macOS/Node 22 it terminates at ~40 levels with silently-swallowed ENOENTs; on larger trees / other platforms, memory usage explodes → OOM.

## Out of scope (follow-ups)

- Drop the redundant `<worktree>/.tff-cc` symlink entirely (Variant 1). Requires routing 5 guard commands (`pre-op-guard`, `direct-edit-guard`, `session-remind`, `spec-edit-guard`, `detect-direct-edit`) through `getProjectHome`.
- `resolveStartupHomeDir` fallback branch (catch → `cwd/.tff-cc`) is not exercised by any test.
- `getProjectId` now runs at startup for every CLI invocation; in a fresh clone this writes `.tff-project-id` and creates project-home dirs before any command logic runs. Narrow regression on the "read-only inspection shouldn't write" surface.
- `expect(elapsed).toBeLessThan(10_000)` in the cycle integration test is tautological vs. `execFileSync` `timeout: 10_000` — consider tightening.

## Test plan

- [x] Walker unit tests (`recover-orphans.walker.spec.ts`): 2/2 pass in <200ms against cyclic symlink tree
- [x] End-to-end cycle test (`cli-startup-recovery-cycle.integration.spec.ts`): CLI completes under the 10s timeout, stale tmp swept
- [x] Existing recovery integration tests (`cli-startup-orphan-recovery`, `cli-recovery-marker-replay`) migrated to new resolver — 4/4 pass
- [x] Full suite: 1695 passed, 2 skipped (baseline)
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [x] Local smoke: `node dist/cli/index.js schema --command slice:list` returns in 128ms in a real worktree

Release-please will cut this as **0.9.12** via patch bump.