### PR TITLE
feat(routing): detect default branch via symbolic-ref

### DIFF
--- a/src/cli/commands/routing-judge-prepare.cmd.ts
+++ b/src/cli/commands/routing-judge-prepare.cmd.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { prepareJudgeEvidenceUseCase } from "../../application/routing/prepare-judge-evidence.js";
 import { preconditionViolationError } from "../../domain/errors/precondition-violation.error.js";
 import { sliceLabelFor } from "../../domain/helpers/branch-naming.js";
+import { detectDefaultBranch } from "../../domain/helpers/default-branch.js";
 import { resolveBaseBranch } from "../../domain/helpers/slice-resolvers.js";
 import type { DiffReader } from "../../domain/ports/diff-reader.port.js";
 import type { SliceMergeLookup } from "../../domain/ports/slice-merge-lookup.port.js";
@@ -140,8 +141,7 @@ export const routingJudgePrepareCmd = async (
 		}
 
 		// Resolve merge branches: slice's resolved base branch, plus default branch.
-		// TODO: detect default from `git symbolic-ref refs/remotes/origin/HEAD`.
-		const defaultBranch = "main";
+		const defaultBranch = await detectDefaultBranch(runGit, { cwd: projectRoot });
 		let baseBranch: string;
 		try {
 			baseBranch = resolveBaseBranch(sliceEntity.data, milestone);

--- a/src/domain/helpers/default-branch.ts
+++ b/src/domain/helpers/default-branch.ts
@@ -1,0 +1,38 @@
+/**
+ * Detect the repository's default branch name.
+ *
+ * Best-effort, never throws. Tries (in order):
+ *   1. `git symbolic-ref refs/remotes/origin/HEAD --short` → strip `origin/`.
+ *   2. `git config --get init.defaultBranch`.
+ *   3. Fallback to "main".
+ */
+
+export type RunGit = (cmd: string, args: string[], opts: { cwd: string }) => Promise<string>;
+
+export const detectDefaultBranch = async (
+	runGit: RunGit,
+	opts: { cwd: string },
+): Promise<string> => {
+	try {
+		const out = await runGit("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"], opts);
+		const trimmed = out.trim();
+		if (trimmed.startsWith("origin/")) {
+			const name = trimmed.slice("origin/".length).trim();
+			if (name.length > 0) return name;
+		} else if (trimmed.length > 0) {
+			return trimmed;
+		}
+	} catch {
+		// Fall through to next strategy.
+	}
+
+	try {
+		const out = await runGit("git", ["config", "--get", "init.defaultBranch"], opts);
+		const trimmed = out.trim();
+		if (trimmed.length > 0) return trimmed;
+	} catch {
+		// Fall through to final fallback.
+	}
+
+	return "main";
+};

--- a/tests/unit/domain/helpers/default-branch.spec.ts
+++ b/tests/unit/domain/helpers/default-branch.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { detectDefaultBranch, type RunGit } from "../../../../src/domain/helpers/default-branch.js";
+
+const opts = { cwd: "/tmp/repo" };
+
+describe("detectDefaultBranch", () => {
+	it("returns symbolic-ref result stripped of origin/ prefix", async () => {
+		const runGit: RunGit = vi.fn(async () => "origin/main\n");
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("main");
+		expect(runGit).toHaveBeenCalledWith(
+			"git",
+			["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+			opts,
+		);
+	});
+
+	it("returns master when symbolic-ref returns origin/master", async () => {
+		const runGit: RunGit = vi.fn(async () => "origin/master\n");
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("master");
+	});
+
+	it("trims whitespace from symbolic-ref output", async () => {
+		const runGit: RunGit = vi.fn(async () => "  origin/develop  \n");
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("develop");
+	});
+
+	it("falls back to git config init.defaultBranch when symbolic-ref throws", async () => {
+		const runGit: RunGit = vi.fn(async (_cmd, args) => {
+			if (args[0] === "symbolic-ref") {
+				throw new Error("no upstream");
+			}
+			return "trunk\n";
+		});
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("trunk");
+		expect(runGit).toHaveBeenCalledWith("git", ["config", "--get", "init.defaultBranch"], opts);
+	});
+
+	it("falls back to 'main' when both symbolic-ref and config throw", async () => {
+		const runGit: RunGit = vi.fn(async () => {
+			throw new Error("git failure");
+		});
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("main");
+	});
+
+	it("falls back to 'main' when symbolic-ref returns empty/whitespace output", async () => {
+		const runGit: RunGit = vi.fn(async (_cmd, args) => {
+			if (args[0] === "symbolic-ref") return "   \n";
+			throw new Error("no init.defaultBranch");
+		});
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("main");
+	});
+
+	it("falls back to config when symbolic-ref returns empty", async () => {
+		const runGit: RunGit = vi.fn(async (_cmd, args) => {
+			if (args[0] === "symbolic-ref") return "";
+			return "develop\n";
+		});
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("develop");
+	});
+
+	it("falls back to 'main' when config returns empty", async () => {
+		const runGit: RunGit = vi.fn(async (_cmd, args) => {
+			if (args[0] === "symbolic-ref") throw new Error("nope");
+			return "\n";
+		});
+		await expect(detectDefaultBranch(runGit, opts)).resolves.toBe("main");
+	});
+});


### PR DESCRIPTION
## Summary
Replaces the hardcoded \`defaultBranch = "main"\` in \`routing:judge-prepare\` with a fallback chain: \`git symbolic-ref refs/remotes/origin/HEAD --short\` → \`git config init.defaultBranch\` → \`"main"\`.

Helper never throws — every git invocation in try/catch; default detection is advisory.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test\` — 1819 passing (+8 new helper tests)
- [ ] Manual: run on a repo using \`master\` — judge-prepare correctly identifies it