### PR TITLE
feat(skill): add security-review skill cherry-picked from Sentry

### DIFF
--- a/agents/tff-security-auditor.md
+++ b/agents/tff-security-auditor.md
@@ -24,6 +24,7 @@ All code inspection is performed under the provided worktree path.
 Security review ∀PR — blocks on critical ∧ high findings.
 
 ## Skills Loaded
+- @skills/security-review/SKILL.md
 - @references/security-baseline.md
 
 ## Fresh-Reviewer Rule

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: security-review
+description: "Use when running security review on a diff/PR/file. Research-vs-Reporting discipline, three-tier confidence gate, attacker-controllable taxonomy."
+---
+
+# Security Review
+
+## When to Use
+
+∀ security review (slice ship, milestone audit, ad-hoc `/security-review`). Pairs with @references/security-baseline.md (STRIDE / OWASP Top 10).
+
+## HARD-GATE: Research vs Reporting
+
+**Report on**: only the file/diff/code provided.
+**Research**: the entire codebase to build confidence before reporting.
+
+¬report findings on pattern matching alone. ∀ candidate finding:
+1. Trace data flow source -> sink
+2. Check sanitization, validation, framework defenses ∈ between
+3. Confirm the source is attacker-controllable
+4. Only then: report
+
+A grep hit is a hypothesis, not a finding.
+
+## Three-Tier Confidence Gate
+
+```
+HIGH    -> report as [VULN-NNN]: clear exploit, attacker-controlled source reaches dangerous sink
+MEDIUM  -> note as [VERIFY-NNN]: plausible but unconfirmed; needs human review
+LOW     -> do NOT report: theoretical, framework-mitigated, or speculative
+```
+
+Confidence is orthogonal to severity. A HIGH-confidence Minor still ships as `[VULN-NNN]`. A MEDIUM-confidence Critical ships as `[VERIFY-NNN]` with explicit "reason for uncertainty".
+
+| Confidence | Required evidence |
+|---|---|
+| HIGH | Source traced to attacker input ∧ sink reached unsanitized ∧ exploit path articulable |
+| MEDIUM | Suspicious pattern ∧ ¬able to fully trace ∨ framework defense unclear |
+| LOW | Pattern only; no traced flow; framework likely mitigates |
+
+## Source Taxonomy
+
+The single most important question: **is the source attacker-controllable?**
+
+| Attacker-controlled (UNSAFE) | Server-controlled (SAFE) |
+|---|---|
+| HTTP request body / query / params | Hardcoded constants ∈ source |
+| HTTP headers / cookies | `process.env.X` / config files / settings module |
+| URL path segments | Database rows written by trusted code only |
+| File uploads (name, content, MIME) | Internal service calls (authenticated, mutual TLS) |
+| WebSocket message payloads | Compile-time string literals |
+| User-supplied filenames or paths | Build-time generated assets |
+| External webhook payloads | Output of cryptographic primitives on safe input |
+| Browser-supplied JWT claims (¬ verified) | Verified-then-trusted JWT claims |
+
+Contrast:
+
+```ts
+// UNSAFE — req.query.url is attacker-controlled
+await fetch(req.query.url);
+
+// SAFE — config.UPSTREAM_URL is server-controlled
+await fetch(config.UPSTREAM_URL);
+```
+
+A SAFE source can become UNSAFE if reachable by an attacker upstream (e.g. DB row written by user input). Trace one hop further when in doubt.
+
+## Quick Patterns Reference
+
+### Always Flag — Critical
+
+```
+raw SQL with string concat / template:           `query("SELECT ... " + x)`
+eval / Function constructor on dynamic input:    `eval(x)`, `new Function(x)`
+child_process.exec / spawn shell with user input
+deserialize untrusted (pickle, YAML.load, Marshal)
+secrets ∈ committed code (keys, tokens, passwords)
+SSRF: fetch/http on user-supplied URL ¬allowlisted
+path traversal: `fs.readFile(req.params.x)` w/o normalize+contain
+```
+
+### Always Flag — High
+
+```
+hardcoded JWT secret / signing key
+missing CSRF token on state-changing route (non-API ∨ cookie auth)
+unauthenticated admin / internal endpoint
+plaintext password storage ∨ weak hash (md5, sha1, unsalted)
+weak crypto (DES, RC4, ECB mode, predictable IV)
+authz check missing ∈ object access (IDOR shape)
+open redirect on user-supplied URL
+```
+
+### Always Flag — Secrets (regex-shaped)
+
+```
+aws_access_key_id\s*=\s*AKIA[0-9A-Z]{16}
+-----BEGIN (RSA |EC |OPENSSH |)PRIVATE KEY-----
+ghp_[A-Za-z0-9]{36}
+xox[baprs]-[A-Za-z0-9-]{10,}
+sk-[A-Za-z0-9]{32,}
+postgres(ql)?:\/\/[^:]+:[^@]+@
+```
+
+### Check Context First — FLAG vs SAFE
+
+| Pattern | FLAG when | SAFE when |
+|---|---|---|
+| `dangerouslySetInnerHTML` | input is user-controlled ∨ untrusted | input is markdown rendered server-side via sanitizing library |
+| `child_process.exec(cmd)` | `cmd` interpolates user input | `cmd` is a hardcoded literal ∨ uses execFile w/ argv array |
+| `pickle.loads(data)` / `YAML.load` | `data` came from network ∨ user | `data` came from trusted internal source ∨ test fixture |
+| `fs.readFile(path)` | `path` derives from request ¬ normalized + contained | `path` is a constant ∨ resolved against an allowlist |
+| `fetch(url)` server-side | `url` is user-supplied ¬ allowlisted | `url` is config-driven ∨ matched against host allowlist |
+| `redirect(target)` | `target` from query/body ¬ validated | `target` is internal route literal ∨ allowlist-matched |
+
+## Output Schema
+
+∀ finding: emit a block matching the template exactly. ¬prose between blocks.
+
+```
+## Findings
+
+### [VULN-001] <short title> — <Critical|High|Medium> severity
+**Location:** path/to/file.ts:42
+**Confidence:** HIGH
+**Issue:** one-paragraph description of the vulnerability
+**Impact:** what an attacker can do (concrete, not abstract)
+**Evidence:** code snippet showing the vulnerable flow (source -> sink)
+**Fix:** concrete remediation, ideally with diff
+
+### [VERIFY-002] <short title> — needs human review
+**Location:** path/to/file.ts:123
+**Confidence:** MEDIUM
+**Reason for uncertainty:** why we can't confirm (e.g. couldn't trace caller, framework defense unclear)
+**Suggested check:** what the human reviewer should look at
+```
+
+Severity vocabulary maps to @references/security-baseline.md (Critical / High / Medium / Low). Confidence (HIGH / MEDIUM / LOW) is orthogonal.
+
+If ∅ findings: emit `## Findings\n\nNo issues found at HIGH or MEDIUM confidence.`
+
+## Anti-Patterns
+
+- Reporting LOW-confidence findings to look thorough
+- Flagging a pattern w/o tracing data flow
+- Treating server-controlled sources as attacker-controlled (false positives)
+- Speculating about exploits without an articulable path
+- Reporting findings outside the diff scope (research is unbounded; reporting is not)
+- Conflating severity with confidence
+
+## Rules
+
+- ∀ finding: filepath:line required
+- ∀ HIGH-confidence finding: source -> sink trace ∈ Evidence
+- ∀ MEDIUM-confidence finding: explicit "Reason for uncertainty"
+- LOW confidence -> ¬report, ¬verify-block, ¬footnote
+- Report only on changed code; research the whole repo to confirm
+- Block PR on Critical ∨ High at HIGH confidence; advise on Medium
+
+## Future Work
+
+Per-class playbooks (SQLi, SSRF, XSS, deserialization, auth/session, crypto, secrets) and language guides (TS, Python) are out of scope for this skill. If recurring false positives ∨ misses surface, add `references/security-review/<class>.md` and link from here.

