### PR TITLE
feat: grill-me/ultra-compress skill patterns + worktree-from-milestone fix

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -20,12 +20,15 @@ Do NOT invoke any implementation skill, write any code, ∨ take any implementat
 3. Assess scope first: multi-subsystem -> decompose before detailing
 4. ∀ assumption: surface explicitly, ¬proceed on implicit agreement
 5. Propose 2-3 approaches w/ trade-offs before committing
+6. ∃ question answerable by codebase exploration -> explore, ¬ ask
+7. APPROACH ∧ DESIGN questions: ship recommended answer (user confirms ∨ overrides). FRAME questions: open, ¬ recommendation (avoid biasing problem framing)
+8. Walk decision-tree: resolve dependent decisions before independent ones; ∀ branch -> exhaust before next
 
 ## Flow
 
-1. FRAME: Define problem, constraints, scope (2-4 questions)
+1. FRAME: Define problem, constraints, scope (2-4 open questions, ¬ recommendations)
 2. APPROACH: Propose 2-3, recommend one, user picks
-3. DESIGN: Section-by-section, user approves each inline
+3. DESIGN: Branch-traversal — ∀ decision: state question + recommended answer + dependencies; user confirms ∨ overrides; resolve children before siblings
    - standard: problem, approach, acceptance criteria, non-goals (~1 page)
    - complex: + constraints, architecture, error handling, testing strategy (~3 pages)
 4. WRITE: `project spec document (e.g., docs/specs/SPEC.md)`
@@ -52,6 +55,9 @@ Dispatch via Agent tool (subagent_type: general-purpose). Checks: completeness, 
 - Implementing before design approved
 - Skipping the FRAME phase (defining problem before solving)
 - Rubber-stamping spec review iterations
