### PR TITLE
fix(workflows): add manual dispatch to recover from missed release sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sync_release_branch:
+        description: "Force-push the release branch from current HEAD (recovery for missed sync)."
+        type: boolean
+        default: true
+      publish_npm:
+        description: "Run bun publish (will fail if the version already exists on npm)."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -43,13 +53,13 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && inputs.publish_npm) }}
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun publish --access public
 
       - name: Sync release branch
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created || (github.event_name == 'workflow_dispatch' && inputs.sync_release_branch) }}
         run: bash scripts/sync-release-branch.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The 0.9.18 GitHub release exists, but the `release` branch never got force-pushed, so consumers pinned to `ref: release` (via `marketplace.json`) are stuck on 0.9.17.
- Root cause: `Publish to npm` and `Sync release branch` are gated on `steps.release.outputs.release_created`. When two release-workflow runs race on the auto-merge of a release-PR (one run tags the release, the next run sees it already exists), `release_created` comes back falsy on the run that fires for the release-merge commit, so both gated steps get skipped.
- Add a `workflow_dispatch` trigger with `sync_release_branch` (default true) and `publish_npm` (default false) inputs, and broaden the `if:` on each step so a manual dispatch can run them. One-click recovery instead of relaxing the script's CI guard locally.

## Recovery for 0.9.18 once this is merged

1. Actions → **Release** → **Run workflow** on `main`.
2. Leave `sync_release_branch=true`, `publish_npm=false`.
3. Confirm the `release` branch tip changes from `6da5c5cc` (snapshot from `5eb49a4` / 0.9.17) to a snapshot from `98ec0759` / 0.9.18.
4. Verify `claude /plugin update tff-cc` picks up 0.9.18.
5. Separately check whether `tff-cc@0.9.18` made it to npm — if not, dispatch again with `publish_npm=true`.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger `workflow_dispatch` with defaults; verify `Sync release branch` runs and the release branch is updated.
- [ ] Verify `Publish to npm` is still skipped (default `publish_npm=false`).
- [ ] Verify the normal push-to-main flow is unchanged: `release_created=true` still triggers both steps; `release_created=false` still skips them.