--- a/skills/skill-baselines.json
+++ b/skills/skill-baselines.json
@@ -79,6 +79,12 @@
       "refinementId": null,
       "sha256": "21699f5b6010940ccb1a048ad5fe152703d3d4873416d45c6770912b97b11457"
     },
+    "security-review": {
+      "approvedAt": "2026-04-30T13:45:00.000Z",
+      "originalCommitSha": "3c0e66c",
+      "refinementId": null,
+      "sha256": "3f401ce4f35c2cff634c730260fbdf605adb7e5dc23b5d68d20d498f285cc9db"
+    },
     "skill-authoring": {
       "approvedAt": "2026-04-29T00:00:00.000Z",
       "originalCommitSha": "12d32cd",


### PR DESCRIPTION
## Summary
tff-cc had no \`security-review\` skill — \`/tff:ship\` and \`/tff:complete-milestone\` invoked \`tff-security-auditor\` with only \`@references/security-baseline.md\` (STRIDE/OWASP) for guidance. This adds a methodology skill cherry-picked from [Sentry's open-source security-review skill](https://github.com/getsentry/skills/tree/main/skills/security-review) (Apache 2.0).

## What's new

### \`skills/security-review/SKILL.md\` (new, 162 lines)
Five patterns adopted from Sentry, translated into tff-cc's compact style:

1. **Research-vs-Reporting hard gate** — report only on the diff, but research the whole codebase to confirm exploitability. \"A grep hit is a hypothesis, not a finding.\"
2. **Three-tier confidence gate** (HIGH/MEDIUM/LOW → report/note/skip). Orthogonal to severity. HIGH-confidence Minor still ships as \`[VULN]\`; MEDIUM-confidence Critical ships as \`[VERIFY]\` with \"reason for uncertainty\".
3. **Attacker-controlled vs server-controlled source taxonomy** — 8 examples per column with a contrasting code snippet (\`fetch(req.query.url)\` UNSAFE vs \`fetch(config.UPSTREAM_URL)\` SAFE).
4. **Quick Patterns Reference** — always-flag (critical/high/secrets blocklists) + a FLAG-vs-SAFE context table for ambiguous patterns (\`dangerouslySetInnerHTML\`, \`exec()\`, \`pickle.loads\`, etc.).
5. **Strict output schema** — \`[VULN-NNN]\` and \`[VERIFY-NNN]\` blocks with required fields (Location, Confidence, Issue, Impact, Evidence, Fix / Reason for uncertainty + Suggested check).

### \`agents/tff-security-auditor.md\`
Loads the new skill alongside the existing security-baseline reference. **This is what makes the methodology actually fire** during \`/tff:ship\` and \`/tff:complete-milestone\`.

### \`skills/skill-baselines.json\`
New manifest entry for governance invariant.

## Deliberately omitted
- **Per-vulnerability-class playbooks** (Sentry has 18 — injection, ssrf, xss, deserialization, etc.). Defer to a follow-up if recurring false positives or misses surface; \`Future Work\` section in the skill marks this.
- **Language-specific guides** — Sentry's are Django/Flask/React/Vue-heavy; tff-cc is TS-heavy with different framework defenses. Out of scope until needed.
- **Infrastructure guides** — irrelevant scope for tff-cc.

## Test plan
- [x] \`bun run test\` — 1845 passing (governance invariant satisfied)
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [ ] Manual: trigger \`/tff:ship\` on a small slice — verify tff-security-auditor's review output uses the \`[VULN-NNN]\` schema and applies the confidence gate

## Attribution
Patterns adopted from getsentry/skills/security-review (Apache 2.0). The Sentry skill itself is not vendored — only its conceptual model is translated into tff-cc's notation. Source URL referenced in the commit message.