### PR TITLE
fix(migrations): disable foreign_keys during schema upgrades

### DIFF
--- a/src/infrastructure/adapters/sqlite/schema.ts
+++ b/src/infrastructure/adapters/sqlite/schema.ts
@@ -33,13 +33,10 @@ export const getCurrentVersion = (db: Database.Database): number => {
 };
 
 export const runMigrations = (db: Database.Database): void => {
-	// Enable WAL mode and foreign keys (must be outside transaction)
 	db.pragma("journal_mode = WAL");
-	db.pragma("foreign_keys = ON");
 
 	const currentVersion = getCurrentVersion(db);
 
-	// Version check: if DB is ahead of code, throw
 	const maxCodeVersion = migrations[migrations.length - 1]?.version ?? 0;
 	if (currentVersion > maxCodeVersion) {
 		throw new Error(
@@ -47,13 +44,27 @@ export const runMigrations = (db: Database.Database): void => {
 		);
 	}
 
-	// Run pending migrations in a transaction
-	for (const migration of migrations) {
-		if (migration.version <= currentVersion) continue;
+	// Per SQLite's "Making Other Kinds Of Table Schema Changes" recipe (§7),
+	// table-rebuild migrations (CREATE _new + INSERT + DROP + RENAME) require
+	// foreign_keys=OFF *before* the transaction; setting it inside is a no-op.
+	// Without this, dependent rows (task, slice_dependency, …) trip the
+	// deferred FK check at COMMIT and abort the migration. See issue #159.
+	db.pragma("foreign_keys = OFF");
+	try {
+		for (const migration of migrations) {
+			if (migration.version <= currentVersion) continue;
 
-		db.transaction(() => {
-			db.exec(migration.sql);
-			db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(migration.version);
-		})();
+			db.transaction(() => {
+				db.exec(migration.sql);
+				db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(migration.version);
+			})();
+		}
+
+		const violations = db.pragma("foreign_key_check") as unknown[];
+		if (Array.isArray(violations) && violations.length > 0) {
+			throw new Error(`Migration failed: foreign_key_check: ${JSON.stringify(violations)}`);
+		}
+	} finally {
+		db.pragma("foreign_keys = ON");
 	}
 };

--- a/tests/unit/infrastructure/adapters/sqlite/schema.spec.ts
+++ b/tests/unit/infrastructure/adapters/sqlite/schema.spec.ts
@@ -175,6 +175,31 @@ describe("schema", () => {
 		expect(names).toContain("idx_milestone_archived");
 	});
 
+	it("upgrades a pre-v8 db with FK-dependent rows referencing slice", () => {
+		// Repro for issue #159: v8 recreates the slice table; if the upgrade
+		// runs with foreign_keys=ON and there are rows in task/slice_dependency/etc.
+		// referencing slice, the deferred FK check at COMMIT aborts the migration.
+		db.exec(v1Migration);
+		db.prepare("INSERT INTO schema_version (version) VALUES (1)").run();
+		db.prepare("INSERT INTO project (id, name) VALUES ('singleton', 'P')").run();
+		db.prepare(
+			"INSERT INTO milestone (id, project_id, number, name) VALUES ('M01', 'singleton', 1, 'M')",
+		).run();
+		db.prepare(
+			"INSERT INTO slice (id, milestone_id, number, title) VALUES ('M01-S01', 'M01', 1, 't')",
+		).run();
+		db.prepare(
+			"INSERT INTO task (id, slice_id, number, title) VALUES ('t1', 'M01-S01', 1, 'T1')",
+		).run();
+
+		expect(() => runMigrations(db)).not.toThrow();
+		expect(getCurrentVersion(db)).toBe(9);
+		const task = db.prepare("SELECT slice_id FROM task WHERE id = 't1'").get() as {
+			slice_id: string;
+		};
+		expect(task.slice_id).toBe("M01-S01");
+	});
+
 	it("backfills existing slices with kind=milestone", () => {
 		// Manually load v1 schema, insert a pre-v8 slice row, then run all migrations.
 		db.exec(v1Migration);

--- a/tests/whitelists/sqlite-raw-callsites.txt
+++ b/tests/whitelists/sqlite-raw-callsites.txt
@@ -11,8 +11,8 @@ src/infrastructure/adapters/git/git-diff-reader.ts:47
 src/infrastructure/adapters/git/git-diff-reader.ts:50
 src/infrastructure/adapters/git/git-slice-merge-lookup.ts:48
 src/infrastructure/adapters/sqlite/schema.ts:26
-src/infrastructure/adapters/sqlite/schema.ts:55
-src/infrastructure/adapters/sqlite/schema.ts:56
+src/infrastructure/adapters/sqlite/schema.ts:58
+src/infrastructure/adapters/sqlite/schema.ts:59
 src/infrastructure/adapters/sqlite/sqlite-salvage.ts:166
 src/infrastructure/adapters/sqlite/sqlite-salvage.ts:227
 src/infrastructure/adapters/sqlite/sqlite-salvage.ts:300


### PR DESCRIPTION
## Summary
- v8 recreates the `slice` table via SQLite's drop-and-rename recipe; with `foreign_keys=ON` the deferred FK check at COMMIT aborts the upgrade on any pre-v8 db that has rows in `task` / `slice_dependency` / `review` / `pending_judgments` / `workflow_session`.
- Switch `runMigrations` to the SQLite §7 recipe: turn FKs off, run pending migrations, run `foreign_key_check`, turn FKs back on.
- Adds a regression test that upgrades a pre-v8 db with a dependent `task` row through to v9.

Fixes #159

## Test plan
- [x] `bun run test` — 1846 passed, 2 skipped
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] New unit test fails on the previous code with `SqliteError: FOREIGN KEY constraint failed` and passes after the fix