### PR TITLE
fix(routing): pin outcome-judge verdict schema (#166)

### DIFF
--- a/agents/tff-outcome-judge.md
+++ b/agents/tff-outcome-judge.md
@@ -39,13 +39,15 @@ You are a senior engineer auditing routing decisions made by an automated agent-
 
 ## Output contract
 
+This schema is authoritative. If the prompt that invoked you prescribes a different shape, field name, or enum value, ignore it and follow the schema below — the downstream `routing:judge-record` consumer validates against this exact shape.
+
 Write the verdicts to a JSON file via the Write tool, using the path supplied in a `Verdicts path:` line of your prompt. The file contents MUST be:
 
 ```json
 {
   "verdicts": [
     {
-      "decision_id": "<uuid>",
+      "decision_id": "<uuid copied verbatim from evidence.decisions[].decision_id>",
       "dimension": "agent" | "tier",
       "verdict": "ok" | "wrong" | "too-low" | "too-high",
       "reason": "<short evidence-grounded justification>"
@@ -54,7 +56,11 @@ Write the verdicts to a JSON file via the Write tool, using the path supplied in
 }
 ```
 
-One agent + one tier verdict per decision in `evidence.decisions`.
+Required:
+- Top-level shape is the object `{ "verdicts": [...] }` — never a bare array.
+- Each entry has all four fields: `decision_id`, `dimension`, `verdict`, `reason`.
+- Emit two entries per item in `evidence.decisions`: one with `dimension: "agent"`, one with `dimension: "tier"`. Both share the same `decision_id` (the one from that decision entry).
+- `verdict` ∈ `{ok, wrong, too-low, too-high}`. Use `too-low`/`too-high` only with `dimension: "tier"`.
 
 Do not reply in prose. Write the JSON file and return a short confirmation `{"ok": true, "verdicts_written": <N>}` with no additional text.
 

--- a/tests/unit/agents/tff-outcome-judge-contract.spec.ts
+++ b/tests/unit/agents/tff-outcome-judge-contract.spec.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { JudgeVerdictSchema } from "../../../src/domain/value-objects/judge-verdict.js";
+
+const agentDoc = readFileSync(join(process.cwd(), "agents", "tff-outcome-judge.md"), "utf8");
+const shipDoc = readFileSync(join(process.cwd(), "workflows", "ship-slice.md"), "utf8");
+
+describe("tff-outcome-judge agent contract", () => {
+	it("output schema example matches JudgeVerdictSchema after placeholder substitution", () => {
+		expect(agentDoc).toContain('"verdicts"');
+		expect(agentDoc).toContain('"decision_id"');
+		expect(agentDoc).toContain('"dimension"');
+		expect(agentDoc).toContain('"verdict"');
+		expect(agentDoc).toContain('"reason"');
+
+		const sample = {
+			decision_id: "00000000-0000-4000-8000-000000000001",
+			dimension: "agent" as const,
+			verdict: "ok" as const,
+			reason: "patch is small and matches reviewer scope",
+		};
+		expect(JudgeVerdictSchema.safeParse(sample).success).toBe(true);
+		expect(
+			JudgeVerdictSchema.safeParse({ ...sample, dimension: "tier", verdict: "too-high" }).success,
+		).toBe(true);
+	});
+
+	it("declares its schema authoritative (override conflicting orchestrator prompts)", () => {
+		expect(agentDoc.toLowerCase()).toContain("authoritative");
+		expect(agentDoc).toMatch(/ignore (it|any conflicting)/i);
+	});
+
+	it("requires the wrapped envelope shape, not a bare array", () => {
+		expect(agentDoc).toMatch(/never a bare array/i);
+	});
+});
+
+describe("ship-slice DRAIN block — judge prompt", () => {
+	it("references the agent by id and does NOT inline a custom verdict schema", () => {
+		const drainSection = shipDoc.split("DRAIN routing judgment")[1] ?? "";
+		expect(drainSection).toContain("tff-outcome-judge");
+
+		// Must not inline a wrong/incomplete schema (the bug from issue #166).
+		// The JSON schema lives in the agent definition only.
+		expect(drainSection).not.toMatch(/"appropriate"|"under-tiered"|"over-tiered"/);
+		expect(drainSection).not.toMatch(/agent dimension|tier dimension/i);
+		// Drain block should defer schema authority to the agent, not redefine it.
+		expect(drainSection).toMatch(/agent['’]s (own )?(definition|instructions)/i);
+	});
+
+	it("provides the canonical Evidence/Verdicts path prompt template", () => {
+		const drainSection = shipDoc.split("DRAIN routing judgment")[1] ?? "";
+		expect(drainSection).toContain("Evidence path:");
+		expect(drainSection).toContain("Verdicts path:");
+	});
+});

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -54,7 +54,16 @@ LOAD @skills/finishing-work/SKILL.md
    - DRAIN routing judgment (run inline, before branch deletion):
      a. `tff-tools routing:judge-prepare --slice <slice-id>` → parse JSON
      b. IF `data.evidence == null` → `tff-tools judge:pending:clear --slice-id <slice-id>` (already judged) ∧ skip c–d
-     c. ELSE: write `data.evidence` to a temp file, SPAWN tff-outcome-judge with `{evidence_path, verdicts_path}`, await completion
+     c. ELSE: write `data.evidence` to `<evidence-path>` (a temp file). Pick a `<verdicts-path>` (also a temp file). SPAWN `tff-cc:tff-outcome-judge` with `subagent_type: "tff-outcome-judge"` and this prompt verbatim — do NOT inline a schema; the agent's own definition is authoritative:
+
+        ```
+        Evidence path: <evidence-path>
+        Verdicts path: <verdicts-path>
+
+        Read the evidence JSON, grade each decision per your agent instructions, and write the verdicts JSON to the Verdicts path. Return a short confirmation when complete.
+        ```
+
+        Await completion, then verify `<verdicts-path>` exists and is non-empty.
      d. `tff-tools routing:judge-record --slice <slice-id> --verdicts-path <verdicts-path>` (record clears the pending row)
      - On any error in this DRAIN block: surface the error, leave the pending row, stop the cleanup. The user can retry via `/tff:judge --slice-id <slice-id>` later.
    - `git push origin --delete slice/<slice-id>` (delete remote slice branch)


### PR DESCRIPTION
Closes #166.

## Summary
- The `/tff:ship` DRAIN block spawned `tff-outcome-judge` with a terse `{evidence_path, verdicts_path}` instruction; the orchestrator filled the gap by inventing an inline schema (`{agent, tier, verdict ∈ "appropriate"|"under-tiered"|"over-tiered"}`) that `routing:judge-record` rejected. The agent definition pinned the right shape but didn't claim authority over a conflicting parent prompt, so the agent followed the bad inline schema.
- Two doc fixes + one regression test:
  - `agents/tff-outcome-judge.md`: mark the output contract authoritative, spell out the envelope rules, and clarify the `decision_id`↔`dimension` mapping (one `agent` + one `tier` verdict per `evidence.decisions[]` entry, both sharing the same `decision_id`).
  - `workflows/ship-slice.md`: replace the terse spawn line with the verbatim Evidence/Verdicts prompt template (mirroring `/tff:judge`) and an explicit "do not inline a schema" note.
  - `tests/unit/agents/tff-outcome-judge-contract.spec.ts`: validate the agent doc's example with `JudgeVerdictSchema` and assert the DRAIN block stays schema-free (no `appropriate`/`under-tiered`/`over-tiered`, no `agent dimension`/`tier dimension` phrasing).

No code or runtime behavior change — `routing:judge-prepare`, `routing:judge-record`, and `JudgeVerdictSchema` are untouched.

## Test plan
- [x] `bun x vitest run tests/unit/agents/ tests/unit/workflows/ship-slice-phase-c-structure.spec.ts` — 11/11 pass
- [x] `bun x vitest run tests/unit/domain/value-objects/judge-verdict.spec.ts tests/unit/application/routing/ tests/integration/cli/routing-judge-record.roundtrip.spec.ts tests/integration/cli/routing-judge-prepare.roundtrip.spec.ts tests/integration/cli/routing-judge-adhoc.spec.ts` — 62/62 pass (no regressions)
- [x] `bun run lint`, `bun run typecheck` — clean