### PR TITLE
fix(cli): isolate TFF_CC_HOME sandbox from cwd (#172)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 *.tsbuildinfo
 .tff/
-.tff-cc/
+/.tff-cc
 .claude/
 docs/
 *.db

--- a/src/application/project/init-project.ts
+++ b/src/application/project/init-project.ts
@@ -46,7 +46,26 @@ export const initProject = async (
 	return Ok({ project: saveResult.data });
 };
 
-const REQUIRED_GITIGNORE_ENTRIES = [`${TFF_CC_DIR}/`, "build/"];
+// Root-anchored, no trailing slash: matches the toplevel `.tff-cc` whether it
+// is the canonical symlink, a real dir, or a regular file. The trailing-slash
+// form (`/.tff-cc/`) only matches directories, so it would silently fail to
+// ignore the symlink that `project:init` creates. Anchoring with `/` ensures
+// a stray `<some-dir>/.tff-cc/` (e.g., test pollution in a subdir) is NOT
+// hidden — it surfaces in `git status` instead of being masked.
+const REQUIRED_GITIGNORE_ENTRIES = [`/${TFF_CC_DIR}`, "build/"];
+
+function gitignoreLineSatisfies(line: string, entry: string): boolean {
+	const trimmed = line.trim();
+	if (trimmed === "" || trimmed.startsWith("#")) return false;
+	// Accept any of: `entry`, no-trailing-slash, no-leading-slash, both stripped.
+	const stripped = entry.replace(/^\//, "").replace(/\/$/, "");
+	return (
+		trimmed === entry ||
+		trimmed === entry.replace(/\/$/, "") ||
+		trimmed === stripped ||
+		trimmed === `${stripped}/`
+	);
+}
 
 async function ensureGitignored(artifactStore: ArtifactStore): Promise<void> {
 	const gitignorePath = ".gitignore";
@@ -59,8 +78,7 @@ async function ensureGitignored(artifactStore: ArtifactStore): Promise<void> {
 
 	const lines = existing.split("\n");
 	const missing = REQUIRED_GITIGNORE_ENTRIES.filter(
-		(entry) =>
-			!lines.some((line) => line.trim() === entry || line.trim() === entry.replace(/\/$/, "")),
+		(entry) => !lines.some((line) => gitignoreLineSatisfies(line, entry)),
 	);
 
 	if (missing.length === 0) return;

--- a/src/cli/commands/project-init.cmd.ts
+++ b/src/cli/commands/project-init.cmd.ts
@@ -3,7 +3,7 @@ import { isOk } from "../../domain/result.js";
 import { MarkdownArtifactAdapter } from "../../infrastructure/adapters/filesystem/markdown-artifact.adapter.js";
 import { GitCliAdapter } from "../../infrastructure/adapters/git/git-cli.adapter.js";
 import { createStateStores } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
-import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
+import { resolveProjectRoot, resolveRepoRoot } from "../../infrastructure/home-directory.js";
 import { installPostCheckoutHook } from "../../infrastructure/hooks/install-post-checkout.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
 
@@ -40,18 +40,24 @@ export const projectInitCmd = async (args: string[]): Promise<string> => {
 	const { name, vision } = parsed.data as { name: string; vision?: string };
 	const finalVision = vision || name;
 
-	const cwd = resolveRepoRoot(process.cwd());
+	const repoRoot = resolveRepoRoot(process.cwd());
+	const projectRoot = resolveProjectRoot(process.cwd());
 	// Note: .tff-cc/ symlink is created by getProjectId() called from createStateStores()
 	const { projectStore } = createStateStores();
-	const artifactStore = new MarkdownArtifactAdapter(cwd);
-	const _gitOps = new GitCliAdapter(cwd);
+	const artifactStore = new MarkdownArtifactAdapter(projectRoot);
+	const _gitOps = new GitCliAdapter(repoRoot);
 
 	const result = await initProject({ name, vision: finalVision }, { projectStore, artifactStore });
 	if (isOk(result)) {
-		try {
-			installPostCheckoutHook(cwd);
-		} catch {
-			// Hook installation is best-effort
+		// Skip writing into the surrounding worktree's `.git/hooks/` when
+		// running against an isolated TFF_CC_HOME sandbox — the hook is a
+		// real-repo concern and would leak into cwd otherwise.
+		if (!process.env.TFF_CC_HOME) {
+			try {
+				installPostCheckoutHook(repoRoot);
+			} catch {
+				// Hook installation is best-effort
+			}
 		}
 		return JSON.stringify({ ok: true, data: result.data });
 	}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,11 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { handleStartupRecovery } from "../application/recovery/handle-startup-recovery.js";
 import { NativeBindingError } from "../infrastructure/adapters/sqlite/native-binding-error.js";
-import { getProjectHome, getProjectId, resolveRepoRoot } from "../infrastructure/home-directory.js";
+import {
+	getProjectHome,
+	getProjectId,
+	resolveProjectRoot,
+} from "../infrastructure/home-directory.js";
 import { branchGuardCheckCmd, branchGuardCheckSchema } from "./commands/branch-guard-check.cmd.js";
 import { checkpointLoadCmd, checkpointLoadSchema } from "./commands/checkpoint-load.cmd.js";
 import { checkpointSaveCmd, checkpointSaveSchema } from "./commands/checkpoint-save.cmd.js";
@@ -425,8 +429,11 @@ function flagToJsonSchema(flag: {
 function resolveStartupHomeDir(): string {
 	const cwd = process.cwd();
 	try {
-		const repoRoot = resolveRepoRoot(cwd);
-		const projectId = getProjectId(repoRoot);
+		// resolveProjectRoot honors TFF_CC_HOME: when set, the id-file lives
+		// under TFF_CC_HOME and not in cwd, keeping isolated test sandboxes
+		// from leaking `.tff-project-id` into the surrounding worktree.
+		const projectRoot = resolveProjectRoot(cwd);
+		const projectId = getProjectId(projectRoot);
 		return getProjectHome(projectId);
 	} catch (err) {
 		process.stderr.write(

--- a/src/cli/utils/with-mutating-command.ts
+++ b/src/cli/utils/with-mutating-command.ts
@@ -8,7 +8,7 @@ import {
 	type ClosableStateStores,
 	createClosableStateStoresUnchecked,
 } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
-import { resolveRepoRoot } from "../../infrastructure/home-directory.js";
+import { resolveProjectRoot } from "../../infrastructure/home-directory.js";
 
 export const WITH_MUTATING_COMMAND_TAG = Symbol("with-mutating-command");
 
@@ -86,7 +86,7 @@ export const withMutatingCommand = (handler: Handler, deps?: WrapperDeps): Tagge
 		// Fire on attempt (after guards pass), not on handler success — the sentinel
 		// means "a mutating command reached the handler," which is what the first-
 		// observation probe needs.
-		touchMutatingSentinel(resolveRepoRoot(process.cwd()));
+		touchMutatingSentinel(resolveProjectRoot(process.cwd()));
 		return handler(args);
 	};
 

--- a/src/infrastructure/adapters/sqlite/create-state-stores.ts
+++ b/src/infrastructure/adapters/sqlite/create-state-stores.ts
@@ -16,6 +16,7 @@ import {
 	createTffCcSymlink,
 	getProjectHome,
 	getProjectId,
+	resolveProjectRoot,
 	resolveRepoRoot,
 	warnOnStrayTffFiles,
 } from "../../home-directory.js";
@@ -41,10 +42,15 @@ function getDerivedPaths(): { dbPath: string; journalPath: string; projectId: st
 	const cwd = process.cwd();
 	const repoRoot = resolveRepoRoot(cwd);
 	warnOnStrayTffFiles(cwd, repoRoot);
-	const projectId = getProjectId(repoRoot);
+	// State files (`.tff-project-id`, `.tff-cc` symlink) live at TFF_CC_HOME
+	// when set, otherwise at the repo toplevel. Routing through
+	// resolveProjectRoot keeps tests with TFF_CC_HOME=<tmp> from leaking the
+	// symlink and id-file into the surrounding worktree.
+	const projectRoot = resolveProjectRoot(cwd);
+	const projectId = getProjectId(projectRoot);
 	const home = getProjectHome(projectId);
 
-	createTffCcSymlink(repoRoot, projectId);
+	createTffCcSymlink(projectRoot, projectId);
 
 	return {
 		dbPath: path.join(home, "state.db"),

--- a/src/infrastructure/home-directory.ts
+++ b/src/infrastructure/home-directory.ts
@@ -53,11 +53,6 @@ function findPrimaryWorktreeRoot(repoRoot: string): string | null {
  *  - not inside a git repo
  *  - `git` isn't installed / on PATH
  *  - the repo is bare
- *
- * This is the single source of truth for where tff-cc state files
- * (`.tff-project-id`, `.tff-cc` symlink) live relative to the working tree,
- * so launching tff-cc from any sub-directory of a repo always finds the
- * same toplevel.
  */
 export function resolveRepoRoot(cwd?: string): string {
 	const start = cwd ?? process.cwd();
@@ -70,6 +65,23 @@ export function resolveRepoRoot(cwd?: string): string {
 	} catch {
 		return start;
 	}
+}
+
+/**
+ * Resolve the directory that owns tff-cc state files (`.tff-project-id`,
+ * `.tff-cc` symlink, mutating-cli sentinel).
+ *
+ * - If `TFF_CC_HOME` is set, returns it. The override is the canonical store;
+ *   the symlink/id-file/sentinel live there and cwd is never touched. This
+ *   keeps test sandboxes from leaking into the surrounding worktree.
+ * - Otherwise returns the git toplevel (or `cwd` when not in a repo).
+ *
+ * Single source of truth for where tff-cc writes its on-disk state.
+ */
+export function resolveProjectRoot(cwd?: string): string {
+	const override = process.env.TFF_CC_HOME;
+	if (override) return override;
+	return resolveRepoRoot(cwd);
 }
 
 let warnedStrayThisProcess = false;
@@ -153,8 +165,14 @@ export function readProjectIdFile(repoRoot: string): string | null {
 
 /**
  * Write project ID to .tff-project-id file.
+ *
+ * Ensures the parent directory exists — when `repoRoot` resolves to
+ * `TFF_CC_HOME`, the directory may not have been created yet on first init.
  */
 export function writeProjectIdFile(repoRoot: string, projectId: string): void {
+	if (!existsSync(repoRoot)) {
+		mkdirSync(repoRoot, { recursive: true, mode: 0o700 });
+	}
 	const idPath = join(repoRoot, ".tff-project-id");
 	writeFileSync(idPath, `${projectId}\n`, "utf-8");
 }

--- a/tests/integration/cli-recovery-marker-replay.integration.spec.ts
+++ b/tests/integration/cli-recovery-marker-replay.integration.spec.ts
@@ -20,7 +20,8 @@ beforeEach(() => {
 	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
 	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
 
-	writeFileSync(join(repo, ".tff-project-id"), `${projectId}\n`);
+	// Issue #172: when TFF_CC_HOME is set, the id-file lives at home/.tff-project-id.
+	writeFileSync(join(home, ".tff-project-id"), `${projectId}\n`);
 	mkdirSync(join(home, projectId), { recursive: true });
 });
 afterEach(() => {

--- a/tests/integration/cli-startup-orphan-recovery.integration.spec.ts
+++ b/tests/integration/cli-startup-orphan-recovery.integration.spec.ts
@@ -19,7 +19,10 @@ beforeEach(() => {
 	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
 	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
 
-	writeFileSync(join(repo, ".tff-project-id"), `${projectId}\n`);
+	// When TFF_CC_HOME is set, the project-id file lives alongside the home —
+	// not in cwd (issue #172). Seed at the new canonical location so startup
+	// recovery resolves to the pre-staged `home/{projectId}/`.
+	writeFileSync(join(home, ".tff-project-id"), `${projectId}\n`);
 
 	mkdirSync(join(home, projectId, "milestones"), { recursive: true });
 });

--- a/tests/integration/cli-startup-recovery-cycle.integration.spec.ts
+++ b/tests/integration/cli-startup-recovery-cycle.integration.spec.ts
@@ -26,13 +26,16 @@ beforeEach(() => {
 	execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
 	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repo });
 
-	writeFileSync(join(repo, ".tff-project-id"), `${PROJECT_ID}\n`);
+	// Issue #172: id-file is now at home/.tff-project-id when TFF_CC_HOME is set.
+	writeFileSync(join(home, ".tff-project-id"), `${PROJECT_ID}\n`);
 
 	const projectHome = join(home, PROJECT_ID);
 	mkdirSync(join(projectHome, "milestones"), { recursive: true });
 	mkdirSync(join(projectHome, "worktrees", "M01-S01"), { recursive: true });
 	symlinkSync(projectHome, join(projectHome, "worktrees", "M01-S01", ".tff-cc"));
-	symlinkSync(projectHome, join(repo, ".tff-cc"));
+	// Recreate the home-side symlink that project:init would have produced;
+	// recovery walks from `home/.tff-cc/...` so the cycle still gets exercised.
+	symlinkSync(projectHome, join(home, ".tff-cc"));
 
 	const stale = join(projectHome, "milestones", "STATE.md.tmp");
 	writeFileSync(stale, "stale");

--- a/tests/integration/cli/project-init-subdir.integration.spec.ts
+++ b/tests/integration/cli/project-init-subdir.integration.spec.ts
@@ -1,9 +1,18 @@
 /**
- * Integration test: project:init from a sub-directory
+ * Integration test: project:init isolation
  *
- * Verifies that running `tff-cc project:init` from a sub-directory of a git
- * repo writes `.tff-project-id` and creates the `.tff-cc` symlink at the repo
- * TOPLEVEL — not in the sub-directory where the CLI was invoked.
+ * Two contracts under test:
+ *
+ * 1. When TFF_CC_HOME is set, project:init writes the `.tff-project-id` and
+ *    `.tff-cc` symlink under TFF_CC_HOME exclusively. The surrounding worktree
+ *    (and any sub-directory it was invoked from) MUST be untouched. This is
+ *    issue #172 — tests that set TFF_CC_HOME=<tmp> were leaking the symlink
+ *    and id-file into the dogfood worktree, breaking subsequent tff-tools
+ *    walk-ups.
+ *
+ * 2. When TFF_CC_HOME is unset and `tff-cc project:init` is run from a
+ *    sub-directory of a git repo, the meta files land at the repo TOPLEVEL,
+ *    not at the sub-directory cwd.
  */
 
 import { execFileSync } from "node:child_process";
@@ -12,7 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-describe("project:init from a sub-directory", () => {
+describe("project:init isolation", () => {
 	let tempDir: string;
 	let repoRoot: string;
 	let subDir: string;
@@ -43,11 +52,39 @@ describe("project:init from a sub-directory", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("writes .tff-project-id at the repo toplevel when launched from a sub-directory", () => {
+	it("writes state files exclusively under TFF_CC_HOME when set, leaving cwd untouched", () => {
 		const cliEntry = join(process.cwd(), "dist", "cli", "index.js");
+		const tffHome = join(tempDir, "tff-home");
+		execFileSync(process.execPath, [cliEntry, "project:init", "--name", "isolation-test"], {
+			cwd: subDir,
+			env: { ...process.env, TFF_CC_HOME: tffHome },
+			encoding: "utf-8",
+		});
+
+		// Files land under TFF_CC_HOME — the canonical store when overridden
+		expect(existsSync(join(tffHome, ".tff-project-id"))).toBe(true);
+		expect(existsSync(join(tffHome, ".tff-cc"))).toBe(true);
+
+		// And NOWHERE else: not in the worktree, not in the cwd it was invoked from
+		expect(existsSync(join(repoRoot, ".tff-project-id"))).toBe(false);
+		expect(existsSync(join(repoRoot, ".tff-cc"))).toBe(false);
+		expect(existsSync(join(subDir, ".tff-project-id"))).toBe(false);
+		expect(existsSync(join(subDir, ".tff-cc"))).toBe(false);
+
+		// Git hooks must not be installed into the surrounding repo when sandboxed
+		expect(existsSync(join(repoRoot, ".git", "hooks", "post-checkout"))).toBe(false);
+	});
+
+	it("writes .tff-project-id at the repo toplevel when launched from a sub-directory (no TFF_CC_HOME)", () => {
+		const cliEntry = join(process.cwd(), "dist", "cli", "index.js");
+		// Drop TFF_CC_HOME and redirect HOME so the run still doesn't touch the
+		// user's real ~/.tff-cc. With TFF_CC_HOME unset, the meta files belong
+		// at the repo toplevel — that's the production contract this test guards.
+		const env = { ...process.env, HOME: join(tempDir, "fake-home") };
+		delete env.TFF_CC_HOME;
 		execFileSync(process.execPath, [cliEntry, "project:init", "--name", "subdir-test"], {
 			cwd: subDir,
-			env: { ...process.env, TFF_CC_HOME: join(tempDir, "tff-home") },
+			env,
 			encoding: "utf-8",
 		});
 

--- a/tests/integration/path-contract.spec.ts
+++ b/tests/integration/path-contract.spec.ts
@@ -55,12 +55,18 @@ describe("path contract: artifacts under .tff-cc/ only", () => {
 		}
 	};
 
-	it("project:init creates .tff-cc/ symlink", () => {
+	it("project:init creates .tff-cc/ symlink under TFF_CC_HOME (not in cwd)", () => {
 		cli('project:init --name "TestProject"');
 
-		const symlinkPath = join(tmpRepo, ".tff-cc");
+		// When TFF_CC_HOME is set, the symlink lives under TFF_CC_HOME — never
+		// in the surrounding worktree (issue #172).
+		const symlinkPath = join(tffCcHome, ".tff-cc");
 		expect(existsSync(symlinkPath)).toBe(true);
 		expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+
+		// And cwd stays untouched.
+		expect(existsSync(join(tmpRepo, ".tff-cc"))).toBe(false);
+		expect(existsSync(join(tmpRepo, ".tff-project-id"))).toBe(false);
 	});
 
 	it("after milestone + slice + sync, state lands under .tff-cc/", () => {
@@ -74,7 +80,7 @@ describe("path contract: artifacts under .tff-cc/ only", () => {
 		cli('slice:create --title "S1"');
 		cli(`sync:state --milestone-id ${milestoneShortId}`);
 
-		const symlinkPath = join(tmpRepo, ".tff-cc");
+		const symlinkPath = join(tffCcHome, ".tff-cc");
 		expect(existsSync(symlinkPath)).toBe(true);
 		expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
 	});

--- a/tests/integration/worktree-create-adhoc-slice.integration.spec.ts
+++ b/tests/integration/worktree-create-adhoc-slice.integration.spec.ts
@@ -58,6 +58,7 @@ vi.mock("../../src/infrastructure/home-directory.js", () => ({
 	createTffCcSymlink: vi.fn(),
 	getProjectId: vi.fn(() => "test-project-id"),
 	resolveRepoRoot: vi.fn((cwd: string) => cwd),
+	resolveProjectRoot: vi.fn((cwd: string) => cwd),
 	writeProjectIdFile: vi.fn(),
 }));
 

--- a/tests/unit/application/project/init-project.spec.ts
+++ b/tests/unit/application/project/init-project.spec.ts
@@ -33,14 +33,15 @@ describe("initProject", () => {
 		expect(await artifactStore.exists(".tff-cc/PROJECT.md")).toBe(true);
 	});
 
-	it("should add .tff-cc/ and build/ to .gitignore", async () => {
+	it("should add /.tff-cc (root-anchored, no trailing slash) and build/ to .gitignore", async () => {
 		await initProject(
 			{ name: "my-app", vision: "A great app" },
 			{ projectStore: adapter, artifactStore },
 		);
 		expect(await artifactStore.exists(".gitignore")).toBe(true);
 		const content = await artifactStore.read(".gitignore");
-		expect(isOk(content) && content.data).toContain(".tff-cc/");
+		// `/.tff-cc` — anchored, no trailing slash so it matches the symlink form too.
+		expect(isOk(content) && content.data.split("\n")).toContain("/.tff-cc");
 		expect(isOk(content) && content.data).toContain("build/");
 	});
 
@@ -52,11 +53,28 @@ describe("initProject", () => {
 		);
 		const content = await artifactStore.read(".gitignore");
 		expect(isOk(content) && content.data).toContain("node_modules/");
-		expect(isOk(content) && content.data).toContain(".tff-cc/");
+		expect(isOk(content) && content.data.split("\n")).toContain("/.tff-cc");
 		expect(isOk(content) && content.data).toContain("build/");
 	});
 
-	it("should not duplicate entries already in .gitignore", async () => {
+	it("should not duplicate entries already in .gitignore (anchored form)", async () => {
+		artifactStore.seed({ ".gitignore": "node_modules/\n/.tff-cc\nbuild/\n" });
+		await initProject(
+			{ name: "my-app", vision: "A great app" },
+			{ projectStore: adapter, artifactStore },
+		);
+		const content = await artifactStore.read(".gitignore");
+		if (isOk(content)) {
+			const tffMatches = content.data.split("\n").filter((l) => l.trim() === "/.tff-cc");
+			const buildMatches = content.data.split("\n").filter((l) => l.trim() === "build/");
+			expect(tffMatches).toHaveLength(1);
+			expect(buildMatches).toHaveLength(1);
+		}
+	});
+
+	it("should treat legacy unanchored .tff-cc/ as satisfying the requirement", async () => {
+		// Existing projects with the pre-fix unanchored form should not gain a
+		// duplicate `/.tff-cc` line on re-init.
 		artifactStore.seed({ ".gitignore": "node_modules/\n.tff-cc/\nbuild/\n" });
 		await initProject(
 			{ name: "my-app", vision: "A great app" },
@@ -64,10 +82,10 @@ describe("initProject", () => {
 		);
 		const content = await artifactStore.read(".gitignore");
 		if (isOk(content)) {
-			const tffMatches = content.data.split("\n").filter((l) => l.trim() === ".tff-cc/");
-			const buildMatches = content.data.split("\n").filter((l) => l.trim() === "build/");
-			expect(tffMatches).toHaveLength(1);
-			expect(buildMatches).toHaveLength(1);
+			const anyTff = content.data
+				.split("\n")
+				.filter((l) => [".tff-cc", ".tff-cc/", "/.tff-cc", "/.tff-cc/"].includes(l.trim()));
+			expect(anyTff).toHaveLength(1);
 		}
 	});
 
@@ -79,7 +97,7 @@ describe("initProject", () => {
 		);
 		const content = await artifactStore.read(".gitignore");
 		if (isOk(content)) {
-			expect(content.data).toContain(".tff-cc/");
+			expect(content.data.split("\n")).toContain("/.tff-cc");
 			const buildMatches = content.data.split("\n").filter((l) => l.trim() === "build/");
 			expect(buildMatches).toHaveLength(1);
 		}

--- a/tests/unit/cli/commands/project-init.cmd.spec.ts
+++ b/tests/unit/cli/commands/project-init.cmd.spec.ts
@@ -30,7 +30,8 @@ describe("project:init — .tff-cc/ auto-creation", () => {
 		rmSync(homeDir, { recursive: true, force: true });
 	});
 
-	it("creates .tff-cc/ directory before opening database", async () => {
+	it("creates .tff-cc/ symlink and project-id under TFF_CC_HOME (cwd untouched)", async () => {
+		expect(existsSync(path.join(homeDir, ".tff-cc"))).toBe(false);
 		expect(existsSync(path.join(tmpDir, ".tff-cc"))).toBe(false);
 
 		const result = JSON.parse(
@@ -38,14 +39,15 @@ describe("project:init — .tff-cc/ auto-creation", () => {
 		);
 
 		expect(result.ok).toBe(true);
-		// .tff-cc/ is created for artifacts
-		expect(existsSync(path.join(tmpDir, ".tff-cc"))).toBe(true);
-		// Project ID file is created
-		expect(existsSync(path.join(tmpDir, ".tff-project-id"))).toBe(true);
+		// When TFF_CC_HOME is set, the symlink + id-file live under TFF_CC_HOME
+		// (issue #172: cwd must not be polluted by isolated test sandboxes).
+		expect(existsSync(path.join(homeDir, ".tff-cc"))).toBe(true);
+		expect(existsSync(path.join(homeDir, ".tff-project-id"))).toBe(true);
+		expect(existsSync(path.join(tmpDir, ".tff-cc"))).toBe(false);
+		expect(existsSync(path.join(tmpDir, ".tff-project-id"))).toBe(false);
 
-		// Read project ID to find home directory
-		const projectId = readFileSync(path.join(tmpDir, ".tff-project-id"), "utf-8").trim();
-		// Database is in home directory
+		// Database lives at the project home keyed by id.
+		const projectId = readFileSync(path.join(homeDir, ".tff-project-id"), "utf-8").trim();
 		expect(existsSync(path.join(homeDir, projectId, "state.db"))).toBe(true);
 	});
 

--- a/tests/unit/cli/commands/task-claim.cmd.spec.ts
+++ b/tests/unit/cli/commands/task-claim.cmd.spec.ts
@@ -102,7 +102,7 @@ describe("task:claim — journal integration", () => {
 
 	it("writes task-started journal entry before claiming task", async () => {
 		// Read project ID for journal path
-		const projectIdPath = path.join(tmpDir, ".tff-project-id");
+		const projectIdPath = path.join(homeDir, ".tff-project-id");
 		const projectId = readFileSync(projectIdPath, "utf-8").trim();
 		// Journal filename uses slice UUID, not label
 		const journalPath = path.join(homeDir, projectId, "journal", `${sliceId}.jsonl`);
@@ -135,7 +135,7 @@ describe("task:claim — journal integration", () => {
 
 	it("uses anonymous agent identity when not specified", async () => {
 		// Read project ID for journal path
-		const projectIdPath = path.join(tmpDir, ".tff-project-id");
+		const projectIdPath = path.join(homeDir, ".tff-project-id");
 		const projectId = readFileSync(projectIdPath, "utf-8").trim();
 		// Journal filename uses slice UUID, not label
 		const journalPath = path.join(homeDir, projectId, "journal", `${sliceId}.jsonl`);
@@ -179,7 +179,7 @@ describe("task:claim — journal integration", () => {
 		expect(taskResult.ok).toBe(true);
 
 		// Read project ID for journal path
-		const projectIdPath = path.join(tmpDir, ".tff-project-id");
+		const projectIdPath = path.join(homeDir, ".tff-project-id");
 		const projectId = readFileSync(projectIdPath, "utf-8").trim();
 		// Journal filename uses slice UUID, not label
 		const journalPath = path.join(homeDir, projectId, "journal", `${sliceId}.jsonl`);

--- a/tests/unit/cli/commands/task-close.cmd.spec.ts
+++ b/tests/unit/cli/commands/task-close.cmd.spec.ts
@@ -112,7 +112,7 @@ describe("task:close — journal integration", () => {
 	it("writes task-completed journal entry before closing task", async () => {
 		// Journal is now in home directory under project ID
 		// Read project ID from .tff-project-id
-		const projectIdPath = path.join(tmpDir, ".tff-project-id");
+		const projectIdPath = path.join(homeDir, ".tff-project-id");
 		const projectId = readFileSync(projectIdPath, "utf-8").trim();
 		// Journal filename uses slice UUID, not label
 		const journalPath = path.join(homeDir, projectId, "journal", `${sliceId}.jsonl`);
@@ -199,7 +199,7 @@ describe("task:close — journal integration", () => {
 		expect(claimResult.ok).toBe(true);
 
 		// Read project ID for journal path
-		const projectIdPath = path.join(tmpDir, ".tff-project-id");
+		const projectIdPath = path.join(homeDir, ".tff-project-id");
 		const projectId = readFileSync(projectIdPath, "utf-8").trim();
 		// Journal filename uses slice UUID, not label
 		const journalPath = path.join(homeDir, projectId, "journal", `${sliceId}.jsonl`);
@@ -222,7 +222,7 @@ describe("task:close — journal integration", () => {
 
 	it("increments sequence number for each journal entry", async () => {
 		// Read project ID for journal path
-		const projectIdPath = path.join(tmpDir, ".tff-project-id");
+		const projectIdPath = path.join(homeDir, ".tff-project-id");
 		const projectId = readFileSync(projectIdPath, "utf-8").trim();
 		// Journal filename uses slice UUID, not label
 		const journalPath = path.join(homeDir, projectId, "journal", `${sliceId}.jsonl`);


### PR DESCRIPTION
Closes #172.

## Summary
- Route `.tff-project-id`, `.tff-cc` symlink, observation sentinel, and artifact basePath through a new `resolveProjectRoot(cwd)` helper that honors `TFF_CC_HOME`. When the override is set, state lives under the sandbox and cwd is never touched — isolated tests stop leaking the symlink and id-file into the surrounding worktree, and `tff-tools` walk-ups stop following stale targets.
- Skip the post-checkout git-hook install when `TFF_CC_HOME` is set (was leaking into the real repo's `.git/hooks/`).
- Generated `.gitignore` entry switched to root-anchored `/.tff-cc` (no trailing slash). The trailing-slash form only matches directories, so it silently failed to ignore the symlink form. Anchoring also surfaces stray `<sub>/.tff-cc/` instead of hiding them.

## Files
- `src/infrastructure/home-directory.ts` — new `resolveProjectRoot`; `writeProjectIdFile` ensures parent dir exists for first init under `TFF_CC_HOME`.
- `src/infrastructure/adapters/sqlite/create-state-stores.ts` — `getProjectId` + `createTffCcSymlink` use project root.
- `src/cli/utils/with-mutating-command.ts` — sentinel uses project root (fixes Form B).
- `src/cli/index.ts` — startup recovery uses project root (third leak path: was minting + writing `.tff-project-id` to cwd before any command ran).
- `src/cli/commands/project-init.cmd.ts` — artifact basePath uses project root; `installPostCheckoutHook` gated on `!TFF_CC_HOME`.
- `src/application/project/init-project.ts` — `/${TFF_CC_DIR}` (anchored, no slash); dedup accepts legacy variants so re-init on existing projects doesn't double-add.
- `.gitignore` — same change applied here (this dogfood worktree has `.tff-cc/` as a real dir from past test pollution; the unanchored pattern was masking it).

## Tests
- New: `tests/integration/cli/project-init-subdir.integration.spec.ts` asserts cwd + worktree are empty after `project:init` when `TFF_CC_HOME` is set, plus the no-`TFF_CC_HOME` subdir case.
- Updated: 8 specs that previously read meta files from cwd's tmpDir now read from `TFF_CC_HOME`.
- Updated: gitignore unit tests cover the anchored form and legacy-variant dedup.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run vitest run` — 1853 passed, 2 skipped, 0 failed
- [ ] Manual: spawn cc with `TFF_CC_HOME=<tmp>` from this worktree and confirm no `.tff-cc` / `.tff-project-id` appears at cwd