### PR TITLE
fix(routing): unbreak SPEC.md lookup and feed real signals to routing:decide

### DIFF
--- a/src/cli/commands/routing-decide.cmd.ts
+++ b/src/cli/commands/routing-decide.cmd.ts
@@ -1,11 +1,23 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { decideUseCase } from "../../application/routing/decide.js";
+import type { ExtractInput } from "../../domain/ports/signal-extractor.port.js";
 import { isOk } from "../../domain/result.js";
 import { FilesystemSignalExtractor } from "../../infrastructure/adapters/filesystem/filesystem-signal-extractor.js";
 import { FilesystemTierConfigReader } from "../../infrastructure/adapters/filesystem/filesystem-tier-config-reader.js";
 import { YamlRoutingConfigReader } from "../../infrastructure/adapters/filesystem/yaml-routing-config-reader.js";
 import { JsonlRoutingDecisionLogger } from "../../infrastructure/adapters/jsonl/jsonl-routing-decision-logger.js";
+import { createClosableStateStoresUnchecked } from "../../infrastructure/adapters/sqlite/create-state-stores.js";
 import { resolvePluginRoot } from "../../infrastructure/plugin-root.js";
+import { buildRoutingExtractInput } from "../utils/build-routing-extract-input.js";
 import { type CommandSchema, parseFlags } from "../utils/flag-parser.js";
+
+const execFileP = promisify(execFile);
+
+const runGit = async (cmd: string, args: string[], opts: { cwd: string }): Promise<string> => {
+	const { stdout } = await execFileP(cmd, args, { cwd: opts.cwd, maxBuffer: 16 * 1024 * 1024 });
+	return stdout;
+};
 
 export const routingDecideSchema: CommandSchema = {
 	name: "routing:decide",
@@ -73,15 +85,24 @@ export const routingDecideCmd = async (args: string[]): Promise<string> => {
 	});
 	const logger = new JsonlRoutingDecisionLogger(configRes.data.logging.path);
 
+	const stores = createClosableStateStoresUnchecked();
+	let extractInput: ExtractInput;
+	try {
+		extractInput = await buildRoutingExtractInput(sliceId, {
+			sliceStore: stores.sliceStore,
+			milestoneStore: stores.milestoneStore,
+			runGit,
+			projectRoot,
+		});
+	} finally {
+		stores.close();
+	}
+
 	const res = await decideUseCase(
 		{
 			workflow_id: workflow,
 			slice_id: sliceId,
-			extract_input: {
-				slice_id: sliceId,
-				description: `slice ${sliceId}`,
-				affected_files: [],
-			},
+			extract_input: extractInput,
 		},
 		{ configReader, tierConfigReader, extractor, logger },
 	);

