### PR TITLE
fix(workflows): add plannotator gate for SPEC.md in discuss-slice

### DIFF
--- a/skills/plannotator-usage/SKILL.md
+++ b/skills/plannotator-usage/SKILL.md
@@ -1,24 +1,25 @@
 ---
 name: plannotator-usage
-description: "Use when invoking plannotator for approval review of generated .tff-cc milestone artifacts (plan, verification, requirements, spec)."
+description: "Use when invoking plannotator for approval review of generated .tff-cc milestone artifacts (plan, verification, spec)."
 ---
 
 # Plannotator Usage
 
 ## When to Use
 
-∀ workflows that generate a `.md` artifact under `.tff-cc/milestones/` (except STATE.md).
+∀ workflows that generate a load-bearing `.md` artifact under `.tff-cc/milestones/` or `.tff-cc/{quick,debug}/`.
 
 ## Integration Points
 
 | Artifact | Workflow | Command | Notes |
 |---|---|---|---|
+| SPEC.md | /tff:discuss | invoke Skill `plannotator-annotate` with artifact path | Required |
 | PLAN.md | /tff:plan, /tff:quick, /tff:debug | invoke Skill `plannotator-annotate` with artifact path | Required |
 | VERIFICATION.md | /tff:verify | invoke Skill `plannotator-annotate` with artifact path | Required |
-| REQUIREMENTS.md | /tff:research, /tff:discuss | invoke Skill `plannotator-annotate` with artifact path | Required |
-| SPEC.md / design docs | /tff:plan (when generated) | invoke Skill `plannotator-annotate` with artifact path | Required |
 
-**Excluded:** STATE.md — sync artifact, not a human-reviewed document.
+**Excluded:**
+- STATE.md — sync artifact, not a human-reviewed document.
+- RESEARCH.md (/tff:research) — intermediate notes, ¬ a terminal artifact; downstream review happens on PLAN.md.
 
 ∀ points: opens interactive UI → user annotates → feedback returns to stdout → agent processes
 

--- a/skills/skill-baselines.json
+++ b/skills/skill-baselines.json
@@ -62,10 +62,10 @@
       "sha256": "3c94e0a6ca401a07f3deca43eb632580cc4a9a1a1aefb539ea91d36df729a281"
     },
     "plannotator-usage": {
-      "approvedAt": "2026-04-21T21:40:30.878Z",
+      "approvedAt": "2026-04-30T13:30:00.000Z",
       "originalCommitSha": "12d32cd",
       "refinementId": null,
-      "sha256": "e363e1a8d43aa22a8cc41fa165e53f53128a6ca0f147e198cea600e1556ba600"
+      "sha256": "b485a3974ab2a21f759faaefc09664215a1ceedea8f6901ceb3d27b388ec6fdf"
     },
     "receiving-code-review": {
       "approvedAt": "2026-04-21T21:40:30.878Z",

--- a/workflows/discuss-slice.md
+++ b/workflows/discuss-slice.md
@@ -34,7 +34,7 @@ LOAD @skills/brainstorming/SKILL.md
 ### 3. Write Spec
 WRITE `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md` w/ validated design
 
-### 4. Challenge Spec (SSS only — determined ∈ step 8)
+### 4. Challenge Spec (SSS only — determined ∈ step 9)
 LOAD @skills/stress-testing-specs/SKILL.md → SPAWN subagent: {spec_content}
 REVISE → critical issues → loop Phase 3 (max 2) ∨ escalate
 APPROVE → note concerns ∈ spec, proceed
@@ -47,10 +47,19 @@ LOAD @skills/acceptance-criteria-validation/SKILL.md → SPAWN subagent: {spec_c
 DISPATCH anonymous reviewer via Agent tool (prompt: @skills/brainstorming/SKILL.md)
 Issues → fix, re-dispatch (max 3)
 
-### 7. User Gate
+### 7. Plannotator Review (REQUIRED gate)
+**REQUIRED — do NOT proceed past this step until annotations are resolved.**
+This is a hard dependency per `skills/plannotator-usage/SKILL.md` (no terminal fallback).
+
+invoke Skill `plannotator-annotate` with arg `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md`
+- feedback → revise the artifact, re-invoke
+- approved (no annotations ∨ all resolved) → continue
+- skipping this step is ¬ allowed; if plannotator is unavailable, surface to user ∧ pause
+
+### 8. User Gate
 Ask user: "Spec at `.tff-cc/milestones/<milestone>/slices/<id>/SPEC.md`. Approve?"
 
-### 8. Classify Complexity
+### 9. Classify Complexity
 Based on what was learned during discuss, build `ComplexitySignals`:
 - `estimatedFilesAffected`, `newFilesCreated`, `modulesAffected`
 - `requiresInvestigation`, `architectureImpact`, `hasExternalIntegrations`
@@ -65,7 +74,7 @@ PRESENT result to user, asking inline:
 User confirms → `tff-tools slice:classify` records tier.
 If SSS confirmed → run step 4 (Challenge Spec) now if ¬ already done.
 
-### 9. Transition
+### 10. Transition
 tier = S → `tff-tools slice:transition --slice-id <id> --status planning` (skip research)
 tier = SS ∨ SSS → `tff-tools slice:transition --slice-id <id> --status researching`
 CHECK: `ok` = true → continue | `ok` = false → warn user, offer retry ∨ abort


### PR DESCRIPTION
Closes #154.

## Resolution
**Option A for SPEC.md** (bring the workflow up to the contract) + **Option C for RESEARCH.md** (drop it from the contract). RESEARCH.md is intermediate notes; downstream review happens on PLAN.md, so a separate annotation round adds friction without much signal.

## Changes

### \`workflows/discuss-slice.md\`
- New step 7: \`Plannotator Review (REQUIRED gate)\` between Spec Review (6) and User Gate (now 8). Same imperative REQUIRED-gate language used in PR #153.
- Subsequent steps renumbered: User Gate → 8, Classify → 9, Transition → 10.
- Step 4's cross-reference (\`SSS only — determined ∈ step 8\`) updated to step 9.

### \`skills/plannotator-usage/SKILL.md\`
- Removed REQUIREMENTS.md row (no such artifact existed).
- Removed SPEC.md \`when generated\` qualifier — it's always generated by \`/tff:discuss\`; the qualifier was the loophole that let plan-slice off the hook.
- Mapped SPEC.md to \`/tff:discuss\` (where it's actually written).
- Added explicit excluded-list entry for RESEARCH.md with rationale.
- Description tightened to drop the \"requirements\" reference.

### \`skills/skill-baselines.json\`
- Updated \`plannotator-usage\` hash + approvedAt for the content change above (governance baseline).

## Out of scope (left for a separate pass)
- Auto-Transition section format inconsistency (\`plan-slice.md\` enumerates human gates; \`verify-slice.md\` uses \`¬HUMAN_GATE\` placeholder). Already flagged in #154 as out-of-scope.

## Test plan
- [x] \`bun run test\` — 1845 passing, 2 skipped (skill-baseline integrity test passes after manifest update)
- [x] \`bun run typecheck\` clean
- [ ] Manual: run \`/tff:discuss\` on a new slice — verify step 7 fires with plannotator-annotate on SPEC.md before user gate