### PR TITLE
fix(workflows): make plannotator gate explicit and unskippable

### DIFF
--- a/workflows/debug.md
+++ b/workflows/debug.md
@@ -40,6 +40,8 @@ exploration, spawn Explore subagents ∧ reason about their findings.
    - Write to `.tff-cc/debug/<D-label>/PLAN.md`
 9. HAND OFF to standard pipeline:
    - invoke plan-slice workflow from step 8 (Plannotator Review) onward
+   - **step 8 is a REQUIRED gate** per `skills/plannotator-usage/SKILL.md` — do NOT skip,
+     even for S-tier debug fixes; if plannotator is unavailable, surface to user ∧ pause
    - then: execute-slice → verify-slice → ship-slice (standard workflows)
 
 Debug Phase 2 is an entry point, ¬ a parallel pipeline. Always standalone (kind=debug).

--- a/workflows/plan-slice.md
+++ b/workflows/plan-slice.md
@@ -73,9 +73,14 @@ Issues → revise plan
 DISPATCH anonymous reviewer via Agent tool (prompt: @skills/brainstorming/SKILL.md § Plan Document Reviewer)
 Issues → fix, re-dispatch (max 3)
 
-### 8. Plannotator Review
+### 8. Plannotator Review (REQUIRED gate)
+**REQUIRED — do NOT proceed past this step until annotations are resolved.**
+This is a hard dependency per `skills/plannotator-usage/SKILL.md` (no terminal fallback).
+
 invoke Skill `plannotator-annotate` with arg `.tff-cc/milestones/<milestone>/slices/<id>/PLAN.md`
-feedback → revise ∨ approved → continue
+- feedback → revise the artifact, re-invoke
+- approved (no annotations ∨ all resolved) → continue
+- skipping this step is ¬ allowed; if plannotator is unavailable, surface to user ∧ pause
 
 ### 9. Worktree + Transition
 `tff-tools worktree:create --slice-id <id>`
@@ -90,6 +95,6 @@ After completing all steps above:
 1. READ `.tff-cc/settings.yaml` → check `autonomy.mode`
 2. IF `plan-to-pr`:
    - Non-gate steps: IMMEDIATELY invoke the next workflow — do NOT ask user
-   - Human gates (plan approval, spec approval, completion): pause ∧ ask
+   - Human gates (plan approval, spec approval, completion, **plannotator review**): pause ∧ ask
 3. IF `guided`: suggest next step with `/tff:<command>`, wait for user
 4. Log: `[tff] <slice-id>: planning → executing`

--- a/workflows/quick.md
+++ b/workflows/quick.md
@@ -24,6 +24,8 @@ git repo ∃
    - Write to `.tff-cc/quick/<Q-label>/PLAN.md`
 4. HAND OFF to standard pipeline:
    - invoke plan-slice workflow from step 8 (Plannotator Review) onward
+   - **step 8 is a REQUIRED gate** per `skills/plannotator-usage/SKILL.md` — do NOT skip,
+     even for S-tier quick fixes; if plannotator is unavailable, surface to user ∧ pause
    - then: execute-slice → verify-slice → ship-slice (standard workflows)
 
 Quick is an entry point, ¬ a parallel pipeline. Always standalone (kind=quick).

--- a/workflows/verify-slice.md
+++ b/workflows/verify-slice.md
@@ -9,7 +9,14 @@ LOAD @skills/verification-before-completion/SKILL.md
 ## Steps
 1. LOAD @skills/acceptance-criteria-validation/SKILL.md → SPAWN subagent: {acceptance_criteria from PLAN.md}
    - Verify each criterion against implementation
-2. FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff-cc/milestones/<milestone>/slices/<slice-id>/VERIFICATION.md`
+2. Plannotator Review (REQUIRED gate)
+   **REQUIRED — do NOT proceed past this step until annotations are resolved.**
+   This is a hard dependency per `skills/plannotator-usage/SKILL.md` (no terminal fallback).
+
+   FINDINGS → invoke Skill `plannotator-annotate` with arg `.tff-cc/milestones/<milestone>/slices/<slice-id>/VERIFICATION.md`
+   - feedback → revise the artifact, re-invoke
+   - approved (no annotations ∨ all resolved) → continue
+   - skipping this step is ¬ allowed; if plannotator is unavailable, surface to user ∧ pause
 3. VERDICT:
    - PASS → `tff-tools slice:transition --slice-id <id> --status reviewing`
      CHECK: `ok` = true → suggest `/tff:ship` | `ok` = false → warn user, offer retry ∨ abort


### PR DESCRIPTION
Closes #150.

## Summary
Reworded the plannotator-annotate step in 4 workflows to be imperative and explicitly **REQUIRED**, with an unambiguous "skipping is ¬ allowed" clause. The original wording in \`plan-slice.md\` step 8 looked like steps 6/7 (review-agent dispatches that can be skipped for SS slices), letting the model rationalize away the entire review block.

## Files
- \`workflows/plan-slice.md\` — step 8 reworded; \`plannotator review\` added to the auto-transition human-gate list
- \`workflows/verify-slice.md\` — step 2 reworded
- \`workflows/quick.md\` — hand-off line reinforced with "do NOT skip even for S-tier"
- \`workflows/debug.md\` — same reinforcement

## Why markdown-only
Issue #150 also suggested a CLI-level guard (\`slice:transition --status executing\` blocked when no annotation exists). Deferred — costs more (requires plannotator integration to know what counts as "annotated"), and the wording fix should solve the immediate problem. Reserve as a follow-up if the wording fix doesn't stick.

## Gaps surfaced (not fixed — separate issues if you want them filed)
1. **research-slice.md and discuss-slice.md don't invoke plannotator at all** — yet \`skills/plannotator-usage/SKILL.md\` says REQUIREMENTS.md is Required for both. Either the workflows are missing the step, or the skill table uses the wrong artifact name (workflows produce RESEARCH.md and SPEC.md).
2. **SPEC.md is never annotated** despite being marked Required during /tff:plan.
3. **Auto-Transition section format varies** across workflows (explicit gate list vs \`¬HUMAN_GATE\` placeholder).

## Test plan
- [ ] Manual: run \`/tff:plan\` on a slice — verify step 8 is no longer skipped silently
- [ ] Manual: run \`/tff:verify\` — same check on step 2