--- a/src/cli/utils/build-routing-extract-input.ts
+++ b/src/cli/utils/build-routing-extract-input.ts
@@ -1,0 +1,83 @@
+import { join } from "node:path";
+import type { MilestoneStore } from "../../domain/ports/milestone-store.port.js";
+import type { ExtractInput } from "../../domain/ports/signal-extractor.port.js";
+import type { SliceStore } from "../../domain/ports/slice-store.port.js";
+import { isOk } from "../../domain/result.js";
+import { sliceDir } from "../../shared/paths.js";
+
+const SLICE_LABEL_RE = /^M(\d+)-S(\d+)$/;
+
+export type GitRunner = (cmd: string, args: string[], opts: { cwd: string }) => Promise<string>;
+
+export interface BuildExtractInputDeps {
+	sliceStore: SliceStore;
+	milestoneStore: MilestoneStore;
+	runGit: GitRunner;
+	projectRoot: string;
+}
+
+const readAffectedFiles = async (
+	runGit: GitRunner,
+	cwd: string,
+	baseBranch: string,
+): Promise<string[]> => {
+	try {
+		const out = await runGit("git", ["diff", "--name-only", `${baseBranch}...HEAD`], { cwd });
+		return out
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l.length > 0);
+	} catch {
+		// Missing base branch / no git / detached HEAD — degrade to empty list
+		// rather than fail the routing pipeline.
+		return [];
+	}
+};
+
+/**
+ * Resolve a slice label (M##-S##) to a populated ExtractInput for
+ * routing:decide. Looks up the slice's parent milestone, computes affected
+ * files via `git diff --name-only <base>...HEAD`, and points spec_path at
+ * the canonical SPEC.md location.
+ *
+ * Falls back to a minimal stub when the slice can't be resolved or its
+ * milestone is missing — routing then degrades to the previous always-low
+ * behaviour rather than failing the calling workflow.
+ */
+export const buildRoutingExtractInput = async (
+	sliceLabel: string,
+	deps: BuildExtractInputDeps,
+): Promise<ExtractInput> => {
+	const stub: ExtractInput = {
+		slice_id: sliceLabel,
+		description: `slice ${sliceLabel}`,
+		affected_files: [],
+	};
+
+	const m = SLICE_LABEL_RE.exec(sliceLabel);
+	if (!m) return stub;
+	const milestoneNum = Number.parseInt(m[1], 10);
+	const sliceNum = Number.parseInt(m[2], 10);
+
+	const sliceRes = deps.sliceStore.getSliceByNumbers(milestoneNum, sliceNum);
+	if (!isOk(sliceRes) || !sliceRes.data) return stub;
+	const slice = sliceRes.data;
+
+	let baseBranch: string | undefined = slice.baseBranch;
+	if (!baseBranch && slice.milestoneId) {
+		const msRes = deps.milestoneStore.getMilestone(slice.milestoneId);
+		if (isOk(msRes) && msRes.data) baseBranch = msRes.data.branch;
+	}
+	if (!baseBranch) return stub;
+
+	const affectedFiles = await readAffectedFiles(deps.runGit, deps.projectRoot, baseBranch);
+	const milestoneLabel = `M${m[1].padStart(2, "0")}`;
+	const specPath = join(deps.projectRoot, sliceDir(milestoneLabel, sliceLabel), "SPEC.md");
+
+	return {
+		slice_id: sliceLabel,
+		description: `slice ${sliceLabel}`,
+		affected_files: affectedFiles,
+		spec_path: specPath,
+	};
+};

--- a/src/infrastructure/adapters/filesystem/slice-spec-fs-reader.ts
+++ b/src/infrastructure/adapters/filesystem/slice-spec-fs-reader.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createDomainError, type DomainError } from "../../../domain/errors/domain-error.js";
 import type {
@@ -6,8 +6,29 @@ import type {
 	SliceSpecResult,
 } from "../../../domain/ports/slice-spec-reader.port.js";
 import { Err, Ok, type Result } from "../../../domain/result.js";
+import { debugSliceDir, quickSliceDir, sliceDir } from "../../../shared/paths.js";
 
-const SLICE_LABEL_RE = /^M(\d+)-S(\d+)$/;
+const MILESTONE_SLICE_RE = /^M(\d+)-S\d+$/;
+const ADHOC_SLICE_RE = /^([QD])-\d+$/;
+
+/**
+ * Resolve `<projectRoot>/<sliceDir>/SPEC.md` from a slice label. Path is
+ * deterministic — mirrors the layout written by slice:create. Falls back to
+ * `missing: true` if the file is absent at the expected location.
+ */
+const specPathFor = (projectRoot: string, sliceLabel: string): string | null => {
+	const milestone = MILESTONE_SLICE_RE.exec(sliceLabel);
+	if (milestone) {
+		const milestoneLabel = `M${milestone[1].padStart(2, "0")}`;
+		return join(projectRoot, sliceDir(milestoneLabel, sliceLabel), "SPEC.md");
+	}
+	const adhoc = ADHOC_SLICE_RE.exec(sliceLabel);
+	if (adhoc) {
+		const dir = adhoc[1] === "Q" ? quickSliceDir(sliceLabel) : debugSliceDir(sliceLabel);
+		return join(projectRoot, dir, "SPEC.md");
+	}
+	return null;
+};
 
 export interface SliceSpecFsReaderOpts {
 	projectRoot: string;
@@ -20,30 +41,13 @@ export class SliceSpecFsReader implements SliceSpecReader {
 		sliceLabel: string,
 		maxBytes: number,
 	): Promise<Result<SliceSpecResult, DomainError>> {
-		const m = SLICE_LABEL_RE.exec(sliceLabel);
-		if (!m) {
+		const specPath = specPathFor(this.opts.projectRoot, sliceLabel);
+		if (specPath === null) {
 			return Err(
 				createDomainError("VALIDATION_ERROR", `invalid slice label: ${sliceLabel}`, { sliceLabel }),
 			);
 		}
-		const mNum = m[1].padStart(2, "0");
-		const sNum = m[2].padStart(2, "0");
-		const milestoneDir = join(this.opts.projectRoot, ".tff-cc", "milestones", `M${mNum}`);
 
-		let entries: string[];
-		try {
-			entries = await readdir(milestoneDir);
-		} catch {
-			return Ok({ text: "", truncated: false, missing: true });
-		}
-
-		const prefix = `S${sNum}-`;
-		const sliceDirName = entries.find((e) => e.startsWith(prefix));
-		if (!sliceDirName) {
-			return Ok({ text: "", truncated: false, missing: true });
-		}
-
-		const specPath = join(milestoneDir, sliceDirName, "SPEC.md");
 		let raw: string;
 		try {
 			raw = await readFile(specPath, "utf8");

--- a/tests/unit/cli/utils/build-routing-extract-input.spec.ts
+++ b/tests/unit/cli/utils/build-routing-extract-input.spec.ts
@@ -1,0 +1,189 @@
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildRoutingExtractInput,
+	type GitRunner,
+} from "../../../../src/cli/utils/build-routing-extract-input.js";
+import type { Slice } from "../../../../src/domain/entities/slice.js";
+import type { MilestoneStore } from "../../../../src/domain/ports/milestone-store.port.js";
+import type { SliceStore } from "../../../../src/domain/ports/slice-store.port.js";
+import { Ok } from "../../../../src/domain/result.js";
+
+const stubMilestoneStore = (overrides: Partial<MilestoneStore> = {}): MilestoneStore => {
+	return {
+		getMilestone: vi.fn(),
+		getMilestoneByNumber: vi.fn(),
+		listMilestones: vi.fn(),
+		createMilestone: vi.fn(),
+		updateMilestone: vi.fn(),
+		closeMilestone: vi.fn(),
+		setMilestoneAuditStatus: vi.fn(),
+		...overrides,
+	} as unknown as MilestoneStore;
+};
+
+const stubSliceStore = (overrides: Partial<SliceStore> = {}): SliceStore => {
+	return {
+		createSlice: vi.fn(),
+		getSlice: vi.fn(),
+		getSliceByNumbers: vi.fn(),
+		listSlices: vi.fn(),
+		listSlicesByKind: vi.fn(),
+		updateSlice: vi.fn(),
+		transitionSlice: vi.fn(),
+		archiveSlice: vi.fn(),
+		...overrides,
+	} as unknown as SliceStore;
+};
+
+const fakeSlice = (overrides: Partial<Slice> = {}): Slice =>
+	({
+		id: "slice-uuid-1",
+		milestoneId: "milestone-uuid-1",
+		kind: "milestone",
+		number: 1,
+		title: "Test slice",
+		status: "executing",
+		baseBranch: undefined,
+		branchName: undefined,
+		createdAt: new Date(),
+		...overrides,
+	}) as Slice;
+
+describe("buildRoutingExtractInput", () => {
+	it("returns the legacy stub when the slice label is malformed", async () => {
+		const sliceStore = stubSliceStore();
+		const milestoneStore = stubMilestoneStore();
+		const runGit: GitRunner = vi.fn();
+
+		const result = await buildRoutingExtractInput("not-a-slice", {
+			sliceStore,
+			milestoneStore,
+			runGit,
+			projectRoot: "/repo",
+		});
+
+		expect(result).toEqual({
+			slice_id: "not-a-slice",
+			description: "slice not-a-slice",
+			affected_files: [],
+		});
+		expect(sliceStore.getSliceByNumbers).not.toHaveBeenCalled();
+		expect(runGit).not.toHaveBeenCalled();
+	});
+
+	it("returns the stub when the slice is unknown", async () => {
+		const sliceStore = stubSliceStore({
+			getSliceByNumbers: vi.fn().mockReturnValue(Ok(null)),
+		});
+		const milestoneStore = stubMilestoneStore();
+		const runGit: GitRunner = vi.fn();
+
+		const result = await buildRoutingExtractInput("M01-S01", {
+			sliceStore,
+			milestoneStore,
+			runGit,
+			projectRoot: "/repo",
+		});
+
+		expect(result.affected_files).toEqual([]);
+		expect(result.spec_path).toBeUndefined();
+		expect(runGit).not.toHaveBeenCalled();
+	});
+
+	it("populates affected_files from git diff and points spec_path at the slice dir", async () => {
+		const slice = fakeSlice({ baseBranch: "main" });
+		const sliceStore = stubSliceStore({
+			getSliceByNumbers: vi.fn().mockReturnValue(Ok(slice)),
+		});
+		const milestoneStore = stubMilestoneStore();
+		const runGit: GitRunner = vi
+			.fn<Parameters<GitRunner>, ReturnType<GitRunner>>()
+			.mockResolvedValue(
+				"src/foo.ts\nsrc/bar.ts\nsrc/auth/baz.ts\n\nsrc/qux.ts\nsrc/quux.ts\nsrc/corge.ts\n",
+			);
+
+		const result = await buildRoutingExtractInput("M01-S01", {
+			sliceStore,
+			milestoneStore,
+			runGit,
+			projectRoot: "/repo",
+		});
+
+		expect(runGit).toHaveBeenCalledWith("git", ["diff", "--name-only", "main...HEAD"], {
+			cwd: "/repo",
+		});
+		expect(result.affected_files).toEqual([
+			"src/foo.ts",
+			"src/bar.ts",
+			"src/auth/baz.ts",
+			"src/qux.ts",
+			"src/quux.ts",
+			"src/corge.ts",
+		]);
+		expect(result.affected_files.length).toBeGreaterThanOrEqual(5); // → medium tier downstream
+		expect(result.spec_path).toBe(
+			join("/repo", ".tff-cc", "milestones", "M01", "slices", "M01-S01", "SPEC.md"),
+		);
+	});
+
+	it("falls back to the milestone branch when slice has no explicit base", async () => {
+		const slice = fakeSlice({ baseBranch: undefined, milestoneId: "ms-uuid" });
+		const sliceStore = stubSliceStore({
+			getSliceByNumbers: vi.fn().mockReturnValue(Ok(slice)),
+		});
+		const milestoneStore = stubMilestoneStore({
+			getMilestone: vi.fn().mockReturnValue(
+				Ok({
+					id: "ms-uuid",
+					name: "M",
+					number: 1,
+					status: "open",
+					branch: "milestone/abc12345",
+					createdAt: new Date(),
+				}),
+			),
+		});
+		const runGit: GitRunner = vi
+			.fn<Parameters<GitRunner>, ReturnType<GitRunner>>()
+			.mockResolvedValue("src/a.ts\n");
+
+		const result = await buildRoutingExtractInput("M01-S01", {
+			sliceStore,
+			milestoneStore,
+			runGit,
+			projectRoot: "/repo",
+		});
+
+		expect(runGit).toHaveBeenCalledWith(
+			"git",
+			["diff", "--name-only", "milestone/abc12345...HEAD"],
+			{ cwd: "/repo" },
+		);
+		expect(result.affected_files).toEqual(["src/a.ts"]);
+	});
+
+	it("returns empty affected_files when git fails (e.g. missing branch)", async () => {
+		const slice = fakeSlice({ baseBranch: "main" });
+		const sliceStore = stubSliceStore({
+			getSliceByNumbers: vi.fn().mockReturnValue(Ok(slice)),
+		});
+		const milestoneStore = stubMilestoneStore();
+		const runGit: GitRunner = vi
+			.fn<Parameters<GitRunner>, ReturnType<GitRunner>>()
+			.mockRejectedValue(new Error("fatal: ambiguous argument 'main'"));
+
+		const result = await buildRoutingExtractInput("M01-S01", {
+			sliceStore,
+			milestoneStore,
+			runGit,
+			projectRoot: "/repo",
+		});
+
+		expect(result.affected_files).toEqual([]);
+		// spec_path is still set so the keyword scan can still pick up SPEC.md
+		expect(result.spec_path).toBe(
+			join("/repo", ".tff-cc", "milestones", "M01", "slices", "M01-S01", "SPEC.md"),
+		);
+	});
+});

--- a/tests/unit/infrastructure/adapters/filesystem/slice-spec-fs-reader.spec.ts
+++ b/tests/unit/infrastructure/adapters/filesystem/slice-spec-fs-reader.spec.ts
@@ -8,15 +8,19 @@ import { SliceSpecFsReader } from "../../../../../src/infrastructure/adapters/fi
 describe("SliceSpecFsReader", () => {
 	let root: string;
 	beforeEach(() => {
-		root = mkdtempSync(join(tmpdir(), "tff-phase-e-spec-"));
+		root = mkdtempSync(join(tmpdir(), "tff-spec-reader-"));
 	});
 
-	it("reads SPEC.md from the slice directory", async () => {
-		const dir = join(root, ".tff-cc", "milestones", "M01", "S02-auth-flow");
+	it("reads SPEC.md from a milestone-bound slice directory", async () => {
+		// Layout matches what slice:create writes:
+		//   .tff-cc/milestones/M01/slices/M01-S02/SPEC.md
+		const dir = join(root, ".tff-cc", "milestones", "M01", "slices", "M01-S02");
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, "SPEC.md"), "# auth flow spec\n\nbody", "utf8");
+
 		const reader = new SliceSpecFsReader({ projectRoot: root });
 		const res = await reader.readSpec("M01-S02", 1024);
+
 		expect(isOk(res)).toBe(true);
 		if (!isOk(res)) throw new Error("not ok");
 		expect(res.data.text).toBe("# auth flow spec\n\nbody");
@@ -24,7 +28,33 @@ describe("SliceSpecFsReader", () => {
 		expect(res.data.truncated).toBe(false);
 	});
 
-	it("returns Err for an invalid slice label (no regex match)", async () => {
+	it("reads SPEC.md from a quick slice directory", async () => {
+		const dir = join(root, ".tff-cc", "quick", "Q-01");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "SPEC.md"), "# quick spec", "utf8");
+
+		const reader = new SliceSpecFsReader({ projectRoot: root });
+		const res = await reader.readSpec("Q-01", 1024);
+
+		if (!isOk(res)) throw new Error("not ok");
+		expect(res.data.text).toBe("# quick spec");
+		expect(res.data.missing).toBe(false);
+	});
+
+	it("reads SPEC.md from a debug slice directory", async () => {
+		const dir = join(root, ".tff-cc", "debug", "D-03");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "SPEC.md"), "# debug spec", "utf8");
+
+		const reader = new SliceSpecFsReader({ projectRoot: root });
+		const res = await reader.readSpec("D-03", 1024);
+
+		if (!isOk(res)) throw new Error("not ok");
+		expect(res.data.text).toBe("# debug spec");
+		expect(res.data.missing).toBe(false);
+	});
+
+	it("returns Err for an unparsable slice label", async () => {
 		const reader = new SliceSpecFsReader({ projectRoot: root });
 		const res = await reader.readSpec("not-valid!!", 1024);
 		expect(isOk(res)).toBe(false);
@@ -32,7 +62,7 @@ describe("SliceSpecFsReader", () => {
 		expect(res.error.code).toBe("VALIDATION_ERROR");
 	});
 
-	it("returns missing=true when no slice directory exists", async () => {
+	it("returns missing=true when the slice directory does not exist", async () => {
 		const reader = new SliceSpecFsReader({ projectRoot: root });
 		const res = await reader.readSpec("M99-S99", 1024);
 		if (!isOk(res)) throw new Error("not ok");
@@ -40,35 +70,22 @@ describe("SliceSpecFsReader", () => {
 		expect(res.data.text).toBe("");
 	});
 
-	it("returns missing=true when milestone dir exists but no matching slice entry", async () => {
-		// Create the milestone directory but with a different slice prefix
-		const milestoneDir = join(root, ".tff-cc", "milestones", "M01");
-		mkdirSync(join(milestoneDir, "S03-other-slice"), { recursive: true });
-		const reader = new SliceSpecFsReader({ projectRoot: root });
-		// Ask for S02 — no S02-* entry exists
-		const res = await reader.readSpec("M01-S02", 1024);
-		expect(isOk(res)).toBe(true);
-		if (!isOk(res)) throw new Error("not ok");
-		expect(res.data.missing).toBe(true);
-		expect(res.data.text).toBe("");
-	});
-
-	it("returns missing=true when slice dir exists but SPEC.md is absent", async () => {
-		// Create the slice directory without a SPEC.md file
-		const dir = join(root, ".tff-cc", "milestones", "M01", "S02-no-spec");
+	it("returns missing=true when the slice dir exists but SPEC.md is absent", async () => {
+		const dir = join(root, ".tff-cc", "milestones", "M01", "slices", "M01-S02");
 		mkdirSync(dir, { recursive: true });
+
 		const reader = new SliceSpecFsReader({ projectRoot: root });
 		const res = await reader.readSpec("M01-S02", 1024);
-		expect(isOk(res)).toBe(true);
 		if (!isOk(res)) throw new Error("not ok");
 		expect(res.data.missing).toBe(true);
 		expect(res.data.text).toBe("");
 	});
 
 	it("truncates text larger than maxBytes and marks truncated=true", async () => {
-		const dir = join(root, ".tff-cc", "milestones", "M01", "S02-long");
+		const dir = join(root, ".tff-cc", "milestones", "M01", "slices", "M01-S02");
 		mkdirSync(dir, { recursive: true });
 		writeFileSync(join(dir, "SPEC.md"), "x".repeat(500), "utf8");
+
 		const reader = new SliceSpecFsReader({ projectRoot: root });
 		const res = await reader.readSpec("M01-S02", 100);
 		if (!isOk(res)) throw new Error("not ok");

--- a/tests/whitelists/sqlite-raw-callsites.txt
+++ b/tests/whitelists/sqlite-raw-callsites.txt
@@ -3,7 +3,9 @@ src/cli/utils/resolve-id.ts:35
 src/cli/utils/resolve-id.ts:48
 src/application/milestone/resolve-milestone-id.ts:30
 src/application/guards/milestone-branch-guard.ts:19
-src/infrastructure/adapters/filesystem/slice-spec-fs-reader.ts:23
+src/cli/utils/build-routing-extract-input.ts:57
+src/infrastructure/adapters/filesystem/slice-spec-fs-reader.ts:20
+src/infrastructure/adapters/filesystem/slice-spec-fs-reader.ts:25
 src/infrastructure/adapters/sqlite/schema.ts:26
 src/infrastructure/adapters/sqlite/schema.ts:58
 src/infrastructure/adapters/sqlite/schema.ts:59


### PR DESCRIPTION
## Summary

Two related routing-system bugs, fixed together because they share the same SPEC-path resolution territory.

### Bug 1 — outcome-judge always reports "SPEC.md missing"

`SliceSpecFsReader` globbed the milestone dir for entries starting with `S01-`, but `slice:create` writes `.tff-cc/milestones/M01/slices/M01-S01/` (no slug suffix, plus an intermediate `slices/` dir the reader didn't traverse). The prefix never matched, every `readSpec` returned `missing: true`. The existing tests passed only because they invented their own (incorrect) layout — they didn't reflect what's actually on disk.

Ad-hoc `Q-##` / `D-##` slices were rejected outright by the regex and surfaced as `VALIDATION_ERROR` to the judge.

**Fix:** rewrite the reader to compute the SPEC path deterministically via the same `shared/paths.ts` helpers that `slice:create` uses (`sliceDir`, `quickSliceDir`, `debugSliceDir`). Drop the `readdir` glob. Update tests to reflect the real layout, add `Q-01` and `D-03` coverage.

### Bug 2 — routing:decide always picks haiku / low risk

`routing-decide.cmd.ts` handed the signal extractor a stub:

```ts
extract_input: {
  description: \`slice \${sliceId}\`,  // no risk keywords
  affected_files: [],                   // always 0
}
```

`complexityFromFileCount(0)` → `"low"`, no keywords → `risk: "low"`, default tier policy maps `low → haiku`. **Every** slice routed to haiku regardless of size or risk.

**Fix:** new `buildRoutingExtractInput` helper resolves the slice via `getSliceByNumbers`, derives the base branch (`slice.baseBranch ?? milestone.branch`), runs `git diff --name-only <base>...HEAD` for `affected_files`, and points `spec_path` at the canonical SPEC.md location so `FilesystemSignalExtractor` can keyword-scan real content. Falls back to the legacy stub if the slice / git lookup fails — degrades to current behaviour rather than failing the calling workflow.

## Test plan
- [x] New helper unit suite (`tests/unit/cli/utils/build-routing-extract-input.spec.ts`, 5 tests) covers happy path, milestone-branch fallback, malformed labels, unknown slice, and git-error fail-soft.
- [x] Reader tests rewritten against the real on-disk layout (`tests/unit/infrastructure/adapters/filesystem/slice-spec-fs-reader.spec.ts`, 7 tests including Q-01 and D-03).
- [x] Existing `routing:decide` cmd tests still pass — the cmd preserves the early-return-when-disabled path before any new code runs.
- [x] `bun run typecheck` clean
- [x] Full suite: **1,859 tests pass, 2 skipped**
- [ ] Reviewer: verify CI green
- [ ] Reviewer: spot-check that `routing:decide` against a real slice with 6+ touched files now picks `sonnet`/`opus` rather than `haiku`