### PR TITLE
fix(workflows): prescribe conventional-commit pr titles

### DIFF
--- a/references/conventions.md
+++ b/references/conventions.md
@@ -68,6 +68,18 @@ Special formats:
 - Artifact: `docs(S01): <summary>`
 - Rollback: `revert(S01/T03): <summary>`
 
+## PR Title Format
+
+PR titles become commit messages on `main` (via squash-merge). They MUST be conventional-commit
+so downstream automation (release-please, changelog generation) can parse them.
+
+- **Slice PR:** `<type>(S<NN>): <summary>` — e.g. `docs(S05): add e2e + README updates`.
+- **Milestone PR:** `<type>(M<NN>): <milestone-name>` — e.g. `feat(M01): rule discovery expansion`.
+- **Merge style:** ALWAYS squash-merge slice and milestone PRs. Merge-commit messages
+  (`Merge pull request #N from …`) are unparseable.
+
+Anti-pattern: `M01-S05: <summary>` (no `<type>`, no scope parentheses) — release-please skips it.
+
 ## Branch Discipline
 
 Agents and humans work on **slice branches only** while a milestone has open slices. Two guards enforce this:

--- a/skills/commit-conventions/SKILL.md
+++ b/skills/commit-conventions/SKILL.md
@@ -31,6 +31,18 @@ revert(auth/login): undo broken migration
 chore: update dependencies
 ```
 
+## PR Titles
+
+PR titles become the squash-merge commit on `main` — same conventional-commit rules apply:
+
+| Kind | Format | Example |
+|---|---|---|
+| Slice PR | `<type>(S<NN>): <summary>` | `feat(S03): /pi-rules doctor diagnostic CLI` |
+| Milestone PR | `<type>(M<NN>): <name>` | `feat(M01): rule discovery expansion` |
+
+Always squash-merge — never merge-commit. Merge-commit messages
+(`Merge pull request #N from …`) are non-conventional and break release tooling.
+
 ## Rules
 
 1. Atomic: 1 logical change/commit

--- a/skills/skill-baselines.json
+++ b/skills/skill-baselines.json
@@ -38,10 +38,10 @@
       "sha256": "c1720f0c6a706896dc2f6b0a10776cf05df73b551aee40383fcb578de64354a0"
     },
     "commit-conventions": {
-      "approvedAt": "2026-04-21T21:40:30.878Z",
+      "approvedAt": "2026-05-01T00:00:00.000Z",
       "originalCommitSha": "12d32cd",
       "refinementId": null,
-      "sha256": "12da5515dfe91329066e060d5e5be993e4c2e43cb5e267fdb702dea026de28f1"
+      "sha256": "666f616a9f6ccdce75bcb9d1149da483be64e6dbdfb2aaa13a3bd96c1f75be83"
     },
     "executing-plans": {
       "approvedAt": "2026-04-21T21:40:30.878Z",

--- a/workflows/complete-milestone.md
+++ b/workflows/complete-milestone.md
@@ -31,7 +31,13 @@ Context: @references/orchestrator-pattern.md ∧ @references/conventions.md
    - if ¬ merged → warn user, block milestone completion
 1a. PRE-CLOSE GATE: `tff-tools judge:pending:list --milestone-id <id>` must return `count: 0`.
     If non-zero, drain each via `/tff:judge --slice-id <slice-id>` before continuing — `milestone:close` will refuse otherwise (`PENDING_JUDGMENTS`).
-2. PR: `gh pr create` milestone/<milestone> → main — **ALWAYS show PR URL**
+2. PR: `gh pr create --title "<type>(M<NN>): <milestone-name>"` milestone/<milestone> → main
+   Title format = squash- *or* merge-commit message → MUST be conventional-commit.
+   - `<type>` = `feat` for capability-bearing milestones (the common case), else infer.
+   - When merging the milestone PR into main, **squash-merge** (not merge-commit) so the
+     conventional-commit title becomes the commit message on main. A merge-commit title
+     (`Merge pull request #N from …`) is unparseable by release-please.
+   **ALWAYS show PR URL**
 3. SPAWN tff-security-auditor: milestone-level review
 4. HANDLE: approved → inform ready to merge | changes → fix ∧ re-review
 

--- a/workflows/ship-slice.md
+++ b/workflows/ship-slice.md
@@ -33,7 +33,13 @@ LOAD @skills/finishing-work/SKILL.md
      model = <routing-decisions-json>[agent=tff-security-auditor].tier (fallback: no model param)
      inputs: {diff, @references/security-baseline.md}
    critical ∨ high → blocks PR → SPAWN tff-fixer → re-audit
-5. PR: `gh pr create` — `slice/<slice-id>` → `milestone/<milestone>`
+5. PR: `gh pr create --title "<type>(<scope>): <summary>"` — `slice/<slice-id>` → `milestone/<milestone>`
+   Title format = squash-merge commit message → MUST be conventional-commit so
+   release-please / changelog tooling can parse it once the milestone lands on main.
+   - `<type>` ∈ {feat, fix, refactor, docs, test, chore} — the dominant type of the slice's
+     work. Read it from SPEC.md if labeled; else infer from commit history of the slice.
+   - `<scope>` = `S<NN>` (e.g. `S05`). Anti-pattern: `M01-S05: …` — release-please rejects.
+   - Example: `docs(S05): document hot reload, per-user rules, doctor; add user-rules e2e`
    **Show PR URL to user**
 
 **tff NEVER merges — only creates PR.**


### PR DESCRIPTION
## Summary
- `ship-slice` and `complete-milestone` workflows now prescribe `<type>(<scope>): <summary>` PR titles so squash-merge commits on `main` are parseable by release-please.
- Adds matching guidance to `references/conventions.md` and `skills/commit-conventions/SKILL.md`.
- Re-approves the `commit-conventions` skill baseline for the new content hash.

Closes #169.

## Test plan
- [ ] Run `/tff:ship` on a slice and confirm the orchestrator emits a `<type>(S<NN>): …` PR title.
- [ ] Run `/tff:complete-milestone` and confirm the milestone PR title is `<type>(M<NN>): <name>`.
- [ ] Squash-merge a slice + milestone PR through to `main` and confirm release-please parses the commits (no "No user facing commits found" skip).