### PR TITLE
fix(slice): allow transitions for quick/debug ad-hoc slices

### DIFF
--- a/src/application/checkpoint/save-checkpoint.ts
+++ b/src/application/checkpoint/save-checkpoint.ts
@@ -1,7 +1,7 @@
 import type { DomainError } from "../../domain/errors/domain-error.js";
 import type { ArtifactStore } from "../../domain/ports/artifact-store.port.js";
 import { isOk, Ok, type Result } from "../../domain/result.js";
-import { sliceDir } from "../../shared/paths.js";
+import { sliceDirFor } from "../../shared/paths.js";
 
 export interface CheckpointData {
 	sliceId: string;
@@ -27,6 +27,7 @@ interface SaveCheckpointDeps {
  */
 export const renderCheckpoint = (
 	data: CheckpointData,
+	options?: { kind?: "milestone" | "quick" | "debug"; milestoneLabel?: string },
 ): { dir: string; path: string; content: string } => {
 	const lines: string[] = [
 		`# Checkpoint — ${data.sliceId}`,
@@ -39,8 +40,12 @@ export const renderCheckpoint = (
 		`<!-- checkpoint-json: ${JSON.stringify(data)} -->`,
 		"",
 	];
-	const milestoneId = data.sliceId.match(/^(M\d+)/)?.[1] ?? "M01";
-	const dir = sliceDir(milestoneId, data.sliceId);
+	const milestoneId = data.sliceId.match(/^(M\d+)/)?.[1] ?? options?.milestoneLabel ?? "M01";
+	const dir = sliceDirFor(
+		{ kind: options?.kind ?? "milestone" },
+		(options?.kind ?? "milestone") === "milestone" ? milestoneId : undefined,
+		data.sliceId,
+	);
 	const path = `${dir}/CHECKPOINT.md`;
 	return { dir, path, content: lines.join("\n") };
 };

--- a/src/application/slice/transition-slice.ts
+++ b/src/application/slice/transition-slice.ts
@@ -5,6 +5,7 @@ import { transitionSlice as transitionSliceDomain } from "../../domain/entities/
 import type { DomainError } from "../../domain/errors/domain-error.js";
 import { createDomainError } from "../../domain/errors/domain-error.js";
 import { preconditionViolationError } from "../../domain/errors/precondition-violation.error.js";
+import { sliceLabelFor } from "../../domain/helpers/branch-naming.js";
 import type { Slice } from "../../domain/index.js";
 import { checkSliceStatus } from "../../domain/state-machine/preconditions.js";
 import {
@@ -42,12 +43,6 @@ export type TransitionSliceResponse = TransitionSliceSuccess | TransitionSliceFa
 export interface TransitionSliceDeps {
 	stores: ClosableStateStores;
 }
-
-const sliceLabelFromSlice = (slice: { number: number }, milestoneNumber: number): string => {
-	const ms = String(milestoneNumber).padStart(2, "0");
-	const sn = String(slice.number).padStart(2, "0");
-	return `M${ms}-S${sn}`;
-};
 
 /**
  * Orchestrates a slice status transition end-to-end:
@@ -109,47 +104,60 @@ export const transitionSliceOrchestrator = async (
 		return { ok: false, error: validation.error };
 	}
 
-	if (!currentSlice.milestoneId) {
-		return {
-			ok: false,
-			error: createDomainError(
-				"NOT_FOUND",
-				`Slice "${sliceId}" has no milestone (kind=${currentSlice.kind}); transition not yet supported for ad-hoc slices`,
-			),
-		};
+	let displaySliceLabel: string;
+	let stateContentInput: { milestoneId: string } | { scope: "kind"; kind: "quick" | "debug" };
+	let milestoneNumber: number | undefined;
+
+	if (currentSlice.kind === "milestone") {
+		const milestoneId = currentSlice.milestoneId;
+		if (!milestoneId) {
+			return {
+				ok: false,
+				error: createDomainError(
+					"NOT_FOUND",
+					`Milestone-bound slice "${sliceId}" is missing its milestoneId`,
+				),
+			};
+		}
+		const milestoneResult = milestoneStore.getMilestone(milestoneId);
+		if (!milestoneResult.ok) return { ok: false, error: milestoneResult.error };
+		if (!milestoneResult.data) {
+			return {
+				ok: false,
+				error: createDomainError("NOT_FOUND", `Milestone "${milestoneId}" not found`),
+			};
+		}
+		milestoneNumber = milestoneResult.data.number;
+		displaySliceLabel = sliceLabelFor(currentSlice, milestoneResult.data);
+		stateContentInput = { milestoneId };
+	} else {
+		displaySliceLabel = sliceLabelFor(currentSlice);
+		stateContentInput = { scope: "kind", kind: currentSlice.kind };
 	}
-	const milestoneId = currentSlice.milestoneId;
-	const milestoneResult = milestoneStore.getMilestone(milestoneId);
-	if (!milestoneResult.ok) return { ok: false, error: milestoneResult.error };
-	if (!milestoneResult.data) {
-		return {
-			ok: false,
-			error: createDomainError("NOT_FOUND", `Milestone "${milestoneId}" not found`),
-		};
-	}
-	const milestoneNumber = milestoneResult.data.number;
-	const displaySliceLabel = sliceLabelFromSlice(currentSlice, milestoneNumber);
 
 	// Render STATE.md content (reflecting the post-transition state).
 	// We patch the slice status in-memory to simulate post-commit state; the
 	// renderer is pure so this is safe.
 	const projectedSlice: Slice = { ...currentSlice, status: targetStatus };
-	const stateContent = renderStateMd(
-		{ milestoneId },
-		{
-			milestoneStore,
-			sliceStore: {
-				...sliceStore,
-				listSlices: (mid?: string) => {
-					const base = sliceStore.listSlices(mid);
-					if (!base.ok) return base;
-					const swapped = base.data.map((s) => (s.id === projectedSlice.id ? projectedSlice : s));
-					return { ok: true as const, data: swapped };
-				},
+	const stateContent = renderStateMd(stateContentInput, {
+		milestoneStore,
+		sliceStore: {
+			...sliceStore,
+			listSlices: (mid?: string) => {
+				const base = sliceStore.listSlices(mid);
+				if (!base.ok) return base;
+				const swapped = base.data.map((s) => (s.id === projectedSlice.id ? projectedSlice : s));
+				return { ok: true as const, data: swapped };
 			},
-			taskStore,
+			listSlicesByKind: (kind: "quick" | "debug") => {
+				const base = sliceStore.listSlicesByKind(kind);
+				if (!base.ok) return base;
+				const swapped = base.data.map((s) => (s.id === projectedSlice.id ? projectedSlice : s));
+				return { ok: true as const, data: swapped };
+			},
 		},
-	);
+		taskStore,
+	});
 	if (!stateContent.ok) return { ok: false, error: stateContent.error };
 
 	// Pre-tx staging: STATE.md + CHECKPOINT.md to *.tmp.
@@ -159,14 +167,25 @@ export const transitionSliceOrchestrator = async (
 	const { stateFinalAbs, stateTmpAbs } = stageStateMdTmp(cwd, stagedTmps, stagedDirs);
 	writeFileSync(stateTmpAbs, stateContent.data, "utf8");
 
-	const checkpoint = renderCheckpoint({
-		sliceId: displaySliceLabel,
-		baseCommit: "",
-		currentWave: 0,
-		completedWaves: [],
-		completedTasks: [],
-		executorLog: [],
-	});
+	const checkpoint = renderCheckpoint(
+		{
+			sliceId: displaySliceLabel,
+			baseCommit: "",
+			currentWave: 0,
+			completedWaves: [],
+			completedTasks: [],
+			executorLog: [],
+		},
+		currentSlice.kind === "milestone"
+			? {
+					kind: "milestone",
+					milestoneLabel:
+						milestoneNumber !== undefined
+							? `M${String(milestoneNumber).padStart(2, "0")}`
+							: undefined,
+				}
+			: { kind: currentSlice.kind },
+	);
 	const ckptDirAbs = resolve(cwd, checkpoint.dir);
 	const ckptFinalAbs = resolve(cwd, checkpoint.path);
 	const ckptTmpAbs = `${ckptFinalAbs}.tmp`;

--- a/src/cli/commands/slice-transition.cmd.ts
+++ b/src/cli/commands/slice-transition.cmd.ts
@@ -13,7 +13,7 @@ export const sliceTransitionSchema: CommandSchema = {
 			type: "string",
 			description: "Slice ID (display label e.g. M01-S01 or UUID)",
 			pattern:
-				"^(M\\d+-S\\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+				"^(M\\d+-S\\d+|Q-\\d+|D-\\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
 		},
 		{
 			name: "status",

--- a/tests/integration/slice-transition.integration.spec.ts
+++ b/tests/integration/slice-transition.integration.spec.ts
@@ -71,6 +71,7 @@ beforeEach(() => {
 	const mockSlice = {
 		id: "test-slice-uuid",
 		milestoneId: "m01",
+		kind: "milestone" as const,
 		number: 1,
 		status: "discussing" as const,
 		title: "Test Slice",
@@ -83,6 +84,7 @@ beforeEach(() => {
 			.fn()
 			.mockImplementation((_id: string, _status: string) => ({ ok: true, data: [] })),
 		getSliceByNumbers: vi.fn().mockReturnValue({ ok: true, data: mockSlice }),
+		listSlicesByKind: vi.fn().mockReturnValue({ ok: true, data: [mockSlice] }),
 	});
 	Object.assign(mockMilestoneStore, {
 		getMilestone: vi
@@ -131,6 +133,7 @@ describe("slice-transition integration", () => {
 		const executingSlice = {
 			id: "test-slice-uuid",
 			milestoneId: "m01",
+			kind: "milestone" as const,
 			number: 1,
 			status: "executing" as const,
 			title: "Test Slice",
@@ -141,6 +144,7 @@ describe("slice-transition integration", () => {
 			listSlices: vi.fn().mockReturnValue({ ok: true, data: [executingSlice] }),
 			transitionSlice: vi.fn().mockImplementation(() => ({ ok: true, data: [] })),
 			getSliceByNumbers: vi.fn().mockReturnValue({ ok: true, data: executingSlice }),
+			listSlicesByKind: vi.fn().mockReturnValue({ ok: true, data: [] }),
 		});
 
 		// executing -> reviewing is invalid (must go executing -> verifying -> reviewing).
@@ -152,5 +156,32 @@ describe("slice-transition integration", () => {
 		expect(result.error.code).toBe("INVALID_TRANSITION");
 		expect(result.error.validPredecessors).toEqual(["verifying"]);
 		expect(result.error.recoveryHint).toContain("verifying");
+	});
+
+	it("transitions a quick slice from discussing to researching", async () => {
+		const quickSlice = {
+			id: "quick-slice-uuid",
+			kind: "quick" as const,
+			number: 1,
+			status: "discussing" as const,
+			title: "Quick Slice",
+			createdAt: new Date(),
+		};
+		Object.assign(mockSliceStore, {
+			getSlice: vi.fn().mockReturnValue({ ok: true, data: quickSlice }),
+			listSlices: vi.fn().mockReturnValue({ ok: true, data: [] }),
+			listSlicesByKind: vi.fn().mockReturnValue({ ok: true, data: [quickSlice] }),
+			transitionSlice: vi
+				.fn()
+				.mockImplementation((_id: string, _status: string) => ({ ok: true, data: [] })),
+			getSliceByNumbers: vi.fn().mockReturnValue({ ok: true, data: null }),
+		});
+
+		const result = JSON.parse(
+			await sliceTransitionCmd(["--slice-id", "Q-01", "--status", "researching"]),
+		);
+
+		expect(mockSliceStore.transitionSlice).toHaveBeenCalled();
+		expect(result.ok).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
Fixes #178 — quick slices (`kind=quick`) were stuck in `discussing` forever because the `slice:transition` orchestrator blocked every target with a hard kind-guard.

## Root cause
`transitionSliceOrchestrator` rejected all transitions for ad-hoc slices with:
> Slice "{id}" has no milestone (kind=quick); transition not yet supported for ad-hoc slices

This guard ran after the domain transition validation, so even valid transitions like `discussing → researching` were blocked.

## Changes
- **Removed the ad-hoc guard** in `src/application/slice/transition-slice.ts`
- **Branched `STATE.md` rendering**: milestone-bound slices use `{ milestoneId }` scope; quick/debug slices use `{ scope: "kind", kind }` scope
- **Fixed `CHECKPOINT.md` path generation**: `renderCheckpoint` now accepts optional `kind`/`milestoneLabel` and uses `sliceDirFor` to place quick slices under `.tff-cc/quick/` and debug slices under `.tff-cc/debug/`
- **Updated CLI pattern** in `slice-transition.cmd.ts` to accept `Q-##` and `D-##` labels
- **Added integration test** for quick slice `discussing → researching`

## Test plan
- [x] `npm test -- --run` — 285 files, 1866 tests passing
- [x] Quick slice transition integration test added and passing

## Related
Closes #178