+- Asking the user something a `grep` ∨ `read` could resolve
+- Recommending answers in FRAME phase (biases problem definition)
+- Linear question dump, ¬ following dependency edges of the decision-tree
 
 ## Rules
 

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: report-issue
+description: "Use when the user wants to report a bug, file an issue, or send feedback about tff-cc. Triggers on phrases like 'report issue', 'file a bug', 'tff-cc broke', 'something is wrong with tff-cc', 'open an issue', '/report-issue'."
+compression: ultra
+---
+
+# Report Issue
+
+## When to Use
+
+User reports tff-cc bug ∨ unexpected behavior ∨ wants to file an issue against the tff-cc repo. Repo target: `MonsieurBarti/The-Forge-Flow-CC`.
+
+## HARD-GATE
+
+¬ submit until user explicitly confirms issue body (filing publicly = irreversible). Show full draft -> ask `submit? [y/N]`. Default = ¬ submit.
+
+## Checklist
+
+1. **Detect command** — verify `gh` available: `gh --version`. ¬ available -> abort, instruct user `brew install gh && gh auth login`.
+2. **Collect context** — gather in parallel:
+   - tff-cc version: read `package.json`.version
+   - node + OS: `node --version`, `uname -s -r`
+   - Recent slice ∨ state: `.tff-cc/STATE.md` if exists (truncate ≤ 80 lines)
+   - Recent commits: `git log --oneline -5`
+   - User-supplied: error message, repro steps, expected vs actual
+3. **Classify** — ask user one question: `kind ∈ { bug, feature-request, question, docs }`. Default `bug`.
+4. **Draft** — render issue body per template below.
+5. **Show draft** — present title + body to user verbatim.
+6. **Confirm** — `submit? [y/N]`. ¬ y -> save draft to `/tmp/tff-cc-issue-<timestamp>.md` ∧ abort.
+7. **Submit** — `gh issue create --repo MonsieurBarti/The-Forge-Flow-CC --title "<title>" --body-file <draft-path> --label <kind>`.
+8. **Report** — print returned URL.
+
+## Issue Template
+
+```md
+## Summary
+<one-line>
+
+## Environment
+- tff-cc: <version>
+- node: <version>
+- OS: <uname>
+
+## Repro
+<steps>
+
+## Expected
+<what should happen>
+
+## Actual
+<what happened — include error verbatim ∈ ``` fence>
+
+## Context
+<recent slice / commits if relevant — collapse ∈ <details>>
+```
+
+## Output Format
+
+- On success: `https://github.com/MonsieurBarti/The-Forge-Flow-CC/issues/<n>`
+- On abort: path to saved draft `/tmp/tff-cc-issue-<ts>.md`
+- On `gh` missing: install instructions, ¬ partial state
+
+## Anti-Patterns
+
+- Submitting without showing the user the rendered body first (irreversible publish)
+- Pasting full STATE.md unredacted (may contain repo paths ∨ stale tokens — truncate ∧ scrub)
+- Auto-classifying as `bug` when user said "feature" ∨ "question"
+- Inventing repro steps the user didn't provide — ask, ¬ guess
+- Filing against the wrong repo (always `MonsieurBarti/The-Forge-Flow-CC`, ¬ user's project repo)
+- Re-submitting on retry without de-dup (offer search of existing issues first when title-similarity high)
+
+## Rules
+
+- Repo target hard-coded: `MonsieurBarti/The-Forge-Flow-CC`
+- ∀ submission: user confirmation required
+- ∀ context blob > 80 lines: truncate ∧ note `<truncated>`
+- ¬ include secrets (env vars, tokens, absolute paths under `/Users/<name>` -> mask to `~`)
+- ¬ submit if `gh auth status` fails — instruct `gh auth login` instead

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -22,6 +22,45 @@ description: "Use when <trigger>"
 ---
 ```
 
+## Description Contract
+
+Description = the only field the loader sees when picking skills. Treat as API.
+
+- ≤ 1024 chars
+- Third person, ¬ first
+- Sentence 1: capability (what it does)
+- Sentence 2: `Use when <triggers>` — concrete keywords ∨ contexts ∨ file types
+- ¬ symbolic notation, ¬ compression — loader matches literal substrings
+
+Good: `Extract text and tables from PDFs, fill forms, merge documents. Use when working with PDF files or user mentions PDFs, forms, extraction.`
+Bad: `Helps with documents.`
+
+## Progressive Disclosure
+
+```
+skill-name/
+├── SKILL.md           # ≤100 lines, required
+├── REFERENCE.md       # detailed docs, optional
+├── EXAMPLES.md        # worked examples, optional
+└── scripts/           # deterministic helpers, optional
+```
+
+Split when:
+- SKILL.md > 100 lines
+- ∃ distinct domains in body (split per domain)
+- ∃ rarely-used advanced features (move out of SKILL.md)
+
+Linking: SKILL.md -> REFERENCE.md only (one level deep). ¬ chains.
+
+## Scripts
+
+Add scripts when:
+- Operation deterministic (validation, formatting, parsing)
+- Same code would be regenerated turn after turn
+- Errors need explicit handling, ¬ best-effort
+
+Scripts > generated code: fewer tokens, fewer regressions.
+
 ## Required Sections
 
 1. **When to Use**: Trigger condition (∀ X workflow: load this skill)
@@ -31,10 +70,23 @@ description: "Use when <trigger>"
 5. **Anti-Patterns**: Common mistakes (>=3)
 6. **Rules**: Concise constraints using ∀/∃/¬ notation
 
-## Compression Rules (roxabi)
+## Compression Contract
 
-Use formal notation: ∀ (all), ∃ (∃), ∈ (member), ∧ (∧), ∨ (∨), ¬ (¬), -> (then)
-Target: ~62% token reduction vs prose
+Skill body uses formal notation: ∀ (all), ∃ (exists), ∈ (member), ∧ (and), ∨ (or), ¬ (not), -> (then). Target ~62% token reduction vs prose.
+
+Default level: `ultra` for body. `off` for frontmatter ∧ description (loader parses literal).
+
+### Π — protected zones (¬ compress, ∀ level)
+
+frontmatter · description field · fenced code · inline code · URLs · file paths · CLI commands · headings (count + order) · tool names · numeric versions · quoted error strings · table structure · bullet nesting depth.
+
+### Ω — Auto-Clarity fallback (drop notation -> prose)
+
+section ∈ { security warning, destructive op, irreversible action, ordered multi-step where fragment order risks misread } -> prose, resume notation next section.
+
+### Level dial
+
+Skill MAY declare body compression level via frontmatter `compression: <off|lite|standard|ultra|symbolic>`. Default `ultra`. `symbolic` reserved for skills the model alone reads (¬ user-facing checklists).
 
 ## Evidence Requirements
 
@@ -92,10 +144,28 @@ LOAD @skills/code-review-protocol/SKILL.md
 - Skills that describe rather than prescribe (skills are workflows, ¬documentation)
 - Over-broad trigger conditions ("use always" = never triggered correctly)
 - Skills without anti-patterns section (that's where the real value is)
+- Compressing the description field (loader reads literal — symbolic notation breaks matching)
+- Single-file skills > 100 lines (split into REFERENCE.md / EXAMPLES.md)
+- Generating deterministic logic inline turn-after-turn instead of shipping a script
 
 ## Validation
 
 Run skill validation before deployment.
+
+## Pre-Promotion Checklist
+
+∀ draft -> verify before promoting from drafts/:
+
+- [ ] Description ≤ 1024 chars, 3rd person, includes `Use when <trigger>`, ¬ compressed
+- [ ] SKILL.md ≤ 100 lines (∨ split into REFERENCE.md / EXAMPLES.md)
+- [ ] Frontmatter ∧ description ∧ code blocks ∈ Π (uncompressed)
+- [ ] Anti-Patterns section: ≥ 3 entries
+- [ ] Evidence table: ≥ 3 sessions
+- [ ] ¬ time-sensitive content (dates, "recent", "currently")
+- [ ] Concrete examples, ¬ abstract description only
+- [ ] References one level deep (SKILL.md -> REFERENCE.md, ¬ chains)
+- [ ] Name ∈ `[a-z0-9-]{1,64}`, ¬ leading/trailing/consecutive hyphens
+- [ ] ¬ dangerous_cmds (rm -rf, sudo, curl|bash)
 
 ## Rules
 

--- a/skills/skill-baselines.json
+++ b/skills/skill-baselines.json
@@ -20,10 +20,10 @@
       "sha256": "00a4cfddfead9a3d8695057be11f7377b659940e695f1eee12a31ddae4cc5c19"
     },
     "brainstorming": {
-      "approvedAt": "2026-04-21T21:40:30.878Z",
+      "approvedAt": "2026-04-29T00:00:00.000Z",
       "originalCommitSha": "12d32cd",
       "refinementId": null,
-      "sha256": "ff4cda1cfad792de9399ad2aac67a4d6f888801a3b0770a6f2d41f5a0c87c0c2"
+      "sha256": "1baca3b47ce1cb2aa4bcf7bbfa9f473ce2585805198bb5edade9dd1ccf23d3b0"
     },
     "code-review-protocol": {
       "approvedAt": "2026-04-21T21:40:30.878Z",
@@ -73,11 +73,17 @@
       "refinementId": null,
       "sha256": "cd5b04850ebf0f944bc7776e2b369f6dafcd83d8ca5640f6df9bb657de389ba8"
     },
+    "report-issue": {
+      "approvedAt": "2026-04-29T00:00:00.000Z",
+      "originalCommitSha": "29c3fe2",
+      "refinementId": null,
+      "sha256": "21699f5b6010940ccb1a048ad5fe152703d3d4873416d45c6770912b97b11457"
+    },
     "skill-authoring": {
-      "approvedAt": "2026-04-21T21:40:30.878Z",
+      "approvedAt": "2026-04-29T00:00:00.000Z",
       "originalCommitSha": "12d32cd",
       "refinementId": null,
-      "sha256": "c9d8e0ad9b527fba117adccf5610d2b1bd41165ee52dce39ab40d8c3936157d2"
+      "sha256": "7fb5b0dec0bee13909c991b2a57cc55bc669809c1d3708862afc497a31175b30"
     },
     "stress-testing-specs": {
       "approvedAt": "2026-04-21T21:40:30.878Z",

--- a/src/application/skills/validate-skill.ts
+++ b/src/application/skills/validate-skill.ts
@@ -1,12 +1,15 @@
 import { createDomainError, type DomainError } from "../../domain/errors/domain-error.js";
 import { Err, Ok, type Result } from "../../domain/result.js";
 
+export type CompressionLevel = "off" | "lite" | "standard" | "ultra" | "symbolic";
+
 export interface SkillInput {
 	name: string;
 	description: string;
 	content?: string;
 	existingSkillNames?: string[];
 	maxSize?: number;
+	compression?: CompressionLevel;
 }
 
 interface ValidationResult {
@@ -15,6 +18,14 @@ interface ValidationResult {
 }
 
 const NAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const COMPRESSION_LEVELS: readonly CompressionLevel[] = [
+	"off",
+	"lite",
+	"standard",
+	"ultra",
+	"symbolic",
+];
+const SYMBOLIC_NOTATION_REGEX = /[∀∃∈∉∧∨¬⟺⊂⊃∪∩∅→]/;
 
 export const validateSkill = (input: SkillInput): Result<ValidationResult, DomainError> => {
 	const warnings: string[] = [];
@@ -47,6 +58,21 @@ export const validateSkill = (input: SkillInput): Result<ValidationResult, Domai
 	// Description quality
 	if (!input.description.toLowerCase().startsWith("use when")) {
 		warnings.push('Description should start with "Use when"');
+	}
+
+	// Description must not be compressed — loader matches literal substrings
+	if (SYMBOLIC_NOTATION_REGEX.test(input.description)) {
+		warnings.push("Description contains symbolic notation — loader reads literal, keep prose");
+	}
+
+	// Compression level — body-only contract; runtime application lives in ultra-compress
+	if (input.compression !== undefined && !COMPRESSION_LEVELS.includes(input.compression)) {
+		return Err(
+			createDomainError(
+				"VALIDATION_ERROR",
+				`Invalid compression level "${input.compression}" — must be one of: ${COMPRESSION_LEVELS.join(", ")}`,
+			),
+		);
 	}
 
 	// Name collision check

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -95,7 +95,7 @@ export interface CommandEntry {
 }
 
 const wrap = (handler: CommandFn, schema: CommandSchema): CommandFn =>
-	schema.mutates === true ? withMutatingCommand(handler) : handler;
+	schema.mutates === true ? withMutatingCommand(handler, { commandName: schema.name }) : handler;
 
 export const COMMAND_REGISTRY: Record<string, CommandEntry> = (() => {
 	const branchGuardCheckHandler = branchGuardCheckCmd();

--- a/src/cli/utils/with-mutating-command.ts
+++ b/src/cli/utils/with-mutating-command.ts
@@ -32,7 +32,13 @@ interface TaggedHandler extends Handler {
 
 interface WrapperDeps {
 	gitFactory?: () => GitOps;
+	commandName?: string;
 }
+
+// Bootstrap/teardown commands that MUST run on a milestone branch — the
+// milestone-branch-guard's "switch to slice worktree" remediation is impossible
+// here because these commands are how you create/destroy that worktree.
+const MILESTONE_GUARD_EXEMPT = new Set<string>(["worktree:create", "worktree:delete"]);
 
 // Module-level cache: migrations and DB init run once per process.
 let _cachedStores: ClosableStateStores | null = null;
@@ -62,7 +68,9 @@ export const withMutatingCommand = (handler: Handler, deps?: WrapperDeps): Tagge
 			return JSON.stringify({ ok: false, error: defaultGuard.error });
 		}
 
-		if (process.env.TFF_ALLOW_MILESTONE_COMMIT !== "1") {
+		const isMilestoneGuardExempt =
+			deps?.commandName !== undefined && MILESTONE_GUARD_EXEMPT.has(deps.commandName);
+		if (process.env.TFF_ALLOW_MILESTONE_COMMIT !== "1" && !isMilestoneGuardExempt) {
 			const stores = getStores();
 			const milestoneGuard = await assertNotOnMilestoneBranch(
 				git,

--- a/tests/integration/worktree-create-from-milestone-branch.integration.spec.ts
+++ b/tests/integration/worktree-create-from-milestone-branch.integration.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * worktree:create must work on a milestone branch.
+ *
+ * The whole point of `tff-tools worktree:create --slice-id <id>` is to spawn a
+ * slice worktree from the milestone branch you're sitting on. Forcing the user
+ * off the milestone branch first is impossible — that's what the worktree IS.
+ *
+ * conventions.md scopes milestone-branch-guard to exactly four commands:
+ * slice:transition, task:claim, task:close, review:record. worktree:create is
+ * NOT in that list.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitOps } from "../../src/domain/ports/git-ops.port.js";
+import type { JournalRepository } from "../../src/domain/ports/journal-repository.port.js";
+import { Ok } from "../../src/domain/result.js";
+import type { ClosableStateStores } from "../../src/infrastructure/adapters/sqlite/create-state-stores.js";
+import { SQLiteStateAdapter } from "../../src/infrastructure/adapters/sqlite/sqlite-state.adapter.js";
+
+const { getAdapter, setAdapter } = vi.hoisted(() => {
+	let _adapter: SQLiteStateAdapter | null = null;
+	return {
+		getAdapter: () => _adapter,
+		setAdapter: (a: SQLiteStateAdapter) => {
+			_adapter = a;
+		},
+	};
+});
+
+const nullJournal: JournalRepository = {
+	append: () => Ok(0),
+	readAll: () => Ok([]),
+	readSince: () => Ok([]),
+	count: () => Ok(0),
+};
+
+vi.mock("../../src/infrastructure/adapters/sqlite/create-state-stores.js", () => ({
+	createClosableStateStoresUnchecked: vi.fn((): ClosableStateStores => {
+		const adapter = getAdapter()!;
+		return {
+			db: adapter,
+			projectStore: adapter,
+			milestoneStore: adapter,
+			sliceStore: adapter,
+			taskStore: adapter,
+			dependencyStore: adapter,
+			sliceDependencyStore: adapter,
+			sessionStore: adapter,
+			reviewStore: adapter,
+			milestoneAuditStore: adapter,
+			journalRepository: nullJournal,
+			close: () => {},
+			checkpoint: () => {},
+		};
+	}),
+}));
+
+function unreachable(): never {
+	throw new Error("unexpected call");
+}
+
+function makeGit(branch: string): GitOps {
+	return {
+		getCurrentBranch: async () => Ok(branch),
+		detectDefaultBranch: async () => Ok("main"),
+		createBranch: unreachable,
+		createWorktree: async () => Ok(undefined),
+		deleteWorktree: unreachable,
+		listWorktrees: unreachable,
+		commit: unreachable,
+		revert: unreachable,
+		merge: unreachable,
+		getHeadSha: unreachable,
+		createOrphanWorktree: unreachable,
+		checkoutWorktree: unreachable,
+		branchExists: unreachable,
+		deleteBranch: unreachable,
+		pruneWorktrees: unreachable,
+		lsTree: unreachable,
+		extractFile: unreachable,
+		pushBranch: unreachable,
+		fetchBranch: unreachable,
+	};
+}
+
+function seedAdapter(): { adapter: SQLiteStateAdapter; milestoneId: string; sliceId: string } {
+	const adapter = SQLiteStateAdapter.createInMemory();
+	adapter.init();
+	adapter.saveProject({ name: "Test Project" });
+	adapter.createMilestone({ number: 1, name: "Milestone One" });
+
+	const msR = adapter.listMilestones();
+	if (!msR.ok || msR.data.length === 0) throw new Error("No milestones seeded");
+	const milestoneId = msR.data[0].id;
+
+	adapter.createSlice({ milestoneId, number: 1, title: "Slice One" });
+
+	const slicesR = adapter.listSlices(milestoneId);
+	if (!slicesR.ok || slicesR.data.length === 0) throw new Error("No slices seeded");
+	const sliceId = slicesR.data[0].id;
+
+	return { adapter, milestoneId, sliceId };
+}
+
+beforeEach(() => {
+	vi.resetModules();
+});
+
+afterEach(() => {
+	delete process.env.TFF_ALLOW_MILESTONE_COMMIT;
+});
+
+describe("worktree:create on milestone branch", () => {
+	it("must NOT be refused as REFUSED_ON_MILESTONE_BRANCH when sitting on the milestone branch with the open slice we want a worktree for", async () => {
+		const { adapter, milestoneId } = seedAdapter();
+		setAdapter(adapter);
+
+		const prefix = milestoneId.slice(0, 8);
+		const branch = `milestone/${prefix}`;
+		const git = makeGit(branch);
+
+		const { withMutatingCommand, resetMutatingCommandCache } = await import(
+			"../../src/cli/utils/with-mutating-command.js"
+		);
+		resetMutatingCommandCache();
+		const { worktreeCreateCmd } = await import("../../src/cli/commands/worktree-create.cmd.js");
+
+		const wrapped = withMutatingCommand(worktreeCreateCmd, {
+			gitFactory: () => git,
+			commandName: "worktree:create",
+		});
+		const out = JSON.parse(await wrapped(["--slice-id", "M01-S01"]));
+
+		// Whatever else might fail downstream (filesystem mocks, etc), the guard
+		// itself MUST NOT refuse this command. It's the only path to escape the
+		// milestone branch onto a slice worktree.
+		if (!out.ok) {
+			expect(out.error.code).not.toBe("REFUSED_ON_MILESTONE_BRANCH");
+		}
+	});
+});

--- a/tests/unit/application/skills/validate-skill.spec.ts
+++ b/tests/unit/application/skills/validate-skill.spec.ts
@@ -136,4 +136,36 @@ describe("validateSkill", () => {
 			expect(result.data.warnings.some((w) => w.includes("injection"))).toBe(false);
 		}
 	});
+
+	it("should accept valid compression levels", () => {
+		for (const level of ["off", "lite", "standard", "ultra", "symbolic"] as const) {
+			const result = validateSkill({
+				name: "compressed-skill",
+				description: "Use when compression matters",
+				compression: level,
+			});
+			expect(isOk(result)).toBe(true);
+		}
+	});
+
+	it("should reject invalid compression level", () => {
+		const result = validateSkill({
+			name: "compressed-skill",
+			description: "Use when compression matters",
+			// @ts-expect-error — exercising runtime validation
+			compression: "extreme",
+		});
+		expect(isErr(result)).toBe(true);
+	});
+
+	it("should warn when description contains symbolic notation", () => {
+		const result = validateSkill({
+			name: "compressed-skill",
+			description: "Use when ∀ x ∈ skills ∧ ¬ documented",
+		});
+		expect(isOk(result)).toBe(true);
+		if (isOk(result)) {
+			expect(result.data.warnings.some((w) => w.includes("symbolic"))).toBe(true);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Two independent changes on one branch:

### 1. Skill content updates (commit 177490d)
Brings in patterns from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/productivity) and the local `ultra-compress` PI extension.

- **brainstorming**: codebase-first rule (don't ask what `grep` could answer), recommended-answer per question (APPROACH/DESIGN only — FRAME stays open to avoid biasing problem framing), explicit decision-tree traversal.
- **skill-authoring**: description contract (≤1024 chars, no compression — loader matches literal substrings), progressive disclosure (≤100-line SKILL.md, REFERENCE.md / EXAMPLES.md / scripts/ split), compression contract (Π protected zones, Ω auto-clarity, level dial), pre-promotion checklist.
- **report-issue** (new): `gh`-based issue filing against `MonsieurBarti/The-Forge-Flow-CC` with hard-gate user confirmation, secret/path scrubbing, dedupe consideration.
- **validate-skill**: accepts `compression: off|lite|standard|ultra|symbolic`, rejects unknown levels, warns if description contains symbolic notation.

### 2. Worktree-from-milestone-branch fix (commit fbe3785)
Bug: `worktree:create` had `mutates: true` so `withMutatingCommand` applied the milestone-branch guard — refusing the very command needed to leave the milestone branch onto a slice worktree. Error remediation pointed at `.tff-cc/worktrees/<slice-id>/`, which is exactly what the command was trying to create. Conventions doc scopes that guard to four commands; implementation had drifted to "all mutating commands".

Fix: `MILESTONE_GUARD_EXEMPT = { worktree:create, worktree:delete }` in `with-mutating-command.ts`, thread `schema.name` through `wrap()`. Default-branch guard still applies.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bunx vitest run` — 1752 passed, 2 skipped, 0 failed
- [x] New regression test `tests/integration/worktree-create-from-milestone-branch.integration.spec.ts` red→green
- [x] 3 new tests in `validate-skill.spec.ts` covering compression levels and symbolic-in-description warning
- [ ] Manually exercise `worktree:create` on a real `milestone/<prefix>` branch with open slices

## Side observation (not addressed here)

The same docs/code drift remains for other mutating commands — `observe:record`, `routing:decide`, `sync:state`, `checkpoint:save`, etc. are all blocked on milestone branches today, but `references/conventions.md` only documents the guard for `slice:transition`, `task:claim`, `task:close`, `review:record`. Whether that's intentional belt-and-suspenders or scope creep is a separate question.