### PR TITLE
fix(routing): fall back to plugin root for commands and agents lookup

### DIFF
--- a/bin/tff-tools
+++ b/bin/tff-tools
@@ -18,6 +18,7 @@ while [ -L "$SOURCE" ]; do
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 PLUGIN_ROOT="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
+export TFF_PLUGIN_ROOT="$PLUGIN_ROOT"
 
 CLI="$PLUGIN_ROOT/dist/cli/index.js"
 if [ ! -f "$CLI" ]; then

--- a/src/cli/commands/routing-calibrate.cmd.ts
+++ b/src/cli/commands/routing-calibrate.cmd.ts
@@ -8,6 +8,7 @@ import { JsonlRoutingDecisionReader } from "../../infrastructure/adapters/jsonl/
 import { JsonlRoutingOutcomeReader } from "../../infrastructure/adapters/jsonl/routing-outcome-jsonl-reader.js";
 import { JsonlRoutingOutcomeWriter } from "../../infrastructure/adapters/jsonl/routing-outcome-jsonl-writer.js";
 import { renderCalibrationReport } from "../../infrastructure/adapters/markdown/calibration-report-renderer.js";
+import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { resolveRoutingPaths } from "../utils/routing-paths.js";
 
@@ -26,7 +27,8 @@ export const routingCalibrateCmd = async (args: string[]): Promise<string> => {
 	const { "n-min": nMinFlag } = parsed.data as { "n-min"?: number };
 
 	const projectRoot = process.cwd();
-	const configReader = new YamlRoutingConfigReader({ projectRoot });
+	const pluginRoot = resolvePluginRoot();
+	const configReader = new YamlRoutingConfigReader({ projectRoot, pluginRoot });
 	const configRes = await configReader.readConfig();
 	if (!isOk(configRes)) return JSON.stringify({ ok: false, error: configRes.error });
 

--- a/src/cli/commands/routing-decide.cmd.ts
+++ b/src/cli/commands/routing-decide.cmd.ts
@@ -1,10 +1,10 @@
-import { join } from "node:path";
 import { decideUseCase } from "../../application/routing/decide.js";
 import { isOk } from "../../domain/result.js";
 import { FilesystemSignalExtractor } from "../../infrastructure/adapters/filesystem/filesystem-signal-extractor.js";
 import { FilesystemTierConfigReader } from "../../infrastructure/adapters/filesystem/filesystem-tier-config-reader.js";
 import { YamlRoutingConfigReader } from "../../infrastructure/adapters/filesystem/yaml-routing-config-reader.js";
 import { JsonlRoutingDecisionLogger } from "../../infrastructure/adapters/jsonl/jsonl-routing-decision-logger.js";
+import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 
 export const routingDecideSchema: CommandSchema = {
@@ -54,7 +54,8 @@ export const routingDecideCmd = async (args: string[]): Promise<string> => {
 	};
 
 	const projectRoot = process.cwd();
-	const configReader = new YamlRoutingConfigReader({ projectRoot });
+	const pluginRoot = resolvePluginRoot();
+	const configReader = new YamlRoutingConfigReader({ projectRoot, pluginRoot });
 	const configRes = await configReader.readConfig();
 	if (!isOk(configRes)) {
 		process.stderr.write(`routing: config error — ${JSON.stringify(configRes.error)}\n`);
@@ -68,7 +69,7 @@ export const routingDecideCmd = async (args: string[]): Promise<string> => {
 	const extractor = new FilesystemSignalExtractor();
 	const tierConfigReader = new FilesystemTierConfigReader({
 		projectRoot,
-		agentsDir: join(projectRoot, "agents"),
+		pluginRoot,
 	});
 	const logger = new JsonlRoutingDecisionLogger(configRes.data.logging.path);
 

--- a/src/cli/commands/routing-event.cmd.ts
+++ b/src/cli/commands/routing-event.cmd.ts
@@ -2,6 +2,7 @@ import { isOk } from "../../domain/result.js";
 import { YamlRoutingConfigReader } from "../../infrastructure/adapters/filesystem/yaml-routing-config-reader.js";
 import { JsonlRoutingDecisionLogger } from "../../infrastructure/adapters/jsonl/jsonl-routing-decision-logger.js";
 import { JsonlRoutingDecisionReader } from "../../infrastructure/adapters/jsonl/jsonl-routing-decision-reader.js";
+import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { resolveRoutingPaths } from "../utils/routing-paths.js";
 
@@ -45,7 +46,8 @@ export const routingEventCmd = async (args: string[]): Promise<string> => {
 	};
 
 	const projectRoot = process.cwd();
-	const configReader = new YamlRoutingConfigReader({ projectRoot });
+	const pluginRoot = resolvePluginRoot();
+	const configReader = new YamlRoutingConfigReader({ projectRoot, pluginRoot });
 	const configRes = await configReader.readConfig();
 	if (!isOk(configRes)) {
 		return JSON.stringify({ ok: false, error: configRes.error });

--- a/src/cli/commands/routing-judge-prepare.cmd.ts
+++ b/src/cli/commands/routing-judge-prepare.cmd.ts
@@ -13,6 +13,7 @@ import { GitSliceMergeLookup } from "../../infrastructure/adapters/git/git-slice
 import { JsonlRoutingDecisionReader } from "../../infrastructure/adapters/jsonl/jsonl-routing-decision-reader.js";
 import { JsonlRoutingOutcomeReader } from "../../infrastructure/adapters/jsonl/routing-outcome-jsonl-reader.js";
 import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { resolveSliceId } from "../utils/resolve-id.js";
 import { resolveRoutingPaths } from "../utils/routing-paths.js";
@@ -59,8 +60,9 @@ export const routingJudgePrepareCmd = async (
 	};
 
 	const projectRoot = process.cwd();
+	const pluginRoot = resolvePluginRoot();
 
-	const configReader = new YamlRoutingConfigReader({ projectRoot });
+	const configReader = new YamlRoutingConfigReader({ projectRoot, pluginRoot });
 	const configRes = await configReader.readConfig();
 	if (!isOk(configRes)) return JSON.stringify({ ok: false, error: configRes.error });
 	if (!configRes.data.enabled) {

--- a/src/cli/commands/routing-judge-record.cmd.ts
+++ b/src/cli/commands/routing-judge-record.cmd.ts
@@ -8,6 +8,7 @@ import { JsonlRoutingDecisionReader } from "../../infrastructure/adapters/jsonl/
 import { JsonlRoutingOutcomeReader } from "../../infrastructure/adapters/jsonl/routing-outcome-jsonl-reader.js";
 import { JsonlRoutingOutcomeWriter } from "../../infrastructure/adapters/jsonl/routing-outcome-jsonl-writer.js";
 import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
+import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { resolveSliceId } from "../utils/resolve-id.js";
 import { resolveRoutingPaths } from "../utils/routing-paths.js";
@@ -56,8 +57,9 @@ export const routingJudgeRecordCmd = async (
 	};
 
 	const projectRoot = process.cwd();
+	const pluginRoot = resolvePluginRoot();
 
-	const configReader = new YamlRoutingConfigReader({ projectRoot });
+	const configReader = new YamlRoutingConfigReader({ projectRoot, pluginRoot });
 	const configRes = await configReader.readConfig();
 	if (!isOk(configRes)) return JSON.stringify({ ok: false, error: configRes.error });
 	if (!configRes.data.enabled) {

--- a/src/cli/commands/routing-outcome.cmd.ts
+++ b/src/cli/commands/routing-outcome.cmd.ts
@@ -8,6 +8,7 @@ import { isOk } from "../../domain/result.js";
 import { YamlRoutingConfigReader } from "../../infrastructure/adapters/filesystem/yaml-routing-config-reader.js";
 import { JsonlRoutingDecisionReader } from "../../infrastructure/adapters/jsonl/jsonl-routing-decision-reader.js";
 import { JsonlRoutingOutcomeWriter } from "../../infrastructure/adapters/jsonl/routing-outcome-jsonl-writer.js";
+import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 import { resolveRoutingPaths } from "../utils/routing-paths.js";
 
@@ -57,7 +58,8 @@ export const routingOutcomeCmd = async (args: string[]): Promise<string> => {
 	};
 
 	const projectRoot = process.cwd();
-	const configReader = new YamlRoutingConfigReader({ projectRoot });
+	const pluginRoot = resolvePluginRoot();
+	const configReader = new YamlRoutingConfigReader({ projectRoot, pluginRoot });
 	const configRes = await configReader.readConfig();
 	if (!isOk(configRes)) return JSON.stringify({ ok: false, error: configRes.error });
 

--- a/src/infrastructure/adapters/filesystem/filesystem-tier-config-reader.ts
+++ b/src/infrastructure/adapters/filesystem/filesystem-tier-config-reader.ts
@@ -13,7 +13,18 @@ import { type ModelTier, ModelTierSchema } from "../../../domain/value-objects/t
 
 interface FilesystemTierConfigReaderOpts {
 	projectRoot: string;
-	agentsDir: string;
+	/**
+	 * Fallback root for bundled agents/. When `<projectRoot>/agents/<id>.md`
+	 * doesn't exist, the reader tries `<pluginRoot>/agents/<id>.md`. null/undefined
+	 * = project-only lookup (preserves pre-fallback behavior).
+	 */
+	pluginRoot?: string | null;
+	/**
+	 * @deprecated Prefer `projectRoot` alone (agents are auto-resolved at
+	 * `<projectRoot>/agents/`) with optional `pluginRoot` fallback. Kept as
+	 * an explicit override so existing callers and tests keep working.
+	 */
+	agentsDir?: string;
 }
 
 const DEFAULT_AGENT_MIN_TIER: ModelTier = "haiku";
@@ -62,13 +73,32 @@ export class FilesystemTierConfigReader implements TierConfigReader {
 			return Ok(DEFAULT_AGENT_MIN_TIER); // invalid agent_id → safe fallback
 		}
 		const MAX_AGENT_FILE_SIZE = 1024 * 1024; // 1 MB
-		const path = join(this.opts.agentsDir, `${agent_id}.md`);
-		let raw = "";
-		try {
-			raw = await readFile(path, "utf8");
-		} catch {
-			return Ok(DEFAULT_AGENT_MIN_TIER);
+
+		// Candidate agent-file paths tried in order. `agentsDir` (if explicitly
+		// provided) is tried first for back-compat; otherwise `<projectRoot>/agents/`
+		// is tried, then `<pluginRoot>/agents/` if set.
+		const candidatePaths: string[] = [];
+		if (this.opts.agentsDir) {
+			candidatePaths.push(join(this.opts.agentsDir, `${agent_id}.md`));
+		} else {
+			candidatePaths.push(join(this.opts.projectRoot, "agents", `${agent_id}.md`));
 		}
+		if (this.opts.pluginRoot) {
+			candidatePaths.push(join(this.opts.pluginRoot, "agents", `${agent_id}.md`));
+		}
+
+		let raw = "";
+		let found = false;
+		for (const candidate of candidatePaths) {
+			try {
+				raw = await readFile(candidate, "utf8");
+				found = true;
+				break;
+			} catch {
+				// try next path
+			}
+		}
+		if (!found) return Ok(DEFAULT_AGENT_MIN_TIER);
 		if (raw.length > MAX_AGENT_FILE_SIZE) return Ok(DEFAULT_AGENT_MIN_TIER);
 		const match = raw.match(/^---\n([\s\S]*?)\n---/);
 		if (!match) return Ok(DEFAULT_AGENT_MIN_TIER);

--- a/src/infrastructure/adapters/filesystem/yaml-routing-config-reader.ts
+++ b/src/infrastructure/adapters/filesystem/yaml-routing-config-reader.ts
@@ -50,6 +50,13 @@ const DISABLED_DEFAULT: RoutingConfig = {
 
 export interface YamlRoutingConfigReaderOpts {
 	projectRoot: string;
+	/**
+	 * Fallback root for bundled `commands/` and `agents/`. When the project
+	 * root does not contain the requested file, the reader tries this root
+	 * next so fresh installs work without hand-rolled settings.
+	 * null/undefined = project-only lookup (preserves pre-fallback behavior).
+	 */
+	pluginRoot?: string | null;
 }
 
 export class YamlRoutingConfigReader implements RoutingConfigReader {
@@ -242,14 +249,21 @@ export class YamlRoutingConfigReader implements RoutingConfigReader {
 				}),
 			);
 		}
-		const commandPath = join(this.opts.projectRoot, "commands", ns, `${name}.md`);
+		const roots = [this.opts.projectRoot, this.opts.pluginRoot].filter(
+			(r): r is string => typeof r === "string" && r.length > 0,
+		);
 
-		let raw: string;
-		try {
-			raw = await readFile(commandPath, "utf8");
-		} catch {
-			return Ok(undefined);
+		let raw: string | undefined;
+		for (const root of roots) {
+			const candidate = join(root, "commands", ns, `${name}.md`);
+			try {
+				raw = await readFile(candidate, "utf8");
+				break;
+			} catch {
+				// try next root
+			}
 		}
+		if (raw === undefined) return Ok(undefined);
 		if (raw.length > MAX_YAML_FILE_SIZE) return Ok(undefined);
 
 		const match = raw.match(/^---\n([\s\S]*?)\n---/);
@@ -284,12 +298,21 @@ export class YamlRoutingConfigReader implements RoutingConfigReader {
 	}
 
 	private async hydrateAgentCapability(id: string): Promise<Result<AgentCapability, DomainError>> {
-		const agentPath = join(this.opts.projectRoot, "agents", `${id}.md`);
+		const roots = [this.opts.projectRoot, this.opts.pluginRoot].filter(
+			(r): r is string => typeof r === "string" && r.length > 0,
+		);
 
-		let raw: string;
-		try {
-			raw = await readFile(agentPath, "utf8");
-		} catch {
+		let raw: string | undefined;
+		for (const root of roots) {
+			const candidate = join(root, "agents", `${id}.md`);
+			try {
+				raw = await readFile(candidate, "utf8");
+				break;
+			} catch {
+				// try next root
+			}
+		}
+		if (raw === undefined) {
 			return Err(createDomainError("ROUTING_CONFIG", `agent file not found: ${id}`, { id }));
 		}
 		if (raw.length > MAX_YAML_FILE_SIZE) {

--- a/src/infrastructure/plugin-root.ts
+++ b/src/infrastructure/plugin-root.ts
@@ -1,0 +1,46 @@
+import { existsSync, statSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Returns the plugin cache root — the directory containing the bundled
+ * `commands/` and `agents/` trees — or null when it can't be determined.
+ *
+ * Resolution order:
+ *   1. `process.env.TFF_PLUGIN_ROOT` (set by bin/tff-tools shim). Validated
+ *      so a stale/bogus env var doesn't silently win.
+ *   2. Derive from `import.meta.url` when the bundle is running at the
+ *      conventional location `<pluginRoot>/dist/cli/index.js`. Source-mode
+ *      execution (tests, direct ts-node) does NOT match this layout, so
+ *      derivation returns null there — preventing a dogfood repo root from
+ *      being mistaken for an installed plugin.
+ *   3. null — callers treat this as "project-only lookup".
+ */
+export function resolvePluginRoot(): string | null {
+	const fromEnv = process.env.TFF_PLUGIN_ROOT;
+	if (fromEnv && isValidPluginRoot(fromEnv)) return fromEnv;
+
+	try {
+		const here = dirname(fileURLToPath(import.meta.url));
+		// Only derive when we're running from the bundled CLI layout:
+		//   <pluginRoot>/dist/cli/index.js
+		if (basename(here) === "cli" && basename(dirname(here)) === "dist") {
+			const derived = resolve(here, "..", "..");
+			if (isValidPluginRoot(derived)) return derived;
+		}
+	} catch {
+		// import.meta.url unavailable (unusual runtime) — fall through.
+	}
+
+	return null;
+}
+
+function isValidPluginRoot(dir: string): boolean {
+	if (!existsSync(dir)) return false;
+	try {
+		if (!statSync(dir).isDirectory()) return false;
+	} catch {
+		return false;
+	}
+	return existsSync(resolve(dir, "commands")) || existsSync(resolve(dir, "agents"));
+}

--- a/tests/unit/infrastructure/adapters/filesystem/filesystem-tier-config-reader.spec.ts
+++ b/tests/unit/infrastructure/adapters/filesystem/filesystem-tier-config-reader.spec.ts
@@ -120,3 +120,56 @@ describe("FilesystemTierConfigReader.readAgentMinTier", () => {
 		expect(res.data).toBe("haiku");
 	});
 });
+
+describe("FilesystemTierConfigReader — pluginRoot fallback", () => {
+	let project: string;
+	let plugin: string;
+
+	beforeEach(() => {
+		project = mkdtempSync(join(tmpdir(), "tff-tier-proj-"));
+		plugin = mkdtempSync(join(tmpdir(), "tff-tier-plugin-"));
+	});
+	afterEach(() => {
+		rmSync(project, { recursive: true, force: true });
+		rmSync(plugin, { recursive: true, force: true });
+	});
+
+	it("reads agent min_tier from pluginRoot when project has no agents/", async () => {
+		mkdirSync(join(plugin, "agents"), { recursive: true });
+		writeFileSync(
+			join(plugin, "agents", "tff-security-auditor.md"),
+			`---\nrouting:\n  min_tier: sonnet\n---\n`,
+		);
+		const reader = new FilesystemTierConfigReader({ projectRoot: project, pluginRoot: plugin });
+		const res = await reader.readAgentMinTier("tff-security-auditor");
+		expect(isOk(res)).toBe(true);
+		if (!isOk(res)) return;
+		expect(res.data).toBe("sonnet");
+	});
+
+	it("projectRoot agent wins over pluginRoot agent when both define min_tier", async () => {
+		mkdirSync(join(project, "agents"), { recursive: true });
+		mkdirSync(join(plugin, "agents"), { recursive: true });
+		writeFileSync(
+			join(project, "agents", "tff-spec-reviewer.md"),
+			`---\nrouting:\n  min_tier: opus\n---\n`,
+		);
+		writeFileSync(
+			join(plugin, "agents", "tff-spec-reviewer.md"),
+			`---\nrouting:\n  min_tier: haiku\n---\n`,
+		);
+		const reader = new FilesystemTierConfigReader({ projectRoot: project, pluginRoot: plugin });
+		const res = await reader.readAgentMinTier("tff-spec-reviewer");
+		expect(isOk(res)).toBe(true);
+		if (!isOk(res)) return;
+		expect(res.data).toBe("opus");
+	});
+
+	it("returns haiku default when agent is missing from both roots", async () => {
+		const reader = new FilesystemTierConfigReader({ projectRoot: project, pluginRoot: plugin });
+		const res = await reader.readAgentMinTier("ghost-agent");
+		expect(isOk(res)).toBe(true);
+		if (!isOk(res)) return;
+		expect(res.data).toBe("haiku");
+	});
+});

--- a/tests/unit/infrastructure/adapters/filesystem/yaml-routing-config-reader.spec.ts
+++ b/tests/unit/infrastructure/adapters/filesystem/yaml-routing-config-reader.spec.ts
@@ -116,6 +116,87 @@ describe("YamlRoutingConfigReader.readPool", () => {
 		expect(res.data.agents.map((a) => a.id)).toEqual(["tff-code-reviewer", "tff-security-auditor"]);
 	});
 
+	it("falls back to pluginRoot for command frontmatter when projectRoot has none", async () => {
+		const plugin = await mkProject();
+		try {
+			await writeAgent(plugin, "tff-spec-reviewer", ["standard_review"], 10);
+			await writeAgent(plugin, "tff-code-reviewer", ["code_quality"], 10);
+			await writeShipFrontmatter(plugin, ["tff-spec-reviewer", "tff-code-reviewer"]);
+			const reader = new YamlRoutingConfigReader({ projectRoot: tmp, pluginRoot: plugin });
+			const res = await reader.readPool("tff:ship");
+			expect(isOk(res)).toBe(true);
+			if (!isOk(res)) return;
+			expect(res.data.agents.map((a) => a.id)).toEqual(["tff-spec-reviewer", "tff-code-reviewer"]);
+		} finally {
+			await rm(plugin, { recursive: true, force: true });
+		}
+	});
+
+	it("projectRoot frontmatter wins over pluginRoot when both present", async () => {
+		const plugin = await mkProject();
+		try {
+			await writeAgent(plugin, "tff-spec-reviewer", ["x"]);
+			await writeAgent(plugin, "tff-code-reviewer", ["y"]);
+			await writeShipFrontmatter(plugin, ["tff-spec-reviewer", "tff-code-reviewer"]);
+			await writeAgent(tmp, "tff-security-auditor", ["risk"]);
+			await writeShipFrontmatter(tmp, ["tff-security-auditor"]);
+			const reader = new YamlRoutingConfigReader({ projectRoot: tmp, pluginRoot: plugin });
+			const res = await reader.readPool("tff:ship");
+			expect(isOk(res)).toBe(true);
+			if (!isOk(res)) return;
+			expect(res.data.agents.map((a) => a.id)).toEqual(["tff-security-auditor"]);
+		} finally {
+			await rm(plugin, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to pluginRoot for agent files when projectRoot lacks them", async () => {
+		const plugin = await mkProject();
+		try {
+			await writeShipFrontmatter(tmp, ["tff-spec-reviewer", "tff-code-reviewer"]);
+			await writeAgent(plugin, "tff-spec-reviewer", ["standard_review"], 10);
+			await writeAgent(plugin, "tff-code-reviewer", ["code_quality"], 10);
+			const reader = new YamlRoutingConfigReader({ projectRoot: tmp, pluginRoot: plugin });
+			const res = await reader.readPool("tff:ship");
+			expect(isOk(res)).toBe(true);
+			if (!isOk(res)) return;
+			expect(res.data.agents[0].handles).toEqual(["standard_review"]);
+			expect(res.data.agents[1].handles).toEqual(["code_quality"]);
+		} finally {
+			await rm(plugin, { recursive: true, force: true });
+		}
+	});
+
+	it("projectRoot agent file wins over pluginRoot when both present", async () => {
+		const plugin = await mkProject();
+		try {
+			await writeShipFrontmatter(tmp, ["tff-spec-reviewer"]);
+			await writeAgent(tmp, "tff-spec-reviewer", ["from_project"], 10);
+			await writeAgent(plugin, "tff-spec-reviewer", ["from_plugin"], 10);
+			const reader = new YamlRoutingConfigReader({ projectRoot: tmp, pluginRoot: plugin });
+			const res = await reader.readPool("tff:ship");
+			expect(isOk(res)).toBe(true);
+			if (!isOk(res)) return;
+			expect(res.data.agents[0].handles).toEqual(["from_project"]);
+		} finally {
+			await rm(plugin, { recursive: true, force: true });
+		}
+	});
+
+	it("returns the same no-pool-declared error when both roots lack frontmatter", async () => {
+		const plugin = await mkProject();
+		try {
+			const reader = new YamlRoutingConfigReader({ projectRoot: tmp, pluginRoot: plugin });
+			const res = await reader.readPool("tff:ship");
+			expect(isOk(res)).toBe(false);
+			if (isOk(res)) return;
+			expect(res.error.code).toBe("ROUTING_CONFIG");
+			expect(res.error.message).toMatch(/no pool declared/);
+		} finally {
+			await rm(plugin, { recursive: true, force: true });
+		}
+	});
+
 	it("returns ROUTING_CONFIG error for unknown agent id", async () => {
 		await writeShipFrontmatter(tmp, ["tff-ghost"]);
 		const reader = new YamlRoutingConfigReader({ projectRoot: tmp });

--- a/tests/unit/infrastructure/plugin-root.spec.ts
+++ b/tests/unit/infrastructure/plugin-root.spec.ts
@@ -1,0 +1,48 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolvePluginRoot } from "../../../src/infrastructure/plugin-root.js";
+
+describe("resolvePluginRoot", () => {
+	let dir: string;
+	const ORIGINAL_ENV = process.env.TFF_PLUGIN_ROOT;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "plugin-root-"));
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+		if (ORIGINAL_ENV === undefined) delete process.env.TFF_PLUGIN_ROOT;
+		else process.env.TFF_PLUGIN_ROOT = ORIGINAL_ENV;
+	});
+
+	it("returns the env-var path when TFF_PLUGIN_ROOT is set and dir contains commands/", async () => {
+		await mkdir(join(dir, "commands"), { recursive: true });
+		process.env.TFF_PLUGIN_ROOT = dir;
+		expect(resolvePluginRoot()).toBe(dir);
+	});
+
+	it("returns the env-var path when TFF_PLUGIN_ROOT is set and dir contains agents/", async () => {
+		await mkdir(join(dir, "agents"), { recursive: true });
+		process.env.TFF_PLUGIN_ROOT = dir;
+		expect(resolvePluginRoot()).toBe(dir);
+	});
+
+	it("ignores TFF_PLUGIN_ROOT when the directory is missing", async () => {
+		process.env.TFF_PLUGIN_ROOT = join(dir, "does-not-exist");
+		// falls through to import.meta.url; in the test context the bundle root
+		// isn't a plugin root, so the result is null.
+		expect(resolvePluginRoot()).toBeNull();
+	});
+
+	it("ignores TFF_PLUGIN_ROOT when the directory has neither commands/ nor agents/", async () => {
+		process.env.TFF_PLUGIN_ROOT = dir;
+		expect(resolvePluginRoot()).toBeNull();
+	});
+
+	it("returns null when neither env-var nor derivation yields a valid plugin root", () => {
+		delete process.env.TFF_PLUGIN_ROOT;
+		expect(resolvePluginRoot()).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- `YamlRoutingConfigReader` and `FilesystemTierConfigReader` now accept an optional `pluginRoot` and try `projectRoot` first, `pluginRoot` second — user overrides still win.
- New `resolvePluginRoot()` utility reads `TFF_PLUGIN_ROOT` (env-first, validated) and falls back to deriving from the bundled `dist/cli/index.js` layout when invoked directly.
- `bin/tff-tools` exports `TFF_PLUGIN_ROOT="$PLUGIN_ROOT"` so the already-computed (symlink-aware) plugin root is authoritative when the CLI runs via the shim.

Fixes #138.

## What was broken

`routing:decide` (and transitively `routing:judge-prepare` / `routing:judge-record`) failed with `ROUTING_CONFIG: no pool declared for workflow: <id>` on every fresh install, because the readers looked up `commands/<ns>/<name>.md` and `agents/<id>.md` against `process.cwd()`. The `tff:ship` workflow silently swallowed the error per its documented fallback, so Phase C/D/E (routing, feedback, calibration, model judge) were dead-on-arrival. A sibling bug in `FilesystemTierConfigReader` silently returned `DEFAULT_AGENT_MIN_TIER = "haiku"` for the same reason, so every agent's declared `min_tier` was ignored — a quieter variant of the same class of bug. This PR addresses both.

## Resolution order

For every lookup: **project root first, plugin root second.** A user dropping `commands/tff/ship.md` or `agents/<id>.md` into their repo overrides the bundled default; a fresh install with neither falls through to the plugin cache. Error surface is unchanged — when both roots miss, the readers emit the same `ROUTING_CONFIG: no pool declared` / `agent file not found` errors as before.

## Test plan

- [x] 5 new unit tests for `YamlRoutingConfigReader` cover: plugin-only frontmatter hit, project frontmatter wins over plugin, plugin-only agent hit, project agent wins over plugin, both-roots-miss error unchanged.
- [x] 3 new unit tests for `FilesystemTierConfigReader` cover: plugin-only min_tier hit, project wins over plugin, both-roots-miss returns haiku default.
- [x] 5 new unit tests for `resolvePluginRoot()` cover: env-var hit (commands/), env-var hit (agents/), env-var pointing at missing dir returns null, env-var at dir with neither subdir returns null, no env + source-mode returns null.
- [x] Full test suite (`bun run test`): 1708 passed, 2 skipped (pre-existing), 0 failed.
- [x] `bun run lint` clean, `bun run typecheck` clean.
- [x] Manual bundle rebuild + shim `routing:decide --help` smoke test succeeds.

## Back-compat

`FilesystemTierConfigReader` keeps `agentsDir` as an optional `@deprecated` field so existing tests and callers continue to work unchanged. `YamlRoutingConfigReader`'s new `pluginRoot` is purely additive — when omitted, behavior is identical to pre-